### PR TITLE
Docs/Refactor: add provider-agnostic configuration examples and dynamic key resolution (#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,26 @@
-# Model provider configuration
-# Supported: openai, anthropic, local
+# ==========================================
+# PROVIDER CONFIGURATION EXAMPLES
+# Uncomment ONLY ONE of the blocks below to swap providers
+# without changing application logic.
+# ==========================================
+
+# --- Option 1: OpenAI (Default) ---
 MODEL_PROVIDER=openai
-
-# API keys (set the one matching your provider)
-OPENAI_API_KEY=your-key-here
-ANTHROPIC_API_KEY=your-key-here
-
-# Model selection
+OPENAI_API_KEY=your-openai-key-here
 MODEL_NAME=gpt-4o
-# For cost comparison (Chapter 4)
 MODEL_NAME_CHEAP=gpt-4o-mini
-
-# Local model endpoint (if using local provider)
-LOCAL_MODEL_URL=http://localhost:11434/v1
-
-# Eval settings
 EVAL_JUDGE_MODEL=gpt-4o
+
+# --- Option 2: Anthropic (Claude) ---
+# MODEL_PROVIDER=anthropic
+# ANTHROPIC_API_KEY=your-anthropic-key-here
+# MODEL_NAME=claude-3-5-sonnet-20240620
+# MODEL_NAME_CHEAP=claude-3-haiku-20240307
+# EVAL_JUDGE_MODEL=claude-3-5-sonnet-20240620
+
+# --- Option 3: Local Models (e.g., Ollama) ---
+# MODEL_PROVIDER=local
+# LOCAL_MODEL_URL=http://localhost:11434/v1
+# MODEL_NAME=llama3
+# MODEL_NAME_CHEAP=llama3
+# EVAL_JUDGE_MODEL=llama3

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -19,12 +19,21 @@ class ModelConfig(BaseModel):
     """Configuration for the model client."""
 
     provider: str = os.getenv("MODEL_PROVIDER", "openai")
-    api_key: str = os.getenv("OPENAI_API_KEY", "") or os.getenv("ANTHROPIC_API_KEY", "")
     model_name: str = os.getenv("MODEL_NAME", "gpt-4o")
     model_name_cheap: str = os.getenv("MODEL_NAME_CHEAP", "gpt-4o-mini")
     local_url: str = os.getenv("LOCAL_MODEL_URL", "http://localhost:11434/v1")
     temperature: float = 0.0
     max_tokens: int = 4096
+
+    @property
+    def api_key(self) -> str:
+        """Dynamically fetch the correct API key based on the provider."""
+        if self.provider == "openai":
+            return os.getenv("OPENAI_API_KEY", "")
+        if self.provider == "anthropic":
+            return os.getenv("ANTHROPIC_API_KEY", "")
+        return ""
+
 
 
 class EvalConfig(BaseModel):

--- a/src/shared/model_client.py
+++ b/src/shared/model_client.py
@@ -2,12 +2,6 @@
 
 This is the interface between your agent code and any LLM provider.
 The rest of the codebase never imports openai or anthropic directly.
-
-Why this matters:
-- You can switch providers without rewriting agent logic.
-- You can test with a mock client.
-- You can add cost tracking in one place.
-- You can route between cheap and expensive models without changing callers.
 """
 
 from __future__ import annotations
@@ -205,7 +199,9 @@ def create_client(
         return AnthropicClient(api_key=api_key, model_name=model_name)
     elif provider == "local":
         url = base_url or "http://localhost:11434/v1"
-        return OpenAIClient(api_key="local", model_name=model_name, base_url=url)
+        # FIX: Sửa lỗi hardcode 'local'. Ưu tiên dùng api_key nếu có.
+        actual_key = api_key if api_key else "local"
+        return OpenAIClient(api_key=actual_key, model_name=model_name, base_url=url)
     elif provider == "mock":
         return MockClient()
     else:

--- a/src/shared/model_client.py
+++ b/src/shared/model_client.py
@@ -2,6 +2,12 @@
 
 This is the interface between your agent code and any LLM provider.
 The rest of the codebase never imports openai or anthropic directly.
+
+Why this matters:
+- You can switch providers without rewriting agent logic.
+- You can test with a mock client.
+- You can add cost tracking in one place.
+- You can route between cheap and expensive models without changing callers.
 """
 
 from __future__ import annotations
@@ -199,7 +205,7 @@ def create_client(
         return AnthropicClient(api_key=api_key, model_name=model_name)
     elif provider == "local":
         url = base_url or "http://localhost:11434/v1"
-        # FIX: Sửa lỗi hardcode 'local'. Ưu tiên dùng api_key nếu có.
+        # FIX: Resolve hardcoded 'local' key by prioritizing provided api_key.
         actual_key = api_key if api_key else "local"
         return OpenAIClient(api_key=actual_key, model_name=model_name, base_url=url)
     elif provider == "mock":


### PR DESCRIPTION
Hi @sunilp, 
I've completed issue #4 with these improvements: 
1. Structured .env.example with clear provider blocks. 
2. Updated ModelConfig to dynamically resolve the correct API key. 
3. Minor fix in create_client for local providers to support custom keys. 
Fixes #4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the environment configuration template to a provider-selection format with clear examples for OpenAI (default), Anthropic, and Local/Ollama, and reorganized shared model variables for clarity.
* **Bug Fixes**
  * Improved API key selection so credentials load based on the chosen provider, and local provider will use a supplied API key when provided instead of forcing a fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->