### PR TITLE
W3: Evidence Wall + 7 projects + L-001 Lab + Cmd+K

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,6 +15,13 @@ export default defineConfig({
     mdx(),
     svelte(),
   ],
+  vite: {
+    build: {
+      rollupOptions: {
+        external: ['/agentic-ai/pagefind/pagefind.js'],
+      },
+    },
+  },
   redirects: {
     '/proof/baseline-eval-report': '/agentic-ai/evidence/baseline-eval-report/',
     '/proof/workflow-vs-agent-comparison': '/agentic-ai/evidence/workflow-vs-agent-comparison/',

--- a/package.json
+++ b/package.json
@@ -18,10 +18,14 @@
     "@astrojs/mdx": "^4.3.0",
     "@astrojs/svelte": "^7.2.0",
     "astro": "^5.7.0",
+    "d3": "^7.9.0",
+    "d3-array": "^3.2.4",
+    "d3-scale": "^4.0.2",
     "motion": "^12.38.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",
+    "@types/d3": "^7.4.3",
     "@types/node": "^22.0.0",
     "pagefind": "^1.5.2",
     "svelte": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,15 @@ importers:
       astro:
         specifier: ^5.7.0
         version: 5.18.1(@types/node@22.19.19)(rollup@4.60.3)(typescript@5.9.3)(yaml@2.9.0)
+      d3:
+        specifier: ^7.9.0
+        version: 7.9.0
+      d3-array:
+        specifier: ^3.2.4
+        version: 3.2.4
+      d3-scale:
+        specifier: ^4.0.2
+        version: 4.0.2
       motion:
         specifier: ^12.38.0
         version: 12.38.0
@@ -24,6 +33,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.0
         version: 0.9.9(prettier@3.8.3)(typescript@5.9.3)
+      '@types/d3':
+        specifier: ^7.4.3
+        version: 7.4.3
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.19
@@ -958,6 +970,99 @@ packages:
       svelte: ^5.0.0
       vite: ^6.0.0
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -969,6 +1074,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -1219,6 +1327,10 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
@@ -1256,6 +1368,133 @@ packages:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1281,6 +1520,9 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1525,11 +1767,19 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -2013,10 +2263,19 @@ packages:
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -3282,6 +3541,123 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -3293,6 +3669,8 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -3639,6 +4017,8 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@7.2.0: {}
+
   common-ancestor-path@1.0.1: {}
 
   cookie-es@1.2.3: {}
@@ -3675,6 +4055,158 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -3690,6 +4222,10 @@ snapshots:
   deepmerge@4.3.1: {}
 
   defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   dequal@2.0.3: {}
 
@@ -4075,9 +4611,15 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   import-meta-resolve@4.2.0: {}
 
   inline-style-parser@0.2.7: {}
+
+  internmap@2.0.3: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -4870,6 +5412,8 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.60.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -4900,6 +5444,10 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.3
       '@rollup/rollup-win32-x64-msvc': 4.60.3
       fsevents: 2.3.3
+
+  rw@1.3.3: {}
+
+  safer-buffer@2.1.2: {}
 
   sax@1.6.0: {}
 

--- a/public/assets/diagrams/agent-anatomy.svg
+++ b/public/assets/diagrams/agent-anatomy.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="0 0 500 500" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arr-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="500" height="500" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="250" y="32" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Agent Anatomy: The Four Components</text>
+  <line x1="40" y1="44" x2="460" y2="44" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Center circle: Agent Loop label -->
+  <circle cx="250" cy="272" r="58" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="2"/>
+  <text x="250" y="267" text-anchor="middle" font-size="14" font-weight="bold" fill="#374151">Agent</text>
+  <text x="250" y="284" text-anchor="middle" font-size="14" font-weight="bold" fill="#374151">Loop</text>
+
+  <!-- TOP: Observation -->
+  <rect x="155" y="62" width="190" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="250" y="90" text-anchor="middle" font-size="15" font-weight="bold" fill="#1D4ED8">Observation</text>
+  <text x="250" y="108" text-anchor="middle" font-size="11" fill="#6B7280">Perceive current state</text>
+  <text x="250" y="124" text-anchor="middle" font-size="11" fill="#6B7280">query · tool results · history</text>
+
+  <!-- RIGHT: Reasoning -->
+  <rect x="322" y="234" width="150" height="72" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="397" y="262" text-anchor="middle" font-size="15" font-weight="bold" fill="#92400E">Reasoning</text>
+  <text x="397" y="280" text-anchor="middle" font-size="11" fill="#6B7280">Decide what to do</text>
+  <text x="397" y="296" text-anchor="middle" font-size="11" fill="#6B7280">next · LLM call</text>
+
+  <!-- BOTTOM: Action -->
+  <rect x="155" y="378" width="190" height="72" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="250" y="406" text-anchor="middle" font-size="15" font-weight="bold" fill="#B91C1C">Action</text>
+  <text x="250" y="424" text-anchor="middle" font-size="11" fill="#6B7280">Execute via tools</text>
+  <text x="250" y="440" text-anchor="middle" font-size="11" fill="#6B7280">or return answer</text>
+
+  <!-- LEFT: State -->
+  <rect x="28" y="234" width="150" height="72" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="103" y="262" text-anchor="middle" font-size="15" font-weight="bold" fill="#065F46">State</text>
+  <text x="103" y="280" text-anchor="middle" font-size="11" fill="#6B7280">Memory of what</text>
+  <text x="103" y="296" text-anchor="middle" font-size="11" fill="#6B7280">happened so far</text>
+
+  <!-- Arrow: Observation → Reasoning (top to right, clockwise) -->
+  <!-- From bottom-right of Observation box toward Reasoning -->
+  <path d="M345,134 Q420,134 420,232" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Arrow: Reasoning → Action (right to bottom, clockwise) -->
+  <path d="M420,308 Q420,378 345,414" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Arrow: Action → State (bottom to left, clockwise) -->
+  <path d="M155,414 Q80,378 80,308" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Arrow: State → Observation (left to top, clockwise) -->
+  <path d="M80,232 Q80,134 155,134" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Small clockwise rotation hint -->
+  <text x="250" y="466" text-anchor="middle" font-size="11" fill="#9CA3AF">Each step: observe → reason → act → update state → repeat</text>
+</svg>

--- a/public/assets/diagrams/agent-loop-foundations.svg
+++ b/public/assets/diagrams/agent-loop-foundations.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="560" height="520" viewBox="0 0 560 520" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="560" height="520" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="280" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">The Agent Loop</text>
+  <line x1="40" y1="42" x2="520" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Subtitle -->
+  <text x="280" y="62" text-anchor="middle" font-size="12" fill="#6B7280">Three phases. Repeated until the task is done or budget is exhausted.</text>
+
+  <!-- Center circle -->
+  <circle cx="280" cy="280" r="62" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="2"/>
+  <text x="280" y="272" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">Step 1, 2, 3...</text>
+  <text x="280" y="290" text-anchor="middle" font-size="12" fill="#6B7280">Budget: 5 steps</text>
+  <text x="280" y="308" text-anchor="middle" font-size="11" fill="#9CA3AF">remaining</text>
+
+  <!-- TOP: Observe (blue) -->
+  <rect x="175" y="82" width="210" height="84" rx="10" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
+  <text x="280" y="108" text-anchor="middle" font-size="15" font-weight="bold" fill="#1D4ED8">Observe</text>
+  <text x="280" y="128" text-anchor="middle" font-size="11" fill="#374151">Assemble context</text>
+  <text x="280" y="145" text-anchor="middle" font-size="10" fill="#6B7280">query · tool results · history</text>
+  <text x="280" y="160" text-anchor="middle" font-size="10" fill="#6B7280">system prompt · state</text>
+
+  <!-- BOTTOM-RIGHT: Think (amber) -->
+  <rect x="378" y="330" width="160" height="84" rx="10" fill="#FEF3C7" stroke="#F59E0B" stroke-width="2"/>
+  <text x="458" y="356" text-anchor="middle" font-size="15" font-weight="bold" fill="#92400E">Think</text>
+  <text x="458" y="376" text-anchor="middle" font-size="11" fill="#374151">Call the LLM</text>
+  <text x="458" y="393" text-anchor="middle" font-size="10" fill="#6B7280">model reasons over</text>
+  <text x="458" y="408" text-anchor="middle" font-size="10" fill="#6B7280">assembled context</text>
+
+  <!-- BOTTOM-LEFT: Act (green) -->
+  <rect x="22" y="330" width="160" height="84" rx="10" fill="#F0FDF4" stroke="#22c55e" stroke-width="2"/>
+  <text x="102" y="356" text-anchor="middle" font-size="15" font-weight="bold" fill="#15803D">Act</text>
+  <text x="102" y="376" text-anchor="middle" font-size="11" fill="#374151">Execute or answer</text>
+  <text x="102" y="393" text-anchor="middle" font-size="10" fill="#6B7280">run tool · write file</text>
+  <text x="102" y="408" text-anchor="middle" font-size="10" fill="#6B7280">call API · return</text>
+
+  <!-- Arrow: Observe → Think (top to right) -->
+  <path d="M358,148 Q440,148 440,328" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="448" y="240" font-size="10" fill="#374151">LLM</text>
+  <text x="448" y="254" font-size="10" fill="#374151">call</text>
+
+  <!-- Arrow: Think → Act (right to left, bottom) -->
+  <path d="M378,373 Q280,436 182,373" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="280" y="452" text-anchor="middle" font-size="10" fill="#374151">tool call or final answer</text>
+
+  <!-- Arrow: Act → Observe (left to top) -->
+  <path d="M120,328 Q120,148 173,148" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="92" y="240" text-anchor="end" font-size="10" fill="#374151">result</text>
+  <text x="92" y="254" text-anchor="end" font-size="10" fill="#374151">feeds back</text>
+
+  <!-- Step counter example -->
+  <rect x="90" y="472" width="380" height="36" rx="8" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="100" y="490" font-size="11" font-weight="bold" fill="#374151">Step 1:</text>
+  <text x="148" y="490" font-size="11" fill="#6B7280">search("X")</text>
+  <text x="220" y="490" font-size="11" font-weight="bold" fill="#374151">Step 2:</text>
+  <text x="268" y="490" font-size="11" fill="#6B7280">read_result()</text>
+  <text x="348" y="490" font-size="11" font-weight="bold" fill="#374151">Step 3:</text>
+  <text x="396" y="490" font-size="11" fill="#22c55e">answer()</text>
+  <text x="280" y="508" text-anchor="middle" font-size="10" fill="#9CA3AF">Each step burns tokens. Budget enforced by your code, not the model.</text>
+</svg>

--- a/public/assets/diagrams/agent-tax-comparison.svg
+++ b/public/assets/diagrams/agent-tax-comparison.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" width="700" height="400" style="background:#fff;font-family:system-ui,-apple-system,sans-serif;">
+
+  <!-- Background -->
+  <rect width="700" height="400" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="350" y="28" text-anchor="middle" font-size="16" font-weight="600" fill="#374151">The Agent Tax: Overhead by Architecture</text>
+
+  <!-- Subtitle -->
+  <text x="350" y="48" text-anchor="middle" font-size="12" fill="#6B7280">Bar length = relative overhead (longer = more expensive / harder)</text>
+
+  <!-- Y-axis label groups: architectures -->
+  <!-- Rows: Workflow (y=90), Single Agent (y=175), Multi-Agent (y=260), Multi-Agent + HITL (y=345) -->
+
+  <!-- ========== GRID & AXIS ========== -->
+  <!-- X axis labels: Low, Medium, High -->
+  <line x1="190" y1="65" x2="650" y2="65" stroke="#D1D5DB" stroke-width="1"/>
+  <line x1="190" y1="65" x2="190" y2="370" stroke="#6B7280" stroke-width="1.5"/>
+
+  <!-- X scale markers -->
+  <line x1="190" y1="65" x2="190" y2="370" stroke="#D1D5DB" stroke-width="1"/>
+  <line x1="343" y1="65" x2="343" y2="370" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="497" y1="65" x2="497" y2="370" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="650" y1="65" x2="650" y2="370" stroke="#D1D5DB" stroke-width="1"/>
+
+  <text x="190" y="60" text-anchor="middle" font-size="10" fill="#6B7280">Low</text>
+  <text x="343" y="60" text-anchor="middle" font-size="10" fill="#6B7280">Medium</text>
+  <text x="497" y="60" text-anchor="middle" font-size="10" fill="#6B7280">High</text>
+  <text x="650" y="60" text-anchor="middle" font-size="10" fill="#6B7280">Very High</text>
+
+  <!-- Color scale: green (#10B981) -> yellow (#F59E0B) -> red (#EF4444) -->
+  <!-- Low = green, Medium-Low = #84CC16, Medium = #F59E0B, High = #F97316, Very High = #EF4444 -->
+
+  <!-- ========== ROW 1: WORKFLOW ========== -->
+  <text x="185" y="82" text-anchor="end" font-size="13" font-weight="600" fill="#374151">Workflow</text>
+
+  <!-- Latency: short (0-80px out of 460 total) -->
+  <text x="185" y="99" text-anchor="end" font-size="11" fill="#6B7280">Latency</text>
+  <rect x="190" y="88" width="80" height="16" rx="4" fill="#10B981"/>
+  <text x="275" y="100" font-size="10" fill="#6B7280" dx="4">1x</text>
+
+  <!-- Cost: short -->
+  <text x="185" y="118" text-anchor="end" font-size="11" fill="#6B7280">Cost</text>
+  <rect x="190" y="107" width="80" height="16" rx="4" fill="#10B981"/>
+  <text x="275" y="119" font-size="10" fill="#6B7280" dx="4">1x</text>
+
+  <!-- Debuggability: easy = short green -->
+  <text x="185" y="137" text-anchor="end" font-size="11" fill="#6B7280">Debuggability</text>
+  <rect x="190" y="126" width="80" height="16" rx="4" fill="#10B981"/>
+  <text x="275" y="138" font-size="10" fill="#6B7280" dx="4">Easy</text>
+
+  <!-- Divider -->
+  <line x1="190" y1="154" x2="650" y2="154" stroke="#F3F4F6" stroke-width="1"/>
+
+  <!-- ========== ROW 2: SINGLE AGENT ========== -->
+  <text x="185" y="167" text-anchor="end" font-size="13" font-weight="600" fill="#374151">Single Agent</text>
+
+  <!-- Latency: medium -->
+  <text x="185" y="184" text-anchor="end" font-size="11" fill="#6B7280">Latency</text>
+  <rect x="190" y="173" width="200" height="16" rx="4" fill="#F59E0B"/>
+  <text x="395" y="185" font-size="10" fill="#6B7280" dx="4">2-5x</text>
+
+  <!-- Cost: medium -->
+  <text x="185" y="203" text-anchor="end" font-size="11" fill="#6B7280">Cost</text>
+  <rect x="190" y="192" width="200" height="16" rx="4" fill="#F59E0B"/>
+  <text x="395" y="204" font-size="10" fill="#6B7280" dx="4">2-5x</text>
+
+  <!-- Debuggability: medium -->
+  <text x="185" y="222" text-anchor="end" font-size="11" fill="#6B7280">Debuggability</text>
+  <rect x="190" y="211" width="200" height="16" rx="4" fill="#F59E0B"/>
+  <text x="395" y="223" font-size="10" fill="#6B7280" dx="4">N model calls to trace</text>
+
+  <!-- Divider -->
+  <line x1="190" y1="239" x2="650" y2="239" stroke="#F3F4F6" stroke-width="1"/>
+
+  <!-- ========== ROW 3: MULTI-AGENT ========== -->
+  <text x="185" y="252" text-anchor="end" font-size="13" font-weight="600" fill="#374151">Multi-Agent</text>
+
+  <!-- Latency: high -->
+  <text x="185" y="269" text-anchor="end" font-size="11" fill="#6B7280">Latency</text>
+  <rect x="190" y="258" width="350" height="16" rx="4" fill="#F97316"/>
+  <text x="545" y="270" font-size="10" fill="#6B7280" dx="4">3-8x</text>
+
+  <!-- Cost: high -->
+  <text x="185" y="288" text-anchor="end" font-size="11" fill="#6B7280">Cost</text>
+  <rect x="190" y="277" width="350" height="16" rx="4" fill="#F97316"/>
+  <text x="545" y="289" font-size="10" fill="#6B7280" dx="4">3-8x</text>
+
+  <!-- Debuggability: hard -->
+  <text x="185" y="307" text-anchor="end" font-size="11" fill="#6B7280">Debuggability</text>
+  <rect x="190" y="296" width="350" height="16" rx="4" fill="#F97316"/>
+  <text x="545" y="308" font-size="10" fill="#6B7280" dx="4">Blame diffusion</text>
+
+  <!-- Divider -->
+  <line x1="190" y1="324" x2="650" y2="324" stroke="#F3F4F6" stroke-width="1"/>
+
+  <!-- ========== ROW 4: MULTI-AGENT + HITL ========== -->
+  <text x="185" y="337" text-anchor="end" font-size="13" font-weight="600" fill="#374151">Multi-Agent</text>
+  <text x="185" y="350" text-anchor="end" font-size="11" font-weight="500" fill="#6B7280">+ HITL</text>
+
+  <!-- Latency: very high -->
+  <text x="185" y="358" text-anchor="end" font-size="11" fill="#6B7280">Latency</text>
+  <rect x="190" y="347" width="460" height="14" rx="4" fill="#EF4444"/>
+  <!-- overflow indicator -->
+  <text x="652" y="358" font-size="10" fill="#EF4444" font-weight="600" dx="1">+human</text>
+
+  <!-- Cost: very high -->
+  <text x="185" y="374" text-anchor="end" font-size="11" fill="#6B7280">Cost</text>
+  <rect x="190" y="363" width="390" height="14" rx="4" fill="#EF4444"/>
+  <text x="585" y="374" font-size="10" fill="#6B7280" dx="4">+ review time</text>
+
+  <!-- Debuggability: hard but auditable note -->
+  <text x="185" y="390" text-anchor="end" font-size="11" fill="#6B7280">Debuggability</text>
+  <rect x="190" y="379" width="350" height="14" rx="4" fill="#F97316"/>
+  <text x="545" y="390" font-size="10" fill="#6B7280" dx="4">+ audit trail</text>
+
+</svg>

--- a/public/assets/diagrams/agent-trace-waterfall.svg
+++ b/public/assets/diagrams/agent-trace-waterfall.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="680" height="400" viewBox="0 0 680 400" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="680" height="400" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="340" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Agent Trace: Cost and Latency Waterfall</text>
+  <line x1="40" y1="42" x2="640" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Column headers -->
+  <text x="60" y="66" font-size="11" font-weight="bold" fill="#6B7280">STEP</text>
+  <text x="180" y="66" font-size="11" font-weight="bold" fill="#6B7280">ACTION</text>
+  <text x="460" y="66" font-size="11" font-weight="bold" fill="#6B7280">TOKENS</text>
+  <text x="560" y="66" font-size="11" font-weight="bold" fill="#6B7280">TIME</text>
+  <line x1="40" y1="72" x2="640" y2="72" stroke="#E5E7EB" stroke-width="1"/>
+
+  <!-- Step 1 -->
+  <rect x="40" y="80" width="595" height="68" rx="6" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <!-- Step badge -->
+  <circle cx="65" cy="114" r="16" fill="#3B82F6"/>
+  <text x="65" y="119" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">1</text>
+  <!-- Action label -->
+  <text x="110" y="104" font-size="13" font-weight="bold" fill="#1D4ED8">search("agentic AI frameworks 2024")</text>
+  <text x="110" y="122" font-size="11" fill="#374151">Called web_search tool. Got 10 results back.</text>
+  <text x="110" y="138" font-size="11" fill="#6B7280">Observe: initial query assembled · Think: decide to search · Act: call tool</text>
+  <!-- Metrics -->
+  <rect x="440" y="90" width="68" height="46" rx="4" fill="#DBEAFE"/>
+  <text x="474" y="110" text-anchor="middle" font-size="12" font-weight="bold" fill="#1D4ED8">340</text>
+  <text x="474" y="128" text-anchor="middle" font-size="10" fill="#6B7280">tokens</text>
+  <rect x="524" y="90" width="88" height="46" rx="4" fill="#DBEAFE"/>
+  <text x="568" y="110" text-anchor="middle" font-size="12" font-weight="bold" fill="#1D4ED8">0.8s</text>
+  <text x="568" y="128" text-anchor="middle" font-size="10" fill="#6B7280">elapsed</text>
+
+  <!-- Connector line -->
+  <line x1="65" y1="149" x2="65" y2="162" stroke="#D1D5DB" stroke-width="2" stroke-dasharray="3,2"/>
+
+  <!-- Step 2 -->
+  <rect x="40" y="164" width="595" height="68" rx="6" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <circle cx="65" cy="198" r="16" fill="#F59E0B"/>
+  <text x="65" y="203" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">2</text>
+  <text x="110" y="188" font-size="13" font-weight="bold" fill="#92400E">read_result() → search("production agents")</text>
+  <text x="110" y="206" font-size="11" fill="#374151">Skimmed first results. Decided to refine search for production use cases.</text>
+  <text x="110" y="222" font-size="11" fill="#6B7280">Observe: prior result added to context · Think: gap identified · Act: second search</text>
+  <rect x="440" y="174" width="68" height="46" rx="4" fill="#FEF9C3"/>
+  <text x="474" y="194" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">520</text>
+  <text x="474" y="212" text-anchor="middle" font-size="10" fill="#6B7280">tokens</text>
+  <rect x="524" y="174" width="88" height="46" rx="4" fill="#FEF9C3"/>
+  <text x="568" y="194" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">1.1s</text>
+  <text x="568" y="212" text-anchor="middle" font-size="10" fill="#6B7280">elapsed</text>
+
+  <!-- Connector line -->
+  <line x1="65" y1="233" x2="65" y2="246" stroke="#D1D5DB" stroke-width="2" stroke-dasharray="3,2"/>
+
+  <!-- Step 3 -->
+  <rect x="40" y="248" width="595" height="68" rx="6" fill="#F0FDF4" stroke="#22c55e" stroke-width="1.5"/>
+  <circle cx="65" cy="282" r="16" fill="#22c55e"/>
+  <text x="65" y="287" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">3</text>
+  <text x="110" y="272" font-size="13" font-weight="bold" fill="#15803D">synthesize_answer()</text>
+  <text x="110" y="290" font-size="11" fill="#374151">Combined both search results into a structured summary. Returned to user.</text>
+  <text x="110" y="306" font-size="11" fill="#6B7280">Observe: all context assembled · Think: sufficient info · Act: return final answer</text>
+  <rect x="440" y="258" width="68" height="46" rx="4" fill="#DCFCE7"/>
+  <text x="474" y="278" text-anchor="middle" font-size="12" font-weight="bold" fill="#15803D">280</text>
+  <text x="474" y="296" text-anchor="middle" font-size="10" fill="#6B7280">tokens</text>
+  <rect x="524" y="258" width="88" height="46" rx="4" fill="#DCFCE7"/>
+  <text x="568" y="278" text-anchor="middle" font-size="12" font-weight="bold" fill="#15803D">0.6s</text>
+  <text x="568" y="296" text-anchor="middle" font-size="10" fill="#6B7280">elapsed</text>
+
+  <!-- Summary bar -->
+  <rect x="40" y="334" width="595" height="44" rx="6" fill="#111827"/>
+  <text x="110" y="352" font-size="12" font-weight="bold" fill="#ffffff">TOTAL</text>
+  <text x="170" y="352" font-size="12" fill="#9CA3AF">3 steps</text>
+  <text x="280" y="352" font-size="12" font-weight="bold" fill="#60A5FA">1,140 tokens</text>
+  <text x="420" y="352" font-size="12" font-weight="bold" fill="#34D399">$0.04 est.</text>
+  <text x="530" y="352" font-size="12" font-weight="bold" fill="#FBBF24">2.5 seconds</text>
+  <text x="340" y="370" text-anchor="middle" font-size="10" fill="#6B7280">This trace lets you see exactly where budget is spent and where time is lost.</text>
+
+  <!-- Caption -->
+  <text x="340" y="393" text-anchor="middle" font-size="11" fill="#9CA3AF">Logging every step — tokens, time, tool name — is not optional in production.</text>
+</svg>

--- a/public/assets/diagrams/api-contract.svg
+++ b/public/assets/diagrams/api-contract.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="380" viewBox="0 0 700 380" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="arr-right" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arr-left" markerWidth="10" markerHeight="7" refX="1" refY="3.5" orient="auto">
+      <polygon points="10 0, 0 3.5, 10 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arr-down" markerWidth="7" markerHeight="10" refX="3.5" refY="9" orient="auto">
+      <polygon points="0 0, 3.5 10, 7 0" fill="#9CA3AF"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="700" height="380" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="350" y="32" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">The API Contract: Everything Starts Here</text>
+  <line x1="40" y1="44" x2="660" y2="44" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Your Code box -->
+  <rect x="40" y="70" width="140" height="70" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
+  <text x="110" y="100" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Your Code</text>
+  <text x="110" y="118" text-anchor="middle" font-size="11" fill="#6B7280">Python / JS</text>
+  <text x="110" y="132" text-anchor="middle" font-size="11" fill="#6B7280">application</text>
+
+  <!-- LLM API box -->
+  <rect x="280" y="70" width="140" height="70" rx="8" fill="#F0FDF4" stroke="#22c55e" stroke-width="2"/>
+  <text x="350" y="100" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">LLM API</text>
+  <text x="350" y="118" text-anchor="middle" font-size="11" fill="#6B7280">GPT-4 / Claude</text>
+  <text x="350" y="132" text-anchor="middle" font-size="11" fill="#6B7280">Gemini / etc.</text>
+
+  <!-- Response box -->
+  <rect x="520" y="70" width="140" height="70" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="2"/>
+  <text x="590" y="100" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Response</text>
+  <text x="590" y="118" text-anchor="middle" font-size="11" fill="#6B7280">Structured</text>
+  <text x="590" y="132" text-anchor="middle" font-size="11" fill="#6B7280">JSON object</text>
+
+  <!-- Arrow: Code → API (top, going right) -->
+  <line x1="181" y1="95" x2="278" y2="95" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr-right)"/>
+  <text x="229" y="88" text-anchor="middle" font-size="10" fill="#374151">text + tokens</text>
+
+  <!-- Arrow: API → Response (top, going right) -->
+  <line x1="421" y1="95" x2="518" y2="95" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr-right)"/>
+
+  <!-- Arrow: Response → API → Code (bottom, going left) -->
+  <line x1="518" y1="125" x2="421" y2="125" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr-left)"/>
+  <line x1="278" y1="125" x2="181" y2="125" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr-left)"/>
+  <text x="350" y="145" text-anchor="middle" font-size="10" fill="#374151">text + tokens used + cost</text>
+
+  <!-- Divider -->
+  <line x1="40" y1="175" x2="660" y2="175" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="4,4"/>
+  <text x="350" y="168" text-anchor="middle" font-size="10" fill="#9CA3AF">BUILT ON TOP OF THIS BASE</text>
+
+  <!-- Stack layers -->
+  <!-- Layer 3: Top -->
+  <rect x="180" y="190" width="340" height="46" rx="6" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+  <text x="350" y="208" text-anchor="middle" font-size="13" font-weight="bold" fill="#5B21B6">Agents</text>
+  <text x="350" y="228" text-anchor="middle" font-size="11" fill="#6B7280">Multi-step autonomous loops with tool use and iteration</text>
+
+  <!-- Layer 2: Middle -->
+  <rect x="150" y="244" width="400" height="46" rx="6" fill="#ECFDF5" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="350" y="262" text-anchor="middle" font-size="13" font-weight="bold" fill="#15803D">RAG / Chains</text>
+  <text x="350" y="282" text-anchor="middle" font-size="11" fill="#6B7280">Retrieval-augmented pipelines and prompt chaining</text>
+
+  <!-- Layer 1: Bottom (base) -->
+  <rect x="120" y="298" width="460" height="46" rx="6" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
+  <text x="350" y="316" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">LLM API Call</text>
+  <text x="350" y="336" text-anchor="middle" font-size="11" fill="#6B7280">text in → text out  ·  everything else is code around this</text>
+
+  <!-- Caption -->
+  <text x="350" y="368" text-anchor="middle" font-size="11" fill="#9CA3AF">Core insight: no matter how complex your system, it all reduces to text-in, text-out.</text>
+</svg>

--- a/public/assets/diagrams/before-after-guardrails.svg
+++ b/public/assets/diagrams/before-after-guardrails.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="380" viewBox="0 0 720 380" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="720" height="380" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="360" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Guardrails: Before and After</text>
+  <line x1="40" y1="42" x2="680" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- LEFT PANEL: Without Guardrails -->
+  <rect x="30" y="56" width="295" height="296" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="178" y="82" text-anchor="middle" font-size="15" font-weight="bold" fill="#B91C1C">Without Guardrails</text>
+  <line x1="50" y1="92" x2="305" y2="92" stroke="#FCA5A5" stroke-width="1"/>
+
+  <!-- Bullet items -->
+  <!-- Item 1 -->
+  <circle cx="64" cy="122" r="6" fill="#EF4444"/>
+  <text x="80" y="126" font-size="13" font-weight="bold" fill="#374151">Infinite loops</text>
+  <text x="80" y="143" font-size="11" fill="#6B7280">Agent runs forever burning tokens,</text>
+  <text x="80" y="158" font-size="11" fill="#6B7280">no termination condition enforced.</text>
+
+  <!-- Item 2 -->
+  <circle cx="64" cy="185" r="6" fill="#EF4444"/>
+  <text x="80" y="189" font-size="13" font-weight="bold" fill="#374151">Crashes on bad input</text>
+  <text x="80" y="206" font-size="11" fill="#6B7280">Tool receives unexpected data types.</text>
+  <text x="80" y="221" font-size="11" fill="#6B7280">Unhandled exception. Silent failure.</text>
+
+  <!-- Item 3 -->
+  <circle cx="64" cy="248" r="6" fill="#EF4444"/>
+  <text x="80" y="252" font-size="13" font-weight="bold" fill="#374151">No visibility into steps</text>
+  <text x="80" y="269" font-size="11" fill="#6B7280">Can't diagnose what went wrong.</text>
+  <text x="80" y="284" font-size="11" fill="#6B7280">No token/cost/step data logged.</text>
+
+  <!-- Item 4 -->
+  <circle cx="64" cy="311" r="6" fill="#EF4444"/>
+  <text x="80" y="315" font-size="13" font-weight="bold" fill="#374151">Wrong answer ships</text>
+  <text x="80" y="332" font-size="11" fill="#6B7280">No output validation. Confident but</text>
+  <text x="80" y="347" font-size="11" fill="#6B7280">incorrect result reaches the user.</text>
+
+  <!-- CENTER: +10 lines label -->
+  <rect x="328" y="170" width="64" height="52" rx="8" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1.5"/>
+  <text x="360" y="190" text-anchor="middle" font-size="10" font-weight="bold" fill="#374151">+10 lines</text>
+  <text x="360" y="206" text-anchor="middle" font-size="10" fill="#6B7280">of code</text>
+  <text x="360" y="218" text-anchor="middle" font-size="18" fill="#374151">&#8594;</text>
+
+  <!-- RIGHT PANEL: With Guardrails -->
+  <rect x="395" y="56" width="295" height="296" rx="10" fill="#F0FDF4" stroke="#22c55e" stroke-width="2"/>
+  <text x="543" y="82" text-anchor="middle" font-size="15" font-weight="bold" fill="#15803D">With Guardrails</text>
+  <line x1="415" y1="92" x2="670" y2="92" stroke="#86EFAC" stroke-width="1"/>
+
+  <!-- Bullet items -->
+  <!-- Item 1 -->
+  <circle cx="429" cy="122" r="6" fill="#22c55e"/>
+  <text x="445" y="126" font-size="13" font-weight="bold" fill="#374151">Budget stops at 5 steps</text>
+  <text x="445" y="143" font-size="11" fill="#6B7280">Configurable max_steps=5. Loop exits</text>
+  <text x="445" y="158" font-size="11" fill="#6B7280">cleanly with a "budget exceeded" result.</text>
+
+  <!-- Item 2 -->
+  <circle cx="429" cy="185" r="6" fill="#22c55e"/>
+  <text x="445" y="189" font-size="13" font-weight="bold" fill="#374151">Pydantic catches bad args</text>
+  <text x="445" y="206" font-size="11" fill="#6B7280">Tool schemas validated before dispatch.</text>
+  <text x="445" y="221" font-size="11" fill="#6B7280">Type errors caught with clear messages.</text>
+
+  <!-- Item 3 -->
+  <circle cx="429" cy="248" r="6" fill="#22c55e"/>
+  <text x="445" y="252" font-size="13" font-weight="bold" fill="#374151">Each step logged</text>
+  <text x="445" y="269" font-size="11" fill="#6B7280">Step number, tool name, tokens used,</text>
+  <text x="445" y="284" font-size="11" fill="#6B7280">cost, latency captured per step.</text>
+
+  <!-- Item 4 -->
+  <circle cx="429" cy="311" r="6" fill="#22c55e"/>
+  <text x="445" y="315" font-size="13" font-weight="bold" fill="#374151">Output schema enforced</text>
+  <text x="445" y="332" font-size="11" fill="#6B7280">Structured output validated. Malformed</text>
+  <text x="445" y="347" font-size="11" fill="#6B7280">responses rejected before delivery.</text>
+
+  <!-- Caption -->
+  <text x="360" y="368" text-anchor="middle" font-size="11" fill="#374151">Guardrails are not optional safety features. They are the engineering interface between your code and the model.</text>
+</svg>

--- a/public/assets/diagrams/complexity-value-quadrant.svg
+++ b/public/assets/diagrams/complexity-value-quadrant.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 500" width="600" height="500" style="background:#fff;font-family:system-ui,-apple-system,sans-serif;">
+
+  <!-- Background -->
+  <rect width="600" height="500" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="300" y="28" text-anchor="middle" font-size="16" font-weight="600" fill="#374151">Architecture Selection: Complexity vs. Value of Autonomy</text>
+
+  <!-- Axis boundaries: x: 80 to 530, y: 60 to 440 -->
+  <!-- Mid x = 305, mid y = 250 -->
+
+  <!-- Quadrant backgrounds -->
+  <!-- Bottom-left: Workflow (low complexity, low autonomy value) - light green -->
+  <rect x="80" y="250" width="225" height="190" rx="0" fill="#ECFDF5"/>
+  <!-- Bottom-right: Don't Build This (high complexity, low value) - light red -->
+  <rect x="305" y="250" width="225" height="190" rx="0" fill="#FEF2F2"/>
+  <!-- Top-left: Single Agent (low complexity, high value) - light blue -->
+  <rect x="80" y="60" width="225" height="190" rx="0" fill="#EFF6FF"/>
+  <!-- Top-right: Multi-Agent or HITL (high complexity, high value) - light yellow -->
+  <rect x="305" y="60" width="225" height="190" rx="0" fill="#FFFBEB"/>
+
+  <!-- Quadrant borders -->
+  <line x1="80" y1="250" x2="530" y2="250" stroke="#9CA3AF" stroke-width="1.5"/>
+  <line x1="305" y1="60" x2="305" y2="440" stroke="#9CA3AF" stroke-width="1.5"/>
+
+  <!-- Outer border -->
+  <rect x="80" y="60" width="450" height="380" fill="none" stroke="#D1D5DB" stroke-width="1.5"/>
+
+  <!-- ========== Y AXIS ========== -->
+  <!-- Arrow up -->
+  <line x1="80" y1="440" x2="80" y2="50" stroke="#374151" stroke-width="1.5" marker-end="url(#axisArrow)"/>
+  <!-- Y axis label -->
+  <text x="25" y="250" text-anchor="middle" font-size="13" font-weight="600" fill="#374151" transform="rotate(-90 25 250)">Value of Autonomy</text>
+  <!-- Y tick labels -->
+  <text x="75" y="445" text-anchor="end" font-size="11" fill="#6B7280">Low</text>
+  <text x="75" y="65" text-anchor="end" font-size="11" fill="#6B7280">High</text>
+
+  <!-- ========== X AXIS ========== -->
+  <!-- Arrow right -->
+  <line x1="80" y1="440" x2="540" y2="440" stroke="#374151" stroke-width="1.5" marker-end="url(#axisArrow)"/>
+  <!-- X axis label -->
+  <text x="310" y="478" text-anchor="middle" font-size="13" font-weight="600" fill="#374151">Task Complexity</text>
+  <!-- X tick labels -->
+  <text x="80" y="456" text-anchor="middle" font-size="11" fill="#6B7280">Low</text>
+  <text x="530" y="456" text-anchor="middle" font-size="11" fill="#6B7280">High</text>
+
+  <!-- ========== BOTTOM-LEFT: Workflow ========== -->
+  <rect x="110" y="310" width="160" height="54" rx="8" fill="#10B981" stroke="#059669" stroke-width="1.5"/>
+  <text x="190" y="333" text-anchor="middle" font-size="14" font-weight="700" fill="#ffffff">Workflow</text>
+  <text x="190" y="351" text-anchor="middle" font-size="11" fill="#D1FAE5">most tasks belong here</text>
+  <!-- Annotation -->
+  <text x="192" y="282" text-anchor="middle" font-size="11" fill="#065F46" font-style="italic">Fixed steps, predictable</text>
+  <text x="192" y="296" text-anchor="middle" font-size="11" fill="#065F46" font-style="italic">path, easy to audit</text>
+
+  <!-- ========== BOTTOM-RIGHT: Don't Build This ========== -->
+  <rect x="330" y="310" width="170" height="54" rx="8" fill="#EF4444" stroke="#DC2626" stroke-width="1.5"/>
+  <text x="415" y="333" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">Don't Build This</text>
+  <text x="415" y="351" text-anchor="middle" font-size="11" fill="#FEE2E2">complex but not worth it</text>
+  <!-- Annotation -->
+  <text x="415" y="282" text-anchor="middle" font-size="11" fill="#991B1B" font-style="italic">High effort, low return.</text>
+  <text x="415" y="296" text-anchor="middle" font-size="11" fill="#991B1B" font-style="italic">Simplify the problem.</text>
+
+  <!-- ========== TOP-LEFT: Single Agent ========== -->
+  <rect x="110" y="120" width="160" height="54" rx="8" fill="#3B82F6" stroke="#2563EB" stroke-width="1.5"/>
+  <text x="190" y="143" text-anchor="middle" font-size="14" font-weight="700" fill="#ffffff">Single Agent</text>
+  <text x="190" y="161" text-anchor="middle" font-size="11" fill="#DBEAFE">simple autonomy, real value</text>
+  <!-- Annotation -->
+  <text x="192" y="200" text-anchor="middle" font-size="11" fill="#1E40AF" font-style="italic">Adaptive reasoning adds</text>
+  <text x="192" y="214" text-anchor="middle" font-size="11" fill="#1E40AF" font-style="italic">measurable value here</text>
+
+  <!-- ========== TOP-RIGHT: Multi-Agent or HITL ========== -->
+  <rect x="322" y="120" width="183" height="54" rx="8" fill="#F59E0B" stroke="#D97706" stroke-width="1.5"/>
+  <text x="413" y="140" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">Multi-Agent</text>
+  <text x="413" y="156" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">or HITL</text>
+  <text x="413" y="172" text-anchor="middle" font-size="11" fill="#FEF3C7">justified complexity</text>
+  <!-- Annotation -->
+  <text x="413" y="200" text-anchor="middle" font-size="11" fill="#92400E" font-style="italic">Coordination cost is</text>
+  <text x="413" y="214" text-anchor="middle" font-size="11" fill="#92400E" font-style="italic">justified by the stakes</text>
+
+  <!-- Center label -->
+  <circle cx="305" cy="250" r="5" fill="#9CA3AF"/>
+
+  <!-- Arrow markers -->
+  <defs>
+    <marker id="axisArrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#374151"/>
+    </marker>
+  </defs>
+
+</svg>

--- a/public/assets/diagrams/context-pipeline-layers.svg
+++ b/public/assets/diagrams/context-pipeline-layers.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="600" height="400" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="300" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Context Assembly: Three Layers</text>
+  <line x1="60" y1="42" x2="540" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Layer 1: System Prompt -->
+  <rect x="60" y="60" width="480" height="84" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
+  <text x="90" y="85" font-size="12" font-weight="bold" fill="#2563EB" letter-spacing="1">LAYER 1 — SYSTEM PROMPT</text>
+  <text x="300" y="110" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Role definition and constraints</text>
+  <text x="300" y="130" text-anchor="middle" font-size="11" fill="#6B7280">"You are a document intelligence assistant. Answer only from provided evidence."</text>
+
+  <!-- Arrow Layer 1 → 2 -->
+  <line x1="300" y1="144" x2="300" y2="172" stroke="#2563EB" stroke-width="2" stroke-dasharray="4,3" marker-end="url(#arr-blue)"/>
+
+  <!-- Layer 2: Evidence -->
+  <rect x="60" y="173" width="480" height="84" rx="8" fill="#FFF7ED" stroke="#F59E0B" stroke-width="2"/>
+  <text x="90" y="198" font-size="12" font-weight="bold" fill="#B45309" letter-spacing="1">LAYER 2 — EVIDENCE</text>
+  <text x="300" y="223" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Retrieved document chunks with sources</text>
+  <text x="300" y="243" text-anchor="middle" font-size="11" fill="#6B7280">[Excerpt 1] (Source: architecture.md, relevance: 0.87) · [Excerpt 2] ...</text>
+
+  <!-- Arrow Layer 2 → 3 -->
+  <line x1="300" y1="257" x2="300" y2="285" stroke="#2563EB" stroke-width="2" stroke-dasharray="4,3" marker-end="url(#arr-blue)"/>
+
+  <!-- Layer 3: User Query -->
+  <rect x="60" y="286" width="480" height="72" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="2"/>
+  <text x="90" y="311" font-size="12" font-weight="bold" fill="#065F46" letter-spacing="1">LAYER 3 — USER QUERY</text>
+  <text x="300" y="336" text-anchor="middle" font-size="14" font-weight="bold" fill="#065F46">The actual question being asked</text>
+  <text x="300" y="350" text-anchor="middle" font-size="11" fill="#6B7280">"What are the failure modes documented in the architecture file?"</text>
+
+  <!-- Bottom arrow and label -->
+  <line x1="300" y1="358" x2="300" y2="378" stroke="#2563EB" stroke-width="2" marker-end="url(#arr-blue)"/>
+  <text x="300" y="394" text-anchor="middle" font-size="12" fill="#374151" font-weight="bold">Assembled into completion request → model</text>
+</svg>

--- a/public/assets/diagrams/context-window-bucket.svg
+++ b/public/assets/diagrams/context-window-bucket.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="480" viewBox="0 0 500 480" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="500" height="480" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="250" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">The Context Window Bucket</text>
+  <line x1="40" y1="42" x2="460" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Capacity label -->
+  <text x="250" y="62" text-anchor="middle" font-size="13" fill="#374151">Fixed capacity: <tspan font-weight="bold" fill="#111827">128,000 tokens</tspan> — once full, oldest content is dropped</text>
+
+  <!-- Bucket outline -->
+  <rect x="130" y="78" width="240" height="320" rx="4" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="2"/>
+
+  <!-- Overflow zone (red, top) -->
+  <rect x="130" y="78" width="240" height="38" rx="4" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="250" y="96" text-anchor="middle" font-size="11" font-weight="bold" fill="#B91C1C">OVERFLOW — CONTENT LOST</text>
+  <text x="250" y="110" text-anchor="middle" font-size="10" fill="#EF4444">tokens above limit are truncated</text>
+
+  <!-- Segment 5: Tool Results (purple) — from top of content area -->
+  <rect x="130" y="116" width="240" height="56" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1"/>
+  <text x="250" y="138" text-anchor="middle" font-size="12" font-weight="bold" fill="#5B21B6">Tool Results</text>
+  <text x="250" y="155" text-anchor="middle" font-size="10" fill="#6B7280">Function outputs, API responses</text>
+  <text x="388" y="147" text-anchor="middle" font-size="10" fill="#8B5CF6">~25K tokens</text>
+
+  <!-- Segment 4: Conversation History (amber) -->
+  <rect x="130" y="172" width="240" height="68" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1"/>
+  <text x="250" y="196" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">Conversation History</text>
+  <text x="250" y="213" text-anchor="middle" font-size="10" fill="#6B7280">Prior turns, user messages</text>
+  <text x="388" y="207" text-anchor="middle" font-size="10" fill="#F59E0B">~30K tokens</text>
+
+  <!-- Segment 3: Retrieved Documents (green) — large -->
+  <rect x="130" y="240" width="240" height="88" fill="#F0FDF4" stroke="#22c55e" stroke-width="1"/>
+  <text x="250" y="268" text-anchor="middle" font-size="12" font-weight="bold" fill="#15803D">Retrieved Documents</text>
+  <text x="250" y="286" text-anchor="middle" font-size="10" fill="#6B7280">RAG chunks, search results</text>
+  <text x="250" y="303" text-anchor="middle" font-size="10" fill="#6B7280">knowledge base content</text>
+  <text x="388" y="285" text-anchor="middle" font-size="10" fill="#22c55e">~50K tokens</text>
+
+  <!-- Segment 2: Few-shot Examples (light blue) -->
+  <rect x="130" y="328" width="240" height="42" fill="#DBEAFE" stroke="#93C5FD" stroke-width="1"/>
+  <text x="250" y="346" text-anchor="middle" font-size="12" font-weight="bold" fill="#1E40AF">Few-shot Examples</text>
+  <text x="250" y="362" text-anchor="middle" font-size="10" fill="#6B7280">Input/output demonstrations</text>
+  <text x="388" y="352" text-anchor="middle" font-size="10" fill="#3B82F6">~15K tokens</text>
+
+  <!-- Segment 1: System Prompt (blue, bottom) -->
+  <rect x="130" y="370" width="240" height="28" rx="0" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1"/>
+  <rect x="130" y="384" width="240" height="14" rx="0" fill="#EFF6FF"/>
+  <rect x="130" y="370" width="240" height="28" rx="0" fill="none" stroke="#3B82F6" stroke-width="1"/>
+  <text x="250" y="382" text-anchor="middle" font-size="12" font-weight="bold" fill="#1D4ED8">System Prompt</text>
+  <text x="388" y="385" text-anchor="middle" font-size="10" fill="#3B82F6">~8K tokens</text>
+
+  <!-- Bottom of bucket (floor) -->
+  <rect x="128" y="396" width="244" height="4" rx="2" fill="#D1D5DB"/>
+
+  <!-- Legend / caption -->
+  <text x="250" y="428" text-anchor="middle" font-size="11" fill="#374151">Fill order: system prompt first, examples, documents, history, tool results</text>
+  <text x="250" y="448" text-anchor="middle" font-size="11" fill="#9CA3AF">Engineer's job: decide what fills the bucket and in what order.</text>
+  <text x="250" y="466" text-anchor="middle" font-size="11" fill="#EF4444">What overflows gets forgotten.</text>
+</svg>

--- a/public/assets/diagrams/defense-layers.svg
+++ b/public/assets/diagrams/defense-layers.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="480" viewBox="0 0 800 480" font-family="'IBM Plex Sans', sans-serif">
+  <defs>
+    <marker id="arr-dl-dk" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1a3a5c"/>
+    </marker>
+    <marker id="arr-dl-md" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#3d7ab5"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="480" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="34" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a1a">Defense Layers — Memory Integrity Pipeline</text>
+  <line x1="100" y1="48" x2="700" y2="48" stroke="#7eb3d8" stroke-width="1"/>
+
+  <!-- Pipeline flow (left side): Input -->
+  <rect x="40" y="80" width="120" height="50" rx="8" fill="#1a3a5c" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="100" y="102" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">Agent Output</text>
+  <text x="100" y="118" text-anchor="middle" font-size="10" fill="#7eb3d8">correction to store</text>
+
+  <!-- Arrow down to Layer 1 -->
+  <line x1="100" y1="130" x2="100" y2="158" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-dl-dk)"/>
+
+  <!-- ═══ LAYER 1: MemoryValidator ═══ -->
+  <rect x="40" y="160" width="720" height="86" rx="10" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="70" y="182" font-size="11" font-weight="bold" fill="#1a3a5c" letter-spacing="1">LAYER 1</text>
+  <rect x="150" y="170" width="200" height="56" rx="8" fill="#ffffff" stroke="#3d7ab5" stroke-width="2"/>
+  <text x="250" y="194" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">MemoryValidator</text>
+  <text x="250" y="212" text-anchor="middle" font-size="11" fill="#6b7280">Cross-checks against evidence</text>
+
+  <!-- How it works -->
+  <rect x="400" y="170" width="340" height="56" rx="6" fill="#ffffff" stroke="#7eb3d8" stroke-width="1.5"/>
+  <text x="420" y="190" font-size="11" fill="#1a1a1a" font-weight="bold">How:</text>
+  <text x="460" y="190" font-size="11" fill="#6b7280">Retrieves source docs for the claim</text>
+  <text x="420" y="206" font-size="11" fill="#1a1a1a" font-weight="bold">Action:</text>
+  <text x="468" y="206" font-size="11" fill="#6b7280">Reject if no supporting evidence</text>
+  <text x="420" y="220" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#3d7ab5">if similarity(claim, source) &lt; 0.7: reject</text>
+
+  <!-- Arrow: Layer 1 pass → Layer 2 -->
+  <line x1="100" y1="246" x2="100" y2="272" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-dl-dk)"/>
+  <text x="114" y="262" font-size="10" fill="#059669" font-weight="bold">pass</text>
+
+  <!-- ═══ LAYER 2: Independent Verification ═══ -->
+  <rect x="40" y="274" width="720" height="86" rx="10" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="70" y="296" font-size="11" font-weight="bold" fill="#1a3a5c" letter-spacing="1">LAYER 2</text>
+  <rect x="150" y="284" width="200" height="56" rx="8" fill="#ffffff" stroke="#3d7ab5" stroke-width="2"/>
+  <text x="250" y="306" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">Independent Verifier</text>
+  <text x="250" y="324" text-anchor="middle" font-size="11" fill="#6b7280">Separate agent, own retrieval</text>
+
+  <!-- How it works -->
+  <rect x="400" y="284" width="340" height="56" rx="6" fill="#ffffff" stroke="#7eb3d8" stroke-width="1.5"/>
+  <text x="420" y="304" font-size="11" fill="#1a1a1a" font-weight="bold">How:</text>
+  <text x="460" y="304" font-size="11" fill="#6b7280">30% spot-check with fresh retrieval</text>
+  <text x="420" y="320" font-size="11" fill="#1a1a1a" font-weight="bold">Action:</text>
+  <text x="468" y="320" font-size="11" fill="#6b7280">Flag disagreements for human review</text>
+  <text x="420" y="334" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#3d7ab5">if random() &lt; 0.3: verify(claim)</text>
+
+  <!-- Arrow: Layer 2 pass → Layer 3 -->
+  <line x1="100" y1="360" x2="100" y2="386" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-dl-dk)"/>
+  <text x="114" y="376" font-size="10" fill="#059669" font-weight="bold">pass</text>
+
+  <!-- ═══ LAYER 3: AnomalyDetector ═══ -->
+  <rect x="40" y="388" width="720" height="80" rx="10" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="70" y="410" font-size="11" font-weight="bold" fill="#1a3a5c" letter-spacing="1">LAYER 3</text>
+  <rect x="150" y="396" width="200" height="56" rx="8" fill="#ffffff" stroke="#3d7ab5" stroke-width="2"/>
+  <text x="250" y="420" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">AnomalyDetector</text>
+  <text x="250" y="438" text-anchor="middle" font-size="11" fill="#6b7280">Runtime monitoring</text>
+
+  <!-- How it works -->
+  <rect x="400" y="396" width="340" height="56" rx="6" fill="#ffffff" stroke="#7eb3d8" stroke-width="1.5"/>
+  <text x="420" y="416" font-size="11" fill="#1a1a1a" font-weight="bold">How:</text>
+  <text x="460" y="416" font-size="11" fill="#6b7280">Flags dormant memories that suddenly activate</text>
+  <text x="420" y="432" font-size="11" fill="#1a1a1a" font-weight="bold">Action:</text>
+  <text x="468" y="432" font-size="11" fill="#6b7280">Quarantine + alert if spike detected</text>
+  <text x="420" y="446" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#3d7ab5">if access_spike(mem) &gt; 3x: quarantine</text>
+
+  <!-- Memory Store (output, right side) -->
+  <rect x="660" y="80" width="100" height="50" rx="8" fill="#1a3a5c" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="710" y="102" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">Memory</text>
+  <text x="710" y="118" text-anchor="middle" font-size="10" fill="#7eb3d8">clean store</text>
+
+  <!-- Final arrow from Layer 3 to Memory Store (going up-right) -->
+  <path d="M 350 430 Q 500 470 710 132" fill="none" stroke="#059669" stroke-width="2" marker-end="url(#arr-dl-dk)"/>
+  <text x="560" y="310" font-size="10" fill="#059669" font-weight="bold" transform="rotate(-55 560 310)">all layers pass</text>
+
+  <!-- Reject arrows (going right out) -->
+  <text x="770" y="206" font-size="10" fill="#dc2626" font-weight="bold" text-anchor="end">reject</text>
+  <text x="770" y="320" font-size="10" fill="#dc2626" font-weight="bold" text-anchor="end">flag</text>
+  <text x="770" y="432" font-size="10" fill="#dc2626" font-weight="bold" text-anchor="end">quarantine</text>
+</svg>

--- a/public/assets/diagrams/escalation-decision-tree.svg
+++ b/public/assets/diagrams/escalation-decision-tree.svg
@@ -1,0 +1,103 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="450" viewBox="0 0 700 450" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arrowhead-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+    </marker>
+    <marker id="arrowhead-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#EF4444"/>
+    </marker>
+    <marker id="arrowhead-yellow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#F59E0B"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="700" height="450" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="350" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Escalation Decision Tree</text>
+  <line x1="60" y1="42" x2="640" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Start node: Agent wants to act -->
+  <rect x="245" y="55" width="210" height="46" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="350" y="75" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">Agent wants to act</text>
+  <text x="350" y="92" text-anchor="middle" font-size="11" fill="#6B7280">action proposed</text>
+
+  <!-- Arrow down to Diamond 1 -->
+  <line x1="350" y1="101" x2="350" y2="128" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Diamond 1: Risk tier? center=(350,165) half-w=90 half-h=40 -->
+  <polygon points="350,128 440,168 350,208 260,168" fill="#FFF7ED" stroke="#F59E0B" stroke-width="2"/>
+  <text x="350" y="163" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">Risk tier?</text>
+  <text x="350" y="179" text-anchor="middle" font-size="10" fill="#6B7280">evaluate policy</text>
+
+  <!-- Critical path: right from diamond -->
+  <line x1="440" y1="168" x2="560" y2="168" stroke="#EF4444" stroke-width="1.5" marker-end="url(#arrowhead-red)"/>
+  <text x="500" y="160" text-anchor="middle" font-size="10" fill="#EF4444">Critical</text>
+
+  <!-- Always Escalate box (right) -->
+  <rect x="560" y="148" width="120" height="40" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="620" y="165" text-anchor="middle" font-size="11" font-weight="bold" fill="#991B1B">Always</text>
+  <text x="620" y="180" text-anchor="middle" font-size="11" font-weight="bold" fill="#991B1B">Escalate</text>
+
+  <!-- Low/Medium/High path: down from diamond -->
+  <line x1="350" y1="208" x2="350" y2="244" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="365" y="232" font-size="10" fill="#6B7280">High / Med / Low</text>
+
+  <!-- Diamond 2: Confidence >= threshold? center=(350,285) half-w=95 half-h=40 -->
+  <polygon points="350,244 445,284 350,324 255,284" fill="#F9FAFB" stroke="#6B7280" stroke-width="2"/>
+  <text x="350" y="278" text-anchor="middle" font-size="12" font-weight="bold" fill="#374151">Confidence</text>
+  <text x="350" y="293" text-anchor="middle" font-size="12" font-weight="bold" fill="#374151">>= threshold?</text>
+
+  <!-- Yes path: left -->
+  <line x1="255" y1="284" x2="160" y2="284" stroke="#10B981" stroke-width="1.5" marker-end="url(#arrowhead-green)"/>
+  <text x="206" y="276" text-anchor="middle" font-size="10" fill="#10B981">Yes</text>
+
+  <!-- Proceed box -->
+  <rect x="60" y="264" width="100" height="40" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="2"/>
+  <text x="110" y="282" text-anchor="middle" font-size="12" font-weight="bold" fill="#065F46">Proceed</text>
+  <text x="110" y="297" text-anchor="middle" font-size="10" fill="#6B7280">auto-approve</text>
+
+  <!-- No path: right -->
+  <line x1="445" y1="284" x2="540" y2="284" stroke="#EF4444" stroke-width="1.5" marker-end="url(#arrowhead-red)"/>
+  <text x="492" y="276" text-anchor="middle" font-size="10" fill="#EF4444">No</text>
+
+  <!-- Escalate to human box -->
+  <rect x="540" y="264" width="140" height="40" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="610" y="282" text-anchor="middle" font-size="11" font-weight="bold" fill="#991B1B">Escalate</text>
+  <text x="610" y="297" text-anchor="middle" font-size="10" fill="#6B7280">to human reviewer</text>
+
+  <!-- Budget check: below Proceed -->
+  <line x1="110" y1="304" x2="110" y2="348" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Diamond 3: Action budget? center=(110,380) -->
+  <polygon points="110,348 185,380 110,412 35,380" fill="#FFF7ED" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="110" y="375" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Actions taken</text>
+  <text x="110" y="389" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">>= budget?</text>
+
+  <!-- Yes: Halt -->
+  <line x1="35" y1="380" x2="20" y2="380" stroke="#EF4444" stroke-width="1.5"/>
+  <line x1="20" y1="380" x2="20" y2="420" stroke="#EF4444" stroke-width="1.5" marker-end="url(#arrowhead-red)"/>
+  <rect x="30" y="408" width="80" height="30" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="70" y="428" text-anchor="middle" font-size="12" font-weight="bold" fill="#991B1B">Halt</text>
+
+  <!-- Label on Halt path -->
+  <text x="15" y="395" text-anchor="end" font-size="10" fill="#EF4444">Yes</text>
+
+  <!-- No: continue -->
+  <line x1="185" y1="380" x2="280" y2="380" stroke="#10B981" stroke-width="1.5" marker-end="url(#arrowhead-green)"/>
+  <text x="232" y="372" text-anchor="middle" font-size="10" fill="#10B981">No</text>
+  <rect x="280" y="360" width="110" height="40" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="335" y="378" text-anchor="middle" font-size="11" font-weight="bold" fill="#065F46">Continue</text>
+  <text x="335" y="393" text-anchor="middle" font-size="10" fill="#6B7280">autonomous</text>
+
+  <!-- Legend -->
+  <rect x="400" y="356" width="280" height="72" rx="8" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="416" y="374" font-size="11" font-weight="bold" fill="#374151">Risk Tier Thresholds</text>
+  <text x="416" y="390" font-size="10" fill="#6B7280">Low: confidence >= 0.30, max 10 actions</text>
+  <text x="416" y="405" font-size="10" fill="#6B7280">Medium: confidence >= 0.60, max 5 actions</text>
+  <text x="416" y="420" font-size="10" fill="#6B7280">High: confidence >= 0.80, max 2 actions</text>
+</svg>

--- a/public/assets/diagrams/eval-bucket-distribution.svg
+++ b/public/assets/diagrams/eval-bucket-distribution.svg
@@ -1,0 +1,147 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 480" width="820" height="480" style="background:#fff;font-family:'IBM Plex Sans',system-ui,sans-serif;">
+
+  <rect width="820" height="480" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="410" y="34" text-anchor="middle" font-size="18" font-weight="500" fill="#1a1a1a" font-family="Fraunces, Georgia, serif">Same aggregate. Different failure distribution.</text>
+  <text x="410" y="56" text-anchor="middle" font-size="12" fill="#6b6b6b">Two agents at 0.85 accuracy. Only one is shippable.</text>
+
+  <!-- Vertical divider -->
+  <line x1="410" y1="80" x2="410" y2="430" stroke="#e8e8e8" stroke-width="1"/>
+
+  <!-- ============ LEFT: Agent A (uniform distribution) ============ -->
+  <g>
+    <text x="200" y="90" text-anchor="middle" font-size="13" font-weight="600" fill="#1a1a1a" letter-spacing="0.02em">AGENT A</text>
+    <text x="200" y="108" text-anchor="middle" font-size="11" fill="#6b6b6b">uniform failure distribution</text>
+
+    <!-- Aggregate score callout -->
+    <rect x="135" y="120" width="130" height="40" rx="3" fill="#fafaf8" stroke="#9ca3af" stroke-width="1"/>
+    <text x="200" y="138" text-anchor="middle" font-size="10" fill="#6b6b6b" letter-spacing="0.04em">AGGREGATE</text>
+    <text x="200" y="154" text-anchor="middle" font-size="14" font-weight="600" fill="#1a1a1a" font-family="Fraunces, Georgia, serif">0.85</text>
+
+    <!-- Bucket bars: x-axis from 65 to 350, max width = 285 px = 15% -->
+    <!-- bar width per %: 19 px -->
+
+    <g font-size="10" fill="#374151">
+      <!-- Hallucination 2% -->
+      <text x="195" y="195" text-anchor="end">hallucination</text>
+      <rect x="200" y="188" width="38" height="10" fill="#9b4a3f"/>
+      <text x="245" y="196" font-size="9" fill="#6b6b6b">2%</text>
+
+      <!-- Tool selection 2% -->
+      <text x="195" y="215" text-anchor="end">tool selection</text>
+      <rect x="200" y="208" width="38" height="10" fill="#9b4a3f"/>
+      <text x="245" y="216" font-size="9" fill="#6b6b6b">2%</text>
+
+      <!-- Tool invocation 2% -->
+      <text x="195" y="235" text-anchor="end">tool invocation</text>
+      <rect x="200" y="228" width="38" height="10" fill="#b45309"/>
+      <text x="245" y="236" font-size="9" fill="#6b6b6b">2%</text>
+
+      <!-- Scope creep 2% -->
+      <text x="195" y="255" text-anchor="end">scope creep</text>
+      <rect x="200" y="248" width="38" height="10" fill="#b45309"/>
+      <text x="245" y="256" font-size="9" fill="#6b6b6b">2%</text>
+
+      <!-- Refusal 2% -->
+      <text x="195" y="275" text-anchor="end">refusal</text>
+      <rect x="200" y="268" width="38" height="10" fill="#b45309"/>
+      <text x="245" y="276" font-size="9" fill="#6b6b6b">2%</text>
+
+      <!-- Cost runaway 1% -->
+      <text x="195" y="295" text-anchor="end">cost runaway</text>
+      <rect x="200" y="288" width="19" height="10" fill="#9b4a3f"/>
+      <text x="225" y="296" font-size="9" fill="#6b6b6b">1%</text>
+
+      <!-- Latency 2% -->
+      <text x="195" y="315" text-anchor="end">latency</text>
+      <rect x="200" y="308" width="38" height="10" fill="#b45309"/>
+      <text x="245" y="316" font-size="9" fill="#6b6b6b">2%</text>
+
+      <!-- Format 2% -->
+      <text x="195" y="335" text-anchor="end">format</text>
+      <rect x="200" y="328" width="38" height="10" fill="#6b7280"/>
+      <text x="245" y="336" font-size="9" fill="#6b6b6b">2%</text>
+    </g>
+
+    <!-- Assessment -->
+    <text x="200" y="380" text-anchor="middle" font-size="12" fill="#1a1a1a" font-style="italic" font-family="Fraunces, Georgia, serif">Annoying. Survivable.</text>
+    <text x="200" y="400" text-anchor="middle" font-size="10" fill="#6b6b6b">No single failure mode dominates.</text>
+  </g>
+
+  <!-- ============ RIGHT: Agent B (concentrated) ============ -->
+  <g>
+    <text x="620" y="90" text-anchor="middle" font-size="13" font-weight="600" fill="#1a1a1a" letter-spacing="0.02em">AGENT B</text>
+    <text x="620" y="108" text-anchor="middle" font-size="11" fill="#6b6b6b">concentrated on tier-1 buckets</text>
+
+    <!-- Aggregate score callout -->
+    <rect x="555" y="120" width="130" height="40" rx="3" fill="#fafaf8" stroke="#9ca3af" stroke-width="1"/>
+    <text x="620" y="138" text-anchor="middle" font-size="10" fill="#6b6b6b" letter-spacing="0.04em">AGGREGATE</text>
+    <text x="620" y="154" text-anchor="middle" font-size="14" font-weight="600" fill="#1a1a1a" font-family="Fraunces, Georgia, serif">0.85</text>
+
+    <!-- Bucket bars -->
+    <g font-size="10" fill="#374151">
+      <!-- Hallucination 10% -->
+      <text x="615" y="195" text-anchor="end">hallucination</text>
+      <rect x="620" y="188" width="190" height="10" fill="#9b4a3f"/>
+      <text x="817" y="196" font-size="9" fill="#9b4a3f" font-weight="600">10%</text>
+
+      <!-- Tool selection 0% -->
+      <text x="615" y="215" text-anchor="end">tool selection</text>
+      <line x1="620" y1="213" x2="640" y2="213" stroke="#d1d5db" stroke-width="1"/>
+      <text x="645" y="216" font-size="9" fill="#9ca3af">0%</text>
+
+      <!-- Tool invocation 0% -->
+      <text x="615" y="235" text-anchor="end">tool invocation</text>
+      <line x1="620" y1="233" x2="640" y2="233" stroke="#d1d5db" stroke-width="1"/>
+      <text x="645" y="236" font-size="9" fill="#9ca3af">0%</text>
+
+      <!-- Scope creep 0% -->
+      <text x="615" y="255" text-anchor="end">scope creep</text>
+      <line x1="620" y1="253" x2="640" y2="253" stroke="#d1d5db" stroke-width="1"/>
+      <text x="645" y="256" font-size="9" fill="#9ca3af">0%</text>
+
+      <!-- Refusal 0% -->
+      <text x="615" y="275" text-anchor="end">refusal</text>
+      <line x1="620" y1="273" x2="640" y2="273" stroke="#d1d5db" stroke-width="1"/>
+      <text x="645" y="276" font-size="9" fill="#9ca3af">0%</text>
+
+      <!-- Cost runaway 5% -->
+      <text x="615" y="295" text-anchor="end">cost runaway</text>
+      <rect x="620" y="288" width="95" height="10" fill="#9b4a3f"/>
+      <text x="722" y="296" font-size="9" fill="#9b4a3f" font-weight="600">5%</text>
+
+      <!-- Latency 0% -->
+      <text x="615" y="315" text-anchor="end">latency</text>
+      <line x1="620" y1="313" x2="640" y2="313" stroke="#d1d5db" stroke-width="1"/>
+      <text x="645" y="316" font-size="9" fill="#9ca3af">0%</text>
+
+      <!-- Format 0% -->
+      <text x="615" y="335" text-anchor="end">format</text>
+      <line x1="620" y1="333" x2="640" y2="333" stroke="#d1d5db" stroke-width="1"/>
+      <text x="645" y="336" font-size="9" fill="#9ca3af">0%</text>
+    </g>
+
+    <!-- Assessment -->
+    <text x="620" y="380" text-anchor="middle" font-size="12" fill="#1a1a1a" font-style="italic" font-family="Fraunces, Georgia, serif">Unshippable.</text>
+    <text x="620" y="400" text-anchor="middle" font-size="10" fill="#6b6b6b">Two tier-1 buckets dominate. Aggregate hid both.</text>
+  </g>
+
+  <!-- Legend -->
+  <g>
+    <rect x="200" y="430" width="14" height="10" fill="#9b4a3f"/>
+    <text x="220" y="439" font-size="10" fill="#374151">tier 1 (severe)</text>
+
+    <rect x="320" y="430" width="14" height="10" fill="#b45309"/>
+    <text x="340" y="439" font-size="10" fill="#374151">tier 2</text>
+
+    <rect x="400" y="430" width="14" height="10" fill="#6b7280"/>
+    <text x="420" y="439" font-size="10" fill="#374151">tier 3 (cosmetic)</text>
+
+    <text x="540" y="439" font-size="10" fill="#6b6b6b" font-style="italic" font-family="Fraunces, Georgia, serif">15% total failure rate in both agents</text>
+  </g>
+
+  <!-- Caption -->
+  <rect x="60" y="453" width="700" height="0" fill="#fafaf8"/>
+
+</svg>

--- a/public/assets/diagrams/eval-loop.svg
+++ b/public/assets/diagrams/eval-loop.svg
@@ -1,0 +1,121 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="560" viewBox="0 0 800 560" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr-gray" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arr-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+    <marker id="arr-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="560" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="34" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Evaluation Loop — Iterative Quality Cycle</text>
+  <line x1="80" y1="46" x2="720" y2="46" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Subtitle -->
+  <text x="400" y="66" text-anchor="middle" font-size="13" fill="#6B7280">Not a one-time check. A continuous improvement engine.</text>
+
+  <!-- ── Six nodes arranged in a hexagonal cycle ── -->
+  <!-- Center of cycle: (400, 300) radius ~165 -->
+  <!-- Node positions (cx, cy): -->
+  <!--   1. Define Cases   : (400, 106)   top -->
+  <!--   2. Run Agent      : (614, 206)   top-right -->
+  <!--   3. Score Responses: (614, 370)   bottom-right -->
+  <!--   4. Categorize     : (400, 470)   bottom -->
+  <!--   5. Improve System : (186, 370)   bottom-left -->
+  <!--   6. Re-run         : (186, 206)   top-left -->
+
+  <!-- Node 1: Define Cases (top) -->
+  <rect x="300" y="88" width="200" height="58" rx="10" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
+  <text x="400" y="114" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Define Cases</text>
+  <text x="400" y="132" text-anchor="middle" font-size="11" fill="#6B7280">Questions · expected answers · criteria</text>
+
+  <!-- Node 2: Run Agent (top-right) -->
+  <rect x="514" y="186" width="200" height="58" rx="10" fill="#FFF7ED" stroke="#F59E0B" stroke-width="2"/>
+  <text x="614" y="212" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Run Agent</text>
+  <text x="614" y="230" text-anchor="middle" font-size="11" fill="#6B7280">Execute full retrieval-reason cycle</text>
+
+  <!-- Node 3: Score Responses (bottom-right) -->
+  <rect x="514" y="348" width="200" height="58" rx="10" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="2"/>
+  <text x="614" y="374" text-anchor="middle" font-size="14" font-weight="bold" fill="#5B21B6">Score Responses</text>
+  <text x="614" y="392" text-anchor="middle" font-size="11" fill="#6B7280">Faithfulness · relevance · accuracy</text>
+
+  <!-- Node 4: Categorize Failures (bottom) -->
+  <rect x="300" y="450" width="200" height="58" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="400" y="476" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Categorize Failures</text>
+  <text x="400" y="494" text-anchor="middle" font-size="11" fill="#6B7280">Retrieval · reasoning · tool · system</text>
+
+  <!-- Node 5: Improve System (bottom-left) -->
+  <rect x="86" y="348" width="200" height="58" rx="10" fill="#F0FDF4" stroke="#10B981" stroke-width="2"/>
+  <text x="186" y="374" text-anchor="middle" font-size="14" font-weight="bold" fill="#065F46">Improve System</text>
+  <text x="186" y="392" text-anchor="middle" font-size="11" fill="#6B7280">Prompt · retrieval · chunk · model</text>
+
+  <!-- Node 6: Re-run (top-left) -->
+  <rect x="86" y="186" width="200" height="58" rx="10" fill="#FFF7ED" stroke="#F59E0B" stroke-width="2"/>
+  <text x="186" y="212" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Re-run</text>
+  <text x="186" y="230" text-anchor="middle" font-size="11" fill="#6B7280">Full suite + new regression cases</text>
+
+  <!-- ── Arrows between nodes (clockwise) ── -->
+  <!-- 1 (Define Cases) → 2 (Run Agent): diagonal down-right -->
+  <line x1="490" y1="128" x2="528" y2="186" stroke="#2563EB" stroke-width="2" marker-end="url(#arr-blue)"/>
+
+  <!-- 2 (Run Agent) → 3 (Score): straight down -->
+  <line x1="614" y1="244" x2="614" y2="346" stroke="#2563EB" stroke-width="2" marker-end="url(#arr-blue)"/>
+
+  <!-- 3 (Score) → 4 (Categorize): diagonal down-left -->
+  <line x1="524" y1="404" x2="490" y2="450" stroke="#2563EB" stroke-width="2" marker-end="url(#arr-blue)"/>
+
+  <!-- 4 (Categorize) → 5 (Improve): diagonal up-left -->
+  <line x1="310" y1="450" x2="276" y2="404" stroke="#2563EB" stroke-width="2" marker-end="url(#arr-blue)"/>
+
+  <!-- 5 (Improve) → 6 (Re-run): straight up -->
+  <line x1="186" y1="348" x2="186" y2="246" stroke="#2563EB" stroke-width="2" marker-end="url(#arr-blue)"/>
+
+  <!-- 6 (Re-run) → 1 (Define Cases): diagonal up-right -->
+  <line x1="276" y1="192" x2="308" y2="146" stroke="#2563EB" stroke-width="2" marker-end="url(#arr-blue)"/>
+
+  <!-- ── Center label ── -->
+  <circle cx="400" cy="300" r="68" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1.5"/>
+  <text x="400" y="291" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">Continuous</text>
+  <text x="400" y="308" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">Quality</text>
+  <text x="400" y="325" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">Cycle</text>
+
+  <!-- ── Regression Suite box (growing) ── -->
+  <rect x="580" y="64" width="175" height="88" rx="10" fill="#F0FDF4" stroke="#10B981" stroke-width="2"/>
+  <text x="667" y="86" text-anchor="middle" font-size="12" font-weight="bold" fill="#065F46">Regression Suite</text>
+  <text x="667" y="103" text-anchor="middle" font-size="10" fill="#374151">Grows with each cycle.</text>
+  <text x="667" y="118" text-anchor="middle" font-size="10" fill="#374151">Failed cases become</text>
+  <text x="667" y="133" text-anchor="middle" font-size="10" fill="#374151">permanent test cases.</text>
+
+  <!-- Arrow from Categorize to Regression Suite -->
+  <path d="M700,404 L730,404 L730,154 L757,154" fill="none" stroke="#10B981" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arr-green)"/>
+  <text x="735" y="292" font-size="10" fill="#059669" transform="rotate(-90 735 292)">failures added to suite</text>
+
+  <!-- ── Step numbers ── -->
+  <circle cx="400" cy="88" r="10" fill="#2563EB"/>
+  <text x="400" y="92" text-anchor="middle" font-size="11" font-weight="bold" fill="#ffffff">1</text>
+
+  <circle cx="614" cy="186" r="10" fill="#2563EB"/>
+  <text x="614" y="190" text-anchor="middle" font-size="11" font-weight="bold" fill="#ffffff">2</text>
+
+  <circle cx="614" cy="348" r="10" fill="#2563EB"/>
+  <text x="614" y="352" text-anchor="middle" font-size="11" font-weight="bold" fill="#ffffff">3</text>
+
+  <circle cx="400" cy="450" r="10" fill="#2563EB"/>
+  <text x="400" y="454" text-anchor="middle" font-size="11" font-weight="bold" fill="#ffffff">4</text>
+
+  <circle cx="186" cy="348" r="10" fill="#2563EB"/>
+  <text x="186" y="352" text-anchor="middle" font-size="11" font-weight="bold" fill="#ffffff">5</text>
+
+  <circle cx="186" cy="186" r="10" fill="#2563EB"/>
+  <text x="186" y="190" text-anchor="middle" font-size="11" font-weight="bold" fill="#ffffff">6</text>
+
+  <!-- Bottom note -->
+  <text x="400" y="544" text-anchor="middle" font-size="11" fill="#9CA3AF">Each pass through the loop tightens quality gates and expands coverage.</text>
+</svg>

--- a/public/assets/diagrams/failure-surfaces.svg
+++ b/public/assets/diagrams/failure-surfaces.svg
@@ -1,0 +1,136 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="580" viewBox="0 0 800 580" font-family="Arial, Helvetica, sans-serif">
+  <!-- Background -->
+  <rect width="800" height="580" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="34" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Agent Failure Surfaces and Mitigations</text>
+  <line x1="60" y1="46" x2="740" y2="46" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Axis labels -->
+  <text x="200" y="64" text-anchor="middle" font-size="13" font-weight="bold" fill="#6B7280">Data Plane</text>
+  <text x="600" y="64" text-anchor="middle" font-size="13" font-weight="bold" fill="#6B7280">Reasoning Plane</text>
+
+  <!-- Horizontal and vertical dividers -->
+  <line x1="400" y1="72" x2="400" y2="542" stroke="#E5E7EB" stroke-width="2"/>
+  <line x1="60" y1="304" x2="740" y2="304" stroke="#E5E7EB" stroke-width="2"/>
+
+  <!-- Side labels -->
+  <text x="22" y="200" text-anchor="middle" font-size="12" font-weight="bold" fill="#6B7280" transform="rotate(-90 22 200)">Input / Fetch</text>
+  <text x="22" y="430" text-anchor="middle" font-size="12" font-weight="bold" fill="#6B7280" transform="rotate(-90 22 430)">Execution / Infra</text>
+
+  <!-- ══ Q1: Retrieval Failures (top-left) ══ -->
+  <rect x="64" y="74" width="328" height="222" rx="12" fill="#FEF2F2" stroke="#FCA5A5" stroke-width="1.5"/>
+  <text x="84" y="96" font-size="14" font-weight="bold" fill="#B91C1C">Retrieval Failures</text>
+
+  <!-- Failure items -->
+  <rect x="80" y="106" width="148" height="32" rx="6" fill="#ffffff" stroke="#FCA5A5" stroke-width="1.5"/>
+  <text x="154" y="127" text-anchor="middle" font-size="12" font-weight="bold" fill="#7F1D1D">Semantic Gap</text>
+
+  <rect x="80" y="148" width="148" height="32" rx="6" fill="#ffffff" stroke="#FCA5A5" stroke-width="1.5"/>
+  <text x="154" y="169" text-anchor="middle" font-size="12" font-weight="bold" fill="#7F1D1D">Chunk Boundary</text>
+
+  <rect x="80" y="190" width="148" height="32" rx="6" fill="#ffffff" stroke="#FCA5A5" stroke-width="1.5"/>
+  <text x="154" y="211" text-anchor="middle" font-size="12" font-weight="bold" fill="#7F1D1D">Low Relevance</text>
+
+  <!-- Mitigation annotations -->
+  <text x="242" y="108" font-size="10" font-weight="bold" fill="#059669">Mitigation</text>
+  <text x="242" y="122" font-size="10" fill="#374151">Query rewriting;</text>
+  <text x="242" y="135" font-size="10" fill="#374151">HyDE expansion</text>
+
+  <text x="242" y="152" font-size="10" fill="#374151">Overlap-aware</text>
+  <text x="242" y="165" font-size="10" fill="#374151">chunking strategy</text>
+
+  <text x="242" y="194" font-size="10" fill="#374151">Reranker model;</text>
+  <text x="242" y="207" font-size="10" fill="#374151">relevance threshold</text>
+
+  <text x="228" y="246" font-size="10" fill="#6B7280" font-style="italic">Eval signal: retrieval recall@k</text>
+  <text x="228" y="260" font-size="10" fill="#6B7280" font-style="italic">Tracer tag: retrieval_miss</text>
+  <text x="228" y="274" font-size="10" fill="#6B7280" font-style="italic">Budget impact: low</text>
+
+  <!-- ══ Q2: Reasoning Failures (top-right) ══ -->
+  <rect x="408" y="74" width="328" height="222" rx="12" fill="#FFF7ED" stroke="#FCD34D" stroke-width="1.5"/>
+  <text x="428" y="96" font-size="14" font-weight="bold" fill="#92400E">Reasoning Failures</text>
+
+  <rect x="424" y="106" width="164" height="32" rx="6" fill="#ffffff" stroke="#FCD34D" stroke-width="1.5"/>
+  <text x="506" y="127" text-anchor="middle" font-size="12" font-weight="bold" fill="#78350F">Hallucination</text>
+
+  <rect x="424" y="148" width="164" height="32" rx="6" fill="#ffffff" stroke="#FCD34D" stroke-width="1.5"/>
+  <text x="506" y="169" text-anchor="middle" font-size="12" font-weight="bold" fill="#78350F">Citation Fabrication</text>
+
+  <rect x="424" y="190" width="164" height="32" rx="6" fill="#ffffff" stroke="#FCD34D" stroke-width="1.5"/>
+  <text x="506" y="211" text-anchor="middle" font-size="12" font-weight="bold" fill="#78350F">Over-Confidence</text>
+
+  <!-- Mitigation annotations -->
+  <text x="600" y="108" font-size="10" font-weight="bold" fill="#059669">Mitigation</text>
+  <text x="600" y="122" font-size="10" fill="#374151">Faithfulness eval;</text>
+  <text x="600" y="135" font-size="10" fill="#374151">NLI grounding check</text>
+
+  <text x="600" y="152" font-size="10" fill="#374151">Citation grounding;</text>
+  <text x="600" y="165" font-size="10" fill="#374151">URL verification step</text>
+
+  <text x="600" y="194" font-size="10" fill="#374151">Calibration probes;</text>
+  <text x="600" y="207" font-size="10" fill="#374151">hedge-word detector</text>
+
+  <text x="428" y="246" font-size="10" fill="#6B7280" font-style="italic">Eval signal: faithfulness score</text>
+  <text x="428" y="260" font-size="10" fill="#6B7280" font-style="italic">Tracer tag: hallucination_risk</text>
+  <text x="428" y="274" font-size="10" fill="#6B7280" font-style="italic">Budget impact: medium</text>
+
+  <!-- ══ Q3: Tool Failures (bottom-left) ══ -->
+  <rect x="64" y="312" width="328" height="222" rx="12" fill="#F5F3FF" stroke="#C4B5FD" stroke-width="1.5"/>
+  <text x="84" y="334" font-size="14" font-weight="bold" fill="#5B21B6">Tool Failures</text>
+
+  <rect x="80" y="344" width="160" height="32" rx="6" fill="#ffffff" stroke="#C4B5FD" stroke-width="1.5"/>
+  <text x="160" y="365" text-anchor="middle" font-size="12" font-weight="bold" fill="#4C1D95">Argument Hallucination</text>
+
+  <rect x="80" y="386" width="160" height="32" rx="6" fill="#ffffff" stroke="#C4B5FD" stroke-width="1.5"/>
+  <text x="160" y="407" text-anchor="middle" font-size="12" font-weight="bold" fill="#4C1D95">Unnecessary Calls</text>
+
+  <rect x="80" y="428" width="160" height="32" rx="6" fill="#ffffff" stroke="#C4B5FD" stroke-width="1.5"/>
+  <text x="160" y="449" text-anchor="middle" font-size="12" font-weight="bold" fill="#4C1D95">Error Cascade</text>
+
+  <!-- Mitigation annotations -->
+  <text x="254" y="346" font-size="10" font-weight="bold" fill="#059669">Mitigation</text>
+  <text x="254" y="360" font-size="10" fill="#374151">Schema validation;</text>
+  <text x="254" y="373" font-size="10" fill="#374151">arg grounding check</text>
+
+  <text x="254" y="390" font-size="10" fill="#374151">Budget gate;</text>
+  <text x="254" y="403" font-size="10" fill="#374151">tool-use justification</text>
+
+  <text x="254" y="432" font-size="10" fill="#374151">Retry with backoff;</text>
+  <text x="254" y="445" font-size="10" fill="#374151">circuit breaker pattern</text>
+
+  <text x="80" y="484" font-size="10" fill="#6B7280" font-style="italic">Eval signal: tool success rate</text>
+  <text x="80" y="498" font-size="10" fill="#6B7280" font-style="italic">Tracer tag: tool_error</text>
+  <text x="80" y="512" font-size="10" fill="#6B7280" font-style="italic">Budget impact: variable</text>
+
+  <!-- ══ Q4: System Failures (bottom-right) ══ -->
+  <rect x="408" y="312" width="328" height="222" rx="12" fill="#F0F9FF" stroke="#7DD3FC" stroke-width="1.5"/>
+  <text x="428" y="334" font-size="14" font-weight="bold" fill="#0369A1">System Failures</text>
+
+  <rect x="424" y="344" width="162" height="32" rx="6" fill="#ffffff" stroke="#7DD3FC" stroke-width="1.5"/>
+  <text x="505" y="365" text-anchor="middle" font-size="12" font-weight="bold" fill="#075985">Budget Exhaustion</text>
+
+  <rect x="424" y="386" width="162" height="32" rx="6" fill="#ffffff" stroke="#7DD3FC" stroke-width="1.5"/>
+  <text x="505" y="407" text-anchor="middle" font-size="12" font-weight="bold" fill="#075985">Context Overflow</text>
+
+  <rect x="424" y="428" width="162" height="32" rx="6" fill="#ffffff" stroke="#7DD3FC" stroke-width="1.5"/>
+  <text x="505" y="449" text-anchor="middle" font-size="12" font-weight="bold" fill="#075985">API Errors</text>
+
+  <!-- Mitigation annotations -->
+  <text x="598" y="346" font-size="10" font-weight="bold" fill="#059669">Mitigation</text>
+  <text x="598" y="360" font-size="10" fill="#374151">Token budget;</text>
+  <text x="598" y="373" font-size="10" fill="#374151">hard stop + escalate</text>
+
+  <text x="598" y="390" font-size="10" fill="#374151">Summarise history;</text>
+  <text x="598" y="403" font-size="10" fill="#374151">sliding window trim</text>
+
+  <text x="598" y="432" font-size="10" fill="#374151">Retry with jitter;</text>
+  <text x="598" y="445" font-size="10" fill="#374151">fallback model</text>
+
+  <text x="428" y="484" font-size="10" fill="#6B7280" font-style="italic">Eval signal: run completion rate</text>
+  <text x="428" y="498" font-size="10" fill="#6B7280" font-style="italic">Tracer tag: system_abort</text>
+  <text x="428" y="512" font-size="10" fill="#6B7280" font-style="italic">Budget impact: high</text>
+
+  <!-- Bottom note -->
+  <text x="400" y="552" text-anchor="middle" font-size="11" fill="#9CA3AF">Each quadrant maps to a distinct debugging and observability strategy.</text>
+</svg>

--- a/public/assets/diagrams/framework-decision-tree.svg
+++ b/public/assets/diagrams/framework-decision-tree.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="400" viewBox="0 0 700 400" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="700" height="400" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="350" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Framework Decision Tree</text>
+  <line x1="40" y1="42" x2="660" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- ROOT: What are you building? -->
+  <rect x="220" y="60" width="260" height="56" rx="10" fill="#F3F4F6" stroke="#6B7280" stroke-width="2"/>
+  <text x="350" y="84" text-anchor="middle" font-size="14" font-weight="bold" fill="#111827">What are you building?</text>
+  <text x="350" y="102" text-anchor="middle" font-size="11" fill="#6B7280">Start here before choosing a framework</text>
+
+  <!-- Arrow left: Learning/exploring -->
+  <line x1="280" y1="116" x2="155" y2="168" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="185" y="147" text-anchor="middle" font-size="11" fill="#374151">Learning /</text>
+  <text x="185" y="160" text-anchor="middle" font-size="11" fill="#374151">exploring</text>
+
+  <!-- Arrow right: Production system -->
+  <line x1="420" y1="116" x2="545" y2="168" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="510" y="147" text-anchor="middle" font-size="11" fill="#374151">Production</text>
+  <text x="510" y="160" text-anchor="middle" font-size="11" fill="#374151">system</text>
+
+  <!-- LEFT LEAF: Build raw first -->
+  <rect x="50" y="170" width="210" height="60" rx="10" fill="#F0FDF4" stroke="#22c55e" stroke-width="2.5"/>
+  <text x="155" y="195" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">Build raw first</text>
+  <text x="155" y="213" text-anchor="middle" font-size="11" fill="#374151">Pure Python, direct API calls</text>
+  <text x="155" y="228" text-anchor="middle" font-size="10" fill="#6B7280">Learn the mechanics, not the abstraction</text>
+
+  <!-- RIGHT BRANCH: Production sub-question -->
+  <rect x="420" y="170" width="250" height="56" rx="10" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="2"/>
+  <text x="545" y="194" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">Need built-in tracing</text>
+  <text x="545" y="210" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">and eval pipeline?</text>
+
+  <!-- Arrow left from production branch: Not critical -->
+  <line x1="460" y1="226" x2="345" y2="286" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="368" y="257" text-anchor="middle" font-size="11" fill="#374151">Not critical</text>
+  <text x="368" y="270" text-anchor="middle" font-size="11" fill="#374151">right now</text>
+
+  <!-- Arrow right from production branch: Yes -->
+  <line x1="630" y1="226" x2="630" y2="286" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="650" y="262" font-size="11" fill="#374151">Yes,</text>
+  <text x="648" y="275" font-size="11" fill="#374151">critical</text>
+
+  <!-- Left leaf: LangChain -->
+  <rect x="230" y="288" width="230" height="60" rx="10" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="2.5"/>
+  <text x="345" y="312" text-anchor="middle" font-size="14" font-weight="bold" fill="#5B21B6">LangChain</text>
+  <text x="345" y="330" text-anchor="middle" font-size="11" fill="#374151">Rich ecosystem, many integrations</text>
+  <text x="345" y="345" text-anchor="middle" font-size="10" fill="#F59E0B">Watch out: version churn, opaque chains</text>
+
+  <!-- Right leaf: Google ADK -->
+  <rect x="495" y="288" width="175" height="60" rx="10" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2.5"/>
+  <text x="582" y="312" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Google ADK</text>
+  <text x="582" y="330" text-anchor="middle" font-size="11" fill="#374151">Tracing, evals, structured</text>
+  <text x="582" y="345" text-anchor="middle" font-size="10" fill="#F59E0B">Google Cloud ecosystem</text>
+
+  <!-- Dotted line from raw to right side (upgrade path) -->
+  <path d="M260,200 Q340,200 420,185" fill="none" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="340" y="194" text-anchor="middle" font-size="9" fill="#22c55e">start here, upgrade later</text>
+
+  <!-- Caption -->
+  <text x="350" y="374" text-anchor="middle" font-size="11" fill="#374151">No framework is a permanent commitment. Start raw, add structure when you feel the pain of not having it.</text>
+  <text x="350" y="390" text-anchor="middle" font-size="11" fill="#9CA3AF">The right time to add a framework is when you keep re-solving the same problem.</text>
+</svg>

--- a/public/assets/diagrams/framework-layers.svg
+++ b/public/assets/diagrams/framework-layers.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="400" viewBox="0 0 720 400" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="arr-up" markerWidth="7" markerHeight="10" refX="3.5" refY="1" orient="auto">
+      <polygon points="0 10, 3.5 0, 7 10" fill="#6B7280"/>
+    </marker>
+    <marker id="arr-down" markerWidth="7" markerHeight="10" refX="3.5" refY="9" orient="auto">
+      <polygon points="0 0, 3.5 10, 7 0" fill="#6B7280"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="720" height="400" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="360" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Framework Abstraction Layers</text>
+  <line x1="40" y1="42" x2="680" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Left axis labels -->
+  <text x="28" y="116" text-anchor="middle" font-size="10" font-weight="bold" fill="#8B5CF6" transform="rotate(-90,28,116)">More abstraction</text>
+  <line x1="18" y1="80" x2="18" y2="160" stroke="#8B5CF6" stroke-width="2" marker-end="url(#arr-up)"/>
+
+  <text x="28" y="300" text-anchor="middle" font-size="10" font-weight="bold" fill="#374151" transform="rotate(-90,28,300)">More control</text>
+  <line x1="18" y1="340" x2="18" y2="250" stroke="#374151" stroke-width="2" marker-end="url(#arr-down)"/>
+
+  <!-- LAYER 3 (top): LangChain -->
+  <rect x="50" y="68" width="638" height="84" rx="10" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="2"/>
+  <text x="180" y="96" text-anchor="middle" font-size="16" font-weight="bold" fill="#5B21B6">LangChain</text>
+  <text x="180" y="116" text-anchor="middle" font-size="11" fill="#374151">Chains, agents, memory, retrievers</text>
+  <text x="180" y="133" text-anchor="middle" font-size="11" fill="#374151">Large ecosystem, many integrations</text>
+
+  <!-- Tags for LangChain -->
+  <rect x="420" y="80" width="92" height="22" rx="4" fill="#DCFCE7"/>
+  <text x="466" y="96" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Ecosystem</text>
+  <rect x="520" y="80" width="100" height="22" rx="4" fill="#DCFCE7"/>
+  <text x="570" y="96" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Integrations</text>
+  <rect x="420" y="110" width="108" height="22" rx="4" fill="#FEF3C7"/>
+  <text x="474" y="126" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Chains opaque</text>
+  <rect x="536" y="110" width="104" height="22" rx="4" fill="#FEF3C7"/>
+  <text x="588" y="126" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Version churn</text>
+
+  <!-- LAYER 2 (middle): Google ADK -->
+  <rect x="50" y="176" width="638" height="84" rx="10" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
+  <text x="180" y="204" text-anchor="middle" font-size="16" font-weight="bold" fill="#1D4ED8">Google ADK</text>
+  <text x="180" y="224" text-anchor="middle" font-size="11" fill="#374151">Agent development kit, structured evals</text>
+  <text x="180" y="241" text-anchor="middle" font-size="11" fill="#374151">Built-in tracing, Google Cloud native</text>
+
+  <!-- Tags for ADK -->
+  <rect x="420" y="188" width="72" height="22" rx="4" fill="#DCFCE7"/>
+  <text x="456" y="204" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Tracing</text>
+  <rect x="500" y="188" width="54" height="22" rx="4" fill="#DCFCE7"/>
+  <text x="527" y="204" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Eval</text>
+  <rect x="420" y="218" width="96" height="22" rx="4" fill="#FEF3C7"/>
+  <text x="468" y="234" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Loop hidden</text>
+  <rect x="524" y="218" width="140" height="22" rx="4" fill="#FEF3C7"/>
+  <text x="594" y="234" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Context managed</text>
+
+  <!-- LAYER 1 (bottom): Raw Python -->
+  <rect x="50" y="284" width="638" height="84" rx="10" fill="#F3F4F6" stroke="#6B7280" stroke-width="2"/>
+  <text x="180" y="312" text-anchor="middle" font-size="16" font-weight="bold" fill="#374151">Raw Python</text>
+  <text x="180" y="332" text-anchor="middle" font-size="11" fill="#374151">Direct API calls, manual loop, explicit state</text>
+  <text x="180" y="349" text-anchor="middle" font-size="11" fill="#374151">You write everything, you control everything</text>
+
+  <!-- Tags for Raw Python -->
+  <rect x="420" y="296" width="88" height="22" rx="4" fill="#DCFCE7"/>
+  <text x="464" y="312" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Full control</text>
+  <rect x="516" y="296" width="120" height="22" rx="4" fill="#DCFCE7"/>
+  <text x="576" y="312" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Full visibility</text>
+  <rect x="420" y="326" width="136" height="22" rx="4" fill="#FEF3C7"/>
+  <text x="488" y="342" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Full responsibility</text>
+
+  <!-- Caption -->
+  <text x="360" y="384" text-anchor="middle" font-size="11" fill="#374151">Higher abstraction = less code, less insight. Choose based on what you need to debug and own.</text>
+  <text x="360" y="398" text-anchor="middle" font-size="11" fill="#9CA3AF">Recommendation: build raw first, then adopt a framework when you know what pain it solves.</text>
+</svg>

--- a/public/assets/diagrams/full-spectrum-decision.svg
+++ b/public/assets/diagrams/full-spectrum-decision.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" width="800" height="500" style="background:#fff;font-family:system-ui,-apple-system,sans-serif;">
+
+  <!-- Background -->
+  <rect width="800" height="500" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="28" text-anchor="middle" font-size="16" font-weight="600" fill="#374151">Agent Architecture Decision Framework</text>
+
+  <!-- ===================== START NODE ===================== -->
+  <!-- Start: "New AI task" oval at top center -->
+  <ellipse cx="400" cy="65" rx="75" ry="24" fill="#374151"/>
+  <text x="400" y="70" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">New AI task</text>
+
+  <!-- Arrow down from start -->
+  <line x1="400" y1="89" x2="400" y2="117" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- ===================== DECISION 1 ===================== -->
+  <!-- Diamond at (400, 143) -->
+  <polygon points="400,117 470,143 400,169 330,143" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="400" y="140" text-anchor="middle" font-size="11" fill="#374151">Can you draw the</text>
+  <text x="400" y="154" text-anchor="middle" font-size="11" fill="#374151">flowchart?</text>
+
+  <!-- Yes arrow: right to Workflow stop -->
+  <line x1="470" y1="143" x2="555" y2="143" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="513" y="136" text-anchor="middle" font-size="11" fill="#10B981" font-weight="600">Yes</text>
+  <!-- Workflow box -->
+  <rect x="555" y="121" width="110" height="44" rx="8" fill="#D1FAE5" stroke="#10B981" stroke-width="1.5"/>
+  <text x="610" y="140" text-anchor="middle" font-size="12" font-weight="600" fill="#065F46">Use a</text>
+  <text x="610" y="155" text-anchor="middle" font-size="12" font-weight="600" fill="#065F46">Workflow</text>
+  <!-- STOP indicator -->
+  <text x="680" y="143" text-anchor="start" font-size="18" fill="#10B981">&#x2717;</text>
+
+  <!-- No arrow: down -->
+  <line x1="400" y1="169" x2="400" y2="197" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="387" y="185" text-anchor="end" font-size="11" fill="#EF4444" font-weight="600">No</text>
+
+  <!-- ===================== DECISION 2 ===================== -->
+  <polygon points="400,197 470,223 400,249 330,223" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="400" y="219" text-anchor="middle" font-size="11" fill="#374151">Multi-step reasoning</text>
+  <text x="400" y="233" text-anchor="middle" font-size="11" fill="#374151">required?</text>
+
+  <!-- No arrow: left to Workflow stop -->
+  <line x1="330" y1="223" x2="200" y2="223" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="265" y="216" text-anchor="middle" font-size="11" fill="#10B981" font-weight="600">No</text>
+  <!-- Workflow box (left) -->
+  <rect x="90" y="201" width="110" height="44" rx="8" fill="#D1FAE5" stroke="#10B981" stroke-width="1.5"/>
+  <text x="145" y="220" text-anchor="middle" font-size="12" font-weight="600" fill="#065F46">Use a</text>
+  <text x="145" y="235" text-anchor="middle" font-size="12" font-weight="600" fill="#065F46">Workflow</text>
+  <text x="89" y="223" text-anchor="end" font-size="18" fill="#10B981">&#x2717;</text>
+
+  <!-- Yes arrow: down -->
+  <line x1="400" y1="249" x2="400" y2="277" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="387" y="265" text-anchor="end" font-size="11" fill="#EF4444" font-weight="600">Yes</text>
+
+  <!-- ===================== DECISION 3 ===================== -->
+  <polygon points="400,277 470,303 400,329 330,303" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="400" y="299" text-anchor="middle" font-size="11" fill="#374151">Single agent</text>
+  <text x="400" y="313" text-anchor="middle" font-size="11" fill="#374151">sufficient?</text>
+
+  <!-- Yes arrow: right to Single Agent stop -->
+  <line x1="470" y1="303" x2="555" y2="303" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="513" y="296" text-anchor="middle" font-size="11" fill="#10B981" font-weight="600">Yes</text>
+  <!-- Single Agent box -->
+  <rect x="555" y="281" width="110" height="44" rx="8" fill="#DBEAFE" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="610" y="300" text-anchor="middle" font-size="12" font-weight="600" fill="#1E40AF">Use Single</text>
+  <text x="610" y="315" text-anchor="middle" font-size="12" font-weight="600" fill="#1E40AF">Agent</text>
+  <text x="680" y="303" text-anchor="start" font-size="18" fill="#3B82F6">&#x2717;</text>
+
+  <!-- No arrow: down -->
+  <line x1="400" y1="329" x2="400" y2="357" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="387" y="345" text-anchor="end" font-size="11" fill="#EF4444" font-weight="600">No</text>
+
+  <!-- ===================== DECISION 4 ===================== -->
+  <polygon points="400,357 470,383 400,409 330,383" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="400" y="378" text-anchor="middle" font-size="11" fill="#374151">Role specialization or</text>
+  <text x="400" y="392" text-anchor="middle" font-size="11" fill="#374151">verification needed?</text>
+
+  <!-- No arrow: left to Single Agent -->
+  <line x1="330" y1="383" x2="200" y2="383" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="265" y="376" text-anchor="middle" font-size="11" fill="#10B981" font-weight="600">No</text>
+  <!-- Single Agent box (left) -->
+  <rect x="90" y="361" width="110" height="44" rx="8" fill="#DBEAFE" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="145" y="380" text-anchor="middle" font-size="12" font-weight="600" fill="#1E40AF">Use Single</text>
+  <text x="145" y="395" text-anchor="middle" font-size="12" font-weight="600" fill="#1E40AF">Agent</text>
+  <text x="89" y="383" text-anchor="end" font-size="18" fill="#3B82F6">&#x2717;</text>
+
+  <!-- Yes arrow: down -->
+  <line x1="400" y1="409" x2="400" y2="437" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="387" y="425" text-anchor="end" font-size="11" fill="#EF4444" font-weight="600">Yes</text>
+
+  <!-- ===================== MULTI-AGENT OUTCOME ===================== -->
+  <rect x="330" y="437" width="140" height="44" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="400" y="456" text-anchor="middle" font-size="12" font-weight="600" fill="#92400E">Use Multi-Agent</text>
+  <text x="400" y="471" text-anchor="middle" font-size="11" fill="#92400E">System</text>
+
+  <!-- ===================== DECISION 5 (HITL overlay) ===================== -->
+  <!-- Arrow right from multi-agent to HITL check -->
+  <line x1="470" y1="459" x2="530" y2="459" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <!-- HITL check box - orange annotation -->
+  <rect x="530" y="437" width="170" height="44" rx="8" fill="#FFF7ED" stroke="#F97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="615" y="454" text-anchor="middle" font-size="11" font-weight="600" fill="#C2410C">High-risk / oversight</text>
+  <text x="615" y="468" text-anchor="middle" font-size="11" fill="#C2410C">needed? Add HITL gates</text>
+
+  <!-- Arrow markers definition -->
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#6B7280"/>
+    </marker>
+  </defs>
+
+</svg>

--- a/public/assets/diagrams/function-calling-cycle.svg
+++ b/public/assets/diagrams/function-calling-cycle.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="500" viewBox="0 0 700 500" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="700" height="500" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="350" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Function Calling: The Full Cycle</text>
+  <line x1="40" y1="42" x2="660" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Node 1: Your Code (top-left) -->
+  <rect x="40" y="70" width="180" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
+  <text x="130" y="94" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">1. Your Code</text>
+  <text x="130" y="112" text-anchor="middle" font-size="10" fill="#6B7280">send schema + prompt</text>
+  <text x="130" y="128" text-anchor="middle" font-size="10" fill="#3B82F6">{"tools": [...], "messages": [...]}</text>
+
+  <!-- Arrow 1 → 2 -->
+  <line x1="221" y1="106" x2="278" y2="106" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="249" y="98" text-anchor="middle" font-size="9" fill="#374151">HTTP POST</text>
+
+  <!-- Node 2: API (top-right) -->
+  <rect x="480" y="70" width="180" height="72" rx="8" fill="#F0FDF4" stroke="#22c55e" stroke-width="2"/>
+  <text x="570" y="94" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">2. LLM API</text>
+  <text x="570" y="112" text-anchor="middle" font-size="10" fill="#6B7280">model sees schema</text>
+  <text x="570" y="128" text-anchor="middle" font-size="10" fill="#6B7280">decides to call a tool</text>
+
+  <!-- Arrow 2 → 3 (right side going down) -->
+  <line x1="570" y1="143" x2="570" y2="198" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="600" y="175" font-size="9" fill="#374151">tool_call JSON</text>
+
+  <!-- Node 3: Model Response (bottom-right) -->
+  <rect x="480" y="200" width="180" height="80" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="2"/>
+  <text x="570" y="222" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">3. Model Response</text>
+  <text x="570" y="240" text-anchor="middle" font-size="10" fill="#6B7280">{"tool_calls": [{</text>
+  <text x="570" y="255" text-anchor="middle" font-size="10" fill="#6B7280">  "name": "get_weather",</text>
+  <text x="570" y="270" text-anchor="middle" font-size="10" fill="#6B7280">  "args": {"city": "NYC"}}]}</text>
+
+  <!-- Arrow 3 → 4 (bottom going left) -->
+  <line x1="479" y1="240" x2="221" y2="240" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="350" y="232" text-anchor="middle" font-size="9" fill="#374151">your code receives this</text>
+
+  <!-- Node 4: Execute Function (bottom-left) -->
+  <rect x="40" y="200" width="180" height="80" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="2"/>
+  <text x="130" y="222" text-anchor="middle" font-size="13" font-weight="bold" fill="#5B21B6">4. Execute Function</text>
+  <text x="130" y="240" text-anchor="middle" font-size="10" fill="#6B7280">your code runs:</text>
+  <text x="130" y="255" text-anchor="middle" font-size="10" fill="#5B21B6">get_weather("NYC")</text>
+  <text x="130" y="270" text-anchor="middle" font-size="10" fill="#6B7280">→ "72°F, sunny"</text>
+
+  <!-- Arrow 4 → 5 (left side going down) -->
+  <line x1="130" y1="281" x2="130" y2="338" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="90" y="314" font-size="9" fill="#374151">function</text>
+  <text x="90" y="326" font-size="9" fill="#374151">result</text>
+
+  <!-- Node 5: Back to API (bottom center) -->
+  <rect x="40" y="340" width="180" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
+  <text x="130" y="364" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">5. Send Result to API</text>
+  <text x="130" y="381" text-anchor="middle" font-size="10" fill="#6B7280">{"role": "tool",</text>
+  <text x="130" y="396" text-anchor="middle" font-size="10" fill="#6B7280"> "content": "72°F, sunny"}</text>
+
+  <!-- Arrow 5 → 1 (loop back, curved) -->
+  <path d="M220,376 Q350,430 350,130 Q350,106 281,106" fill="none" stroke="#6B7280" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arr)"/>
+  <text x="410" y="420" text-anchor="middle" font-size="10" fill="#9CA3AF">model now writes</text>
+  <text x="410" y="436" text-anchor="middle" font-size="10" fill="#9CA3AF">final answer or</text>
+  <text x="410" y="452" text-anchor="middle" font-size="10" fill="#9CA3AF">calls another tool</text>
+
+  <!-- Loop label in center -->
+  <rect x="268" y="290" width="164" height="32" rx="6" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="350" y="307" text-anchor="middle" font-size="11" font-weight="bold" fill="#374151">Repeats until</text>
+  <text x="350" y="320" text-anchor="middle" font-size="11" fill="#6B7280">final answer returned</text>
+
+  <!-- Caption -->
+  <text x="350" y="480" text-anchor="middle" font-size="11" fill="#9CA3AF">The model never runs code. It only describes the call. Your code executes it.</text>
+</svg>

--- a/public/assets/diagrams/hallucination-mental-model.svg
+++ b/public/assets/diagrams/hallucination-mental-model.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="680" height="360" viewBox="0 0 680 360" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="680" height="360" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="340" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Hallucination: The Correct Mental Model</text>
+  <line x1="40" y1="42" x2="640" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- LEFT PANEL: What you think -->
+  <rect x="40" y="58" width="280" height="264" rx="10" fill="#F0FDF4" stroke="#22c55e" stroke-width="2.5"/>
+  <text x="180" y="84" text-anchor="middle" font-size="15" font-weight="bold" fill="#15803D">What You Think</text>
+  <line x1="60" y1="93" x2="300" y2="93" stroke="#86EFAC" stroke-width="1"/>
+
+  <!-- Magnifying glass icon (simplified) -->
+  <circle cx="180" cy="158" r="46" fill="#DCFCE7" stroke="#22c55e" stroke-width="2"/>
+  <circle cx="170" cy="148" r="26" fill="none" stroke="#15803D" stroke-width="3"/>
+  <line x1="189" y1="166" x2="205" y2="182" stroke="#15803D" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Document lines inside magnifier (fact-checking metaphor) -->
+  <line x1="160" y1="138" x2="182" y2="138" stroke="#15803D" stroke-width="2"/>
+  <line x1="158" y1="147" x2="183" y2="147" stroke="#15803D" stroke-width="2"/>
+  <line x1="160" y1="156" x2="178" y2="156" stroke="#15803D" stroke-width="2"/>
+  <!-- Checkmark overlay -->
+  <text x="195" y="128" font-size="18" fill="#22c55e" font-weight="bold">&#10003;</text>
+
+  <text x="180" y="225" text-anchor="middle" font-size="13" font-weight="bold" fill="#15803D">Fact-Checking Mode</text>
+  <text x="180" y="245" text-anchor="middle" font-size="11" fill="#374151">"The model looks up the</text>
+  <text x="180" y="262" text-anchor="middle" font-size="11" fill="#374151">answer in its knowledge</text>
+  <text x="180" y="279" text-anchor="middle" font-size="11" fill="#374151">and verifies it's correct."</text>
+  <rect x="68" y="293" width="224" height="20" rx="4" fill="#DCFCE7"/>
+  <text x="180" y="307" text-anchor="middle" font-size="11" fill="#15803D">Feels reassuring. Is wrong.</text>
+
+  <!-- VS divider -->
+  <text x="340" y="200" text-anchor="middle" font-size="18" font-weight="bold" fill="#9CA3AF">vs</text>
+
+  <!-- RIGHT PANEL: What actually happens -->
+  <rect x="360" y="58" width="280" height="264" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2.5"/>
+  <text x="500" y="84" text-anchor="middle" font-size="15" font-weight="bold" fill="#B91C1C">What Actually Happens</text>
+  <line x1="380" y1="93" x2="620" y2="93" stroke="#FCA5A5" stroke-width="1"/>
+
+  <!-- Dice icon (probability/randomness metaphor) -->
+  <rect cx="500" cy="158" x="462" y="118" width="72" height="72" rx="10" fill="#FEE2E2" stroke="#EF4444" stroke-width="2.5"/>
+  <!-- Dice dots -->
+  <circle cx="481" cy="137" r="5" fill="#EF4444"/>
+  <circle cx="503" cy="137" r="5" fill="#EF4444"/>
+  <circle cx="525" cy="137" r="5" fill="#EF4444"/>
+  <circle cx="481" cy="159" r="5" fill="#EF4444"/>
+  <circle cx="525" cy="159" r="5" fill="#EF4444"/>
+  <circle cx="481" cy="181" r="5" fill="#EF4444"/>
+  <circle cx="503" cy="181" r="5" fill="#EF4444"/>
+  <circle cx="525" cy="181" r="5" fill="#EF4444"/>
+  <!-- Probability bars behind dice -->
+  <rect x="432" y="148" width="18" height="22" rx="2" fill="#FECACA"/>
+  <rect x="432" y="138" width="18" height="10" rx="2" fill="#EF4444" opacity="0.5"/>
+  <text x="421" y="196" font-size="9" fill="#EF4444">P(word)</text>
+
+  <text x="500" y="225" text-anchor="middle" font-size="13" font-weight="bold" fill="#B91C1C">Probability Machine</text>
+  <text x="500" y="245" text-anchor="middle" font-size="11" fill="#374151">"The model predicts the</text>
+  <text x="500" y="262" text-anchor="middle" font-size="11" fill="#374151">most likely next token</text>
+  <text x="500" y="279" text-anchor="middle" font-size="11" fill="#374151">given what came before."</text>
+  <rect x="388" y="293" width="224" height="20" rx="4" fill="#FEE2E2"/>
+  <text x="500" y="307" text-anchor="middle" font-size="11" fill="#B91C1C">Plausible ≠ true. By design.</text>
+
+  <!-- Caption -->
+  <text x="340" y="345" text-anchor="middle" font-size="11" fill="#374151">Hallucination is not a bug. It is the expected output of a token predictor asked a factual question.</text>
+  <text x="340" y="360" text-anchor="middle" font-size="11" fill="#9CA3AF">Design your system accordingly: verify, don't assume.</text>
+</svg>

--- a/public/assets/diagrams/hitl-approval-flow.svg
+++ b/public/assets/diagrams/hitl-approval-flow.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="580" viewBox="0 0 800 580" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+    <marker id="arrowhead-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+    </marker>
+    <marker id="arrowhead-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#EF4444"/>
+    </marker>
+    <marker id="arrowhead-yellow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#F59E0B"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="580" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="36" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Human-in-the-Loop Approval Flow</text>
+  <line x1="100" y1="48" x2="700" y2="48" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Step 1: Agent Proposes Action -->
+  <rect x="290" y="64" width="220" height="56" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="400" y="88" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Agent Proposes Action</text>
+  <text x="400" y="107" text-anchor="middle" font-size="11" fill="#6B7280">structured action payload</text>
+
+  <!-- Arrow to Escalation Policy -->
+  <line x1="400" y1="120" x2="400" y2="156" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Step 2: Escalation Policy (diamond) -->
+  <!-- Diamond: center (400, 185), half-width=80, half-height=40 -->
+  <polygon points="400,148 490,190 400,232 310,190" fill="#FFF7ED" stroke="#F59E0B" stroke-width="2"/>
+  <text x="400" y="187" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">Risk Check</text>
+  <text x="400" y="203" text-anchor="middle" font-size="10" fill="#6B7280">escalation policy</text>
+
+  <!-- Label: high confidence, low risk (left path) -->
+  <text x="272" y="186" text-anchor="end" font-size="11" fill="#10B981">high conf.</text>
+  <text x="272" y="200" text-anchor="end" font-size="11" fill="#10B981">low risk</text>
+
+  <!-- Label: low confidence, high risk (right path) -->
+  <text x="528" y="186" text-anchor="start" font-size="11" fill="#EF4444">low conf.</text>
+  <text x="528" y="200" text-anchor="start" font-size="11" fill="#EF4444">high risk</text>
+
+  <!-- Left path: Auto-approve -->
+  <line x1="310" y1="190" x2="190" y2="190" stroke="#10B981" stroke-width="1.5" marker-end="url(#arrowhead-green)"/>
+
+  <!-- Auto-approve box -->
+  <rect x="60" y="162" width="130" height="56" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="125" y="187" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Auto-Approve</text>
+  <text x="125" y="204" text-anchor="middle" font-size="11" fill="#6B7280">no human needed</text>
+
+  <!-- Arrow: Auto-approve -> Execute -->
+  <line x1="125" y1="218" x2="125" y2="370" stroke="#10B981" stroke-width="1.5" marker-end="url(#arrowhead-green)"/>
+
+  <!-- Right path: Human Review -->
+  <line x1="490" y1="190" x2="610" y2="190" stroke="#EF4444" stroke-width="1.5" marker-end="url(#arrowhead-red)"/>
+
+  <!-- Human Review box -->
+  <rect x="610" y="162" width="130" height="56" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="675" y="187" text-anchor="middle" font-size="13" font-weight="bold" fill="#991B1B">Human Review</text>
+  <text x="675" y="204" text-anchor="middle" font-size="11" fill="#6B7280">analyst notified</text>
+
+  <!-- Arrow: Human Review -> Human Decision -->
+  <line x1="675" y1="218" x2="675" y2="280" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Human Decision box -->
+  <rect x="585" y="280" width="180" height="64" rx="8" fill="#ffffff" stroke="#374151" stroke-width="2"/>
+  <text x="675" y="305" text-anchor="middle" font-size="14" font-weight="bold" fill="#111827">Human Decides</text>
+  <text x="675" y="323" text-anchor="middle" font-size="11" fill="#10B981">Approve</text>
+  <text x="675" y="338" text-anchor="middle" font-size="11" fill="#6B7280">Reject · Modify</text>
+
+  <!-- Arrow: Approve path -> Execute -->
+  <line x1="585" y1="312" x2="480" y2="370" stroke="#10B981" stroke-width="1.5" marker-end="url(#arrowhead-green)"/>
+  <text x="525" y="346" text-anchor="middle" font-size="11" fill="#10B981">approve</text>
+
+  <!-- Arrow: Reject path -> Reject box -->
+  <line x1="675" y1="344" x2="675" y2="400" stroke="#EF4444" stroke-width="1.5" marker-end="url(#arrowhead-red)"/>
+  <text x="700" y="378" text-anchor="start" font-size="11" fill="#EF4444">reject</text>
+
+  <!-- Execute box -->
+  <rect x="330" y="370" width="180" height="52" rx="8" fill="#EFF6FF" stroke="#2563EB" stroke-width="2"/>
+  <text x="420" y="393" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Execute Action</text>
+  <text x="420" y="411" text-anchor="middle" font-size="11" fill="#6B7280">run · call API · write</text>
+
+  <!-- Reject box -->
+  <rect x="600" y="400" width="150" height="52" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="675" y="423" text-anchor="middle" font-size="14" font-weight="bold" fill="#991B1B">Rejected</text>
+  <text x="675" y="441" text-anchor="middle" font-size="11" fill="#6B7280">action cancelled</text>
+
+  <!-- Arrow: Execute -> Audit Log -->
+  <line x1="420" y1="422" x2="420" y2="480" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Arrow: Reject -> Audit Log -->
+  <line x1="600" y1="430" x2="520" y2="490" stroke="#6B7280" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowhead)"/>
+
+  <!-- Audit Log -->
+  <rect x="270" y="480" width="300" height="52" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+  <text x="420" y="503" text-anchor="middle" font-size="14" font-weight="bold" fill="#5B21B6">Audit Log</text>
+  <text x="420" y="521" text-anchor="middle" font-size="11" fill="#6B7280">decision · actor · timestamp · outcome</text>
+
+  <!-- Arrow from Auto-approve to Audit Log -->
+  <line x1="125" y1="422" x2="270" y2="504" stroke="#10B981" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrowhead-green)"/>
+
+  <!-- Audit arrow from Human Decision -->
+  <line x1="585" y1="312" x2="570" y2="480" stroke="#8B5CF6" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrowhead)"/>
+</svg>

--- a/public/assets/diagrams/incident-runbook-architecture.svg
+++ b/public/assets/diagrams/incident-runbook-architecture.svg
@@ -1,0 +1,154 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="580" viewBox="0 0 800 580" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+    <marker id="arrowhead-purple" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#8B5CF6"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="580" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="36" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Incident Runbook Architecture</text>
+  <line x1="100" y1="48" x2="700" y2="48" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- ===== LAYER 1: Signal Ingestion ===== -->
+  <rect x="40" y="64" width="680" height="100" rx="12" fill="#EFF6FF" stroke="#93C5FD" stroke-width="1.5"/>
+  <text x="58" y="84" font-size="12" font-weight="bold" fill="#2563EB" letter-spacing="1">LAYER 1 — SIGNAL INGESTION</text>
+
+  <!-- Metrics -->
+  <rect x="70" y="94" width="140" height="52" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="140" y="117" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">Metrics</text>
+  <text x="140" y="133" text-anchor="middle" font-size="11" fill="#6B7280">Prometheus · Datadog</text>
+
+  <!-- Logs -->
+  <rect x="250" y="94" width="140" height="52" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="320" y="117" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">Logs</text>
+  <text x="320" y="133" text-anchor="middle" font-size="11" fill="#6B7280">Elasticsearch · Loki</text>
+
+  <!-- Traces -->
+  <rect x="430" y="94" width="140" height="52" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="500" y="117" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">Traces</text>
+  <text x="500" y="133" text-anchor="middle" font-size="11" fill="#6B7280">Jaeger · OpenTelemetry</text>
+
+  <!-- Alerts -->
+  <rect x="610" y="94" width="80" height="52" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="650" y="117" text-anchor="middle" font-size="13" font-weight="bold" fill="#991B1B">Alerts</text>
+  <text x="650" y="133" text-anchor="middle" font-size="11" fill="#6B7280">PagerDuty</text>
+
+  <!-- Arrows between ingestion boxes -->
+  <line x1="210" y1="120" x2="248" y2="120" stroke="#D1D5DB" stroke-width="1" marker-end="url(#arrowhead)"/>
+  <line x1="390" y1="120" x2="428" y2="120" stroke="#D1D5DB" stroke-width="1" marker-end="url(#arrowhead)"/>
+  <line x1="570" y1="120" x2="608" y2="120" stroke="#D1D5DB" stroke-width="1" marker-end="url(#arrowhead)"/>
+
+  <!-- Interlayer arrow 1 -> 2 -->
+  <line x1="360" y1="164" x2="360" y2="192" stroke="#2563EB" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowhead-blue)"/>
+
+  <!-- ===== LAYER 2: Runbook Search ===== -->
+  <rect x="40" y="192" width="680" height="100" rx="12" fill="#F0FDF4" stroke="#6EE7B7" stroke-width="1.5"/>
+  <text x="58" y="212" font-size="12" font-weight="bold" fill="#059669" letter-spacing="1">LAYER 2 — RUNBOOK SEARCH</text>
+
+  <!-- Symptom Classifier -->
+  <rect x="70" y="222" width="170" height="52" rx="8" fill="#ffffff" stroke="#10B981" stroke-width="1.5"/>
+  <text x="155" y="245" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Symptom Classifier</text>
+  <text x="155" y="261" text-anchor="middle" font-size="11" fill="#6B7280">NLP · embedding</text>
+
+  <!-- Runbook Index -->
+  <rect x="290" y="222" width="170" height="52" rx="8" fill="#ffffff" stroke="#10B981" stroke-width="1.5"/>
+  <text x="375" y="245" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Runbook Index</text>
+  <text x="375" y="261" text-anchor="middle" font-size="11" fill="#6B7280">vector store · BM25</text>
+
+  <!-- Ranked Candidates -->
+  <rect x="510" y="222" width="170" height="52" rx="8" fill="#ffffff" stroke="#10B981" stroke-width="1.5"/>
+  <text x="595" y="245" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Ranked Candidates</text>
+  <text x="595" y="261" text-anchor="middle" font-size="11" fill="#6B7280">top-k · reranker</text>
+
+  <!-- Arrows within layer 2 -->
+  <line x1="240" y1="248" x2="288" y2="248" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="460" y1="248" x2="508" y2="248" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Interlayer arrow 2 -> 3 -->
+  <line x1="360" y1="292" x2="360" y2="320" stroke="#2563EB" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowhead-blue)"/>
+
+  <!-- ===== LAYER 3: Remediation Engine ===== -->
+  <rect x="40" y="320" width="680" height="100" rx="12" fill="#FFF7ED" stroke="#FCD34D" stroke-width="1.5"/>
+  <text x="58" y="340" font-size="12" font-weight="bold" fill="#B45309" letter-spacing="1">LAYER 3 — REMEDIATION ENGINE</text>
+
+  <!-- Step Planner -->
+  <rect x="70" y="350" width="160" height="52" rx="8" fill="#ffffff" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="150" y="373" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">Step Planner</text>
+  <text x="150" y="389" text-anchor="middle" font-size="11" fill="#6B7280">LLM plan generation</text>
+
+  <!-- Tool Executor -->
+  <rect x="290" y="350" width="160" height="52" rx="8" fill="#ffffff" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="370" y="373" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">Tool Executor</text>
+  <text x="370" y="389" text-anchor="middle" font-size="11" fill="#6B7280">kubectl · bash · API</text>
+
+  <!-- Safety Guard -->
+  <rect x="510" y="350" width="160" height="52" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="590" y="373" text-anchor="middle" font-size="13" font-weight="bold" fill="#991B1B">Safety Guard</text>
+  <text x="590" y="389" text-anchor="middle" font-size="11" fill="#6B7280">allowlist · dry-run</text>
+
+  <!-- Arrows within layer 3 -->
+  <line x1="230" y1="376" x2="288" y2="376" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="450" y1="376" x2="508" y2="376" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Interlayer arrow 3 -> 4 -->
+  <line x1="360" y1="420" x2="360" y2="448" stroke="#2563EB" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowhead-blue)"/>
+
+  <!-- ===== LAYER 4: Approval Loop ===== -->
+  <rect x="40" y="448" width="680" height="100" rx="12" fill="#F5F3FF" stroke="#C4B5FD" stroke-width="1.5"/>
+  <text x="58" y="468" font-size="12" font-weight="bold" fill="#7C3AED" letter-spacing="1">LAYER 4 — APPROVAL LOOP</text>
+
+  <!-- Auto-execute -->
+  <rect x="70" y="478" width="160" height="52" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="150" y="501" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Auto-Execute</text>
+  <text x="150" y="517" text-anchor="middle" font-size="11" fill="#6B7280">low risk · high conf.</text>
+
+  <!-- HITL Gate -->
+  <rect x="290" y="478" width="160" height="52" rx="8" fill="#ffffff" stroke="#8B5CF6" stroke-width="2"/>
+  <text x="370" y="501" text-anchor="middle" font-size="13" font-weight="bold" fill="#5B21B6">HITL Gate</text>
+  <text x="370" y="517" text-anchor="middle" font-size="11" fill="#6B7280">human approval</text>
+
+  <!-- Rollback -->
+  <rect x="510" y="478" width="160" height="52" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="590" y="501" text-anchor="middle" font-size="13" font-weight="bold" fill="#991B1B">Rollback</text>
+  <text x="590" y="517" text-anchor="middle" font-size="11" fill="#6B7280">on failure · reject</text>
+
+  <!-- Arrows within layer 4 -->
+  <line x1="230" y1="504" x2="288" y2="504" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="450" y1="504" x2="508" y2="504" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- ===== AUDIT TRAIL (vertical bar, right side) ===== -->
+  <rect x="738" y="64" width="44" height="484" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+  <text x="760" y="310" text-anchor="middle" font-size="11" font-weight="bold" fill="#5B21B6" transform="rotate(90 760 310)" letter-spacing="1">AUDIT TRAIL</text>
+
+  <!-- Audit tap lines from each layer -->
+  <line x1="720" y1="120" x2="737" y2="120" stroke="#8B5CF6" stroke-width="1" stroke-dasharray="3,2"/>
+  <circle cx="720" cy="120" r="3" fill="#8B5CF6"/>
+  <text x="718" y="116" text-anchor="end" font-size="9" fill="#8B5CF6">signal event</text>
+
+  <line x1="720" y1="248" x2="737" y2="248" stroke="#8B5CF6" stroke-width="1" stroke-dasharray="3,2"/>
+  <circle cx="720" cy="248" r="3" fill="#8B5CF6"/>
+  <text x="718" y="244" text-anchor="end" font-size="9" fill="#8B5CF6">search event</text>
+
+  <line x1="720" y1="376" x2="737" y2="376" stroke="#8B5CF6" stroke-width="1" stroke-dasharray="3,2"/>
+  <circle cx="720" cy="376" r="3" fill="#8B5CF6"/>
+  <text x="718" y="372" text-anchor="end" font-size="9" fill="#8B5CF6">exec event</text>
+
+  <line x1="720" y1="504" x2="737" y2="504" stroke="#8B5CF6" stroke-width="1" stroke-dasharray="3,2"/>
+  <circle cx="720" cy="504" r="3" fill="#8B5CF6"/>
+  <text x="718" y="500" text-anchor="end" font-size="9" fill="#8B5CF6">approval event</text>
+
+  <!-- Audit trail label on right -->
+  <text x="775" y="130" text-anchor="middle" font-size="10" fill="#9CA3AF" transform="rotate(90 775 130)">INGEST</text>
+  <text x="775" y="258" text-anchor="middle" font-size="10" fill="#9CA3AF" transform="rotate(90 775 258)">SEARCH</text>
+  <text x="775" y="386" text-anchor="middle" font-size="10" fill="#9CA3AF" transform="rotate(90 775 386)">REMEDIATE</text>
+  <text x="775" y="514" text-anchor="middle" font-size="10" fill="#9CA3AF" transform="rotate(90 775 514)">APPROVE</text>
+</svg>

--- a/public/assets/diagrams/mcp-architecture.svg
+++ b/public/assets/diagrams/mcp-architecture.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 260" width="780" height="260" style="background:#fff;font-family:system-ui,-apple-system,sans-serif;">
+
+  <rect width="780" height="260" fill="#ffffff"/>
+
+  <defs>
+    <marker id="ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#3d7ab5"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="390" y="28" text-anchor="middle" font-size="16" font-weight="600" fill="#1a1a1a">MCP Architecture: Three Roles</text>
+
+  <!-- Host -->
+  <rect x="30" y="60" width="200" height="160" rx="10" fill="#1a3a5c" stroke="none"/>
+  <text x="130" y="88" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Host</text>
+  <text x="130" y="106" text-anchor="middle" font-size="9" fill="#c5d5e4">Your AI application</text>
+  <line x1="50" y1="114" x2="210" y2="114" stroke="#3d7ab5" stroke-width="0.5"/>
+
+  <!-- LLM inside host -->
+  <rect x="55" y="124" width="150" height="30" rx="5" fill="#3d7ab5"/>
+  <text x="130" y="143" text-anchor="middle" font-size="10" fill="#fff">LLM (Claude, GPT, etc.)</text>
+
+  <!-- Client inside host -->
+  <rect x="55" y="164" width="150" height="30" rx="5" fill="#7eb3d8"/>
+  <text x="130" y="183" text-anchor="middle" font-size="10" fill="#1a3a5c" font-weight="500">MCP Client</text>
+
+  <!-- Arrow from client to server 1 -->
+  <line x1="230" y1="140" x2="310" y2="100" stroke="#3d7ab5" stroke-width="1.5" marker-end="url(#ar)"/>
+  <line x1="230" y1="179" x2="310" y2="179" stroke="#3d7ab5" stroke-width="1.5" marker-end="url(#ar)"/>
+
+  <!-- Protocol label -->
+  <text x="270" y="132" text-anchor="middle" font-size="8" fill="#3d7ab5" transform="rotate(-20,270,132)">JSON-RPC</text>
+  <text x="270" y="172" text-anchor="middle" font-size="8" fill="#3d7ab5">JSON-RPC</text>
+
+  <!-- Server 1 -->
+  <rect x="315" y="60" width="190" height="80" rx="8" fill="#e8f0f7" stroke="#7eb3d8" stroke-width="1.5"/>
+  <text x="410" y="85" text-anchor="middle" font-size="12" font-weight="600" fill="#1a3a5c">MCP Server 1</text>
+  <text x="410" y="102" text-anchor="middle" font-size="9" fill="#6B7280">e.g. Database tools</text>
+  <rect x="335" y="112" width="60" height="18" rx="3" fill="#c5d5e4"/>
+  <text x="365" y="124" text-anchor="middle" font-size="8" fill="#1a3a5c">query</text>
+  <rect x="405" y="112" width="60" height="18" rx="3" fill="#c5d5e4"/>
+  <text x="435" y="124" text-anchor="middle" font-size="8" fill="#1a3a5c">insert</text>
+
+  <!-- Server 2 -->
+  <rect x="315" y="155" width="190" height="80" rx="8" fill="#e8f0f7" stroke="#7eb3d8" stroke-width="1.5"/>
+  <text x="410" y="180" text-anchor="middle" font-size="12" font-weight="600" fill="#1a3a5c">MCP Server 2</text>
+  <text x="410" y="197" text-anchor="middle" font-size="9" fill="#6B7280">e.g. Search tools</text>
+  <rect x="335" y="207" width="60" height="18" rx="3" fill="#c5d5e4"/>
+  <text x="365" y="219" text-anchor="middle" font-size="8" fill="#1a3a5c">search</text>
+  <rect x="405" y="207" width="60" height="18" rx="3" fill="#c5d5e4"/>
+  <text x="435" y="219" text-anchor="middle" font-size="8" fill="#1a3a5c">fetch</text>
+
+  <!-- Transport labels -->
+  <rect x="560" y="70" width="190" height="80" rx="8" fill="#f8f9fa" stroke="#c5d5e4" stroke-width="1"/>
+  <text x="655" y="92" text-anchor="middle" font-size="11" font-weight="600" fill="#1a3a5c">Transports</text>
+  <text x="580" y="114" font-size="10" fill="#3d7ab5" font-weight="500">stdio</text>
+  <text x="620" y="114" font-size="9" fill="#6B7280">Local process (fast)</text>
+  <text x="580" y="134" font-size="10" fill="#3d7ab5" font-weight="500">HTTP</text>
+  <text x="620" y="134" font-size="9" fill="#6B7280">Remote server (flexible)</text>
+
+  <line x1="507" y1="100" x2="558" y2="100" stroke="#c5d5e4" stroke-width="1" stroke-dasharray="4,2"/>
+  <line x1="507" y1="195" x2="558" y2="130" stroke="#c5d5e4" stroke-width="1" stroke-dasharray="4,2"/>
+
+</svg>

--- a/public/assets/diagrams/mcp-before-after.svg
+++ b/public/assets/diagrams/mcp-before-after.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 340" width="780" height="340" style="background:#fff;font-family:system-ui,-apple-system,sans-serif;">
+
+  <rect width="780" height="340" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="390" y="28" text-anchor="middle" font-size="16" font-weight="600" fill="#1a1a1a">The Problem MCP Solves</text>
+
+  <!-- === LEFT: Without MCP === -->
+  <text x="185" y="60" text-anchor="middle" font-size="13" font-weight="600" fill="#c0392b">Without MCP: 5 apps x 4 tools = 20 integrations</text>
+
+  <!-- Apps -->
+  <rect x="30" y="80" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
+  <text x="70" y="99" text-anchor="middle" font-size="9" fill="#1a3a5c">App 1</text>
+  <rect x="30" y="120" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
+  <text x="70" y="139" text-anchor="middle" font-size="9" fill="#1a3a5c">App 2</text>
+  <rect x="30" y="160" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
+  <text x="70" y="179" text-anchor="middle" font-size="9" fill="#1a3a5c">App 3</text>
+  <rect x="30" y="200" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
+  <text x="70" y="219" text-anchor="middle" font-size="9" fill="#1a3a5c">App 4</text>
+  <rect x="30" y="240" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
+  <text x="70" y="259" text-anchor="middle" font-size="9" fill="#1a3a5c">App 5</text>
+
+  <!-- Tools -->
+  <rect x="260" y="100" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
+  <text x="300" y="119" text-anchor="middle" font-size="9" fill="#1a3a5c">Database</text>
+  <rect x="260" y="145" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
+  <text x="300" y="164" text-anchor="middle" font-size="9" fill="#1a3a5c">Search</text>
+  <rect x="260" y="190" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
+  <text x="300" y="209" text-anchor="middle" font-size="9" fill="#1a3a5c">Email</text>
+  <rect x="260" y="235" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
+  <text x="300" y="254" text-anchor="middle" font-size="9" fill="#1a3a5c">Calendar</text>
+
+  <!-- Spaghetti lines -->
+  <g stroke="#ccc" stroke-width="0.8" opacity="0.6">
+    <line x1="110" y1="95" x2="260" y2="115"/><line x1="110" y1="95" x2="260" y2="160"/>
+    <line x1="110" y1="95" x2="260" y2="205"/><line x1="110" y1="95" x2="260" y2="250"/>
+    <line x1="110" y1="135" x2="260" y2="115"/><line x1="110" y1="135" x2="260" y2="160"/>
+    <line x1="110" y1="135" x2="260" y2="205"/><line x1="110" y1="135" x2="260" y2="250"/>
+    <line x1="110" y1="175" x2="260" y2="115"/><line x1="110" y1="175" x2="260" y2="160"/>
+    <line x1="110" y1="175" x2="260" y2="205"/><line x1="110" y1="175" x2="260" y2="250"/>
+    <line x1="110" y1="215" x2="260" y2="115"/><line x1="110" y1="215" x2="260" y2="160"/>
+    <line x1="110" y1="215" x2="260" y2="205"/><line x1="110" y1="215" x2="260" y2="250"/>
+    <line x1="110" y1="255" x2="260" y2="115"/><line x1="110" y1="255" x2="260" y2="160"/>
+    <line x1="110" y1="255" x2="260" y2="205"/><line x1="110" y1="255" x2="260" y2="250"/>
+  </g>
+
+  <!-- === RIGHT: With MCP === -->
+  <text x="595" y="60" text-anchor="middle" font-size="13" font-weight="600" fill="#3d7ab5">With MCP: 5 + 4 = 9 integrations</text>
+
+  <!-- Apps -->
+  <rect x="440" y="80" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
+  <text x="480" y="99" text-anchor="middle" font-size="9" fill="#1a3a5c">App 1</text>
+  <rect x="440" y="120" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
+  <text x="480" y="139" text-anchor="middle" font-size="9" fill="#1a3a5c">App 2</text>
+  <rect x="440" y="160" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
+  <text x="480" y="179" text-anchor="middle" font-size="9" fill="#1a3a5c">App 3</text>
+  <rect x="440" y="200" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
+  <text x="480" y="219" text-anchor="middle" font-size="9" fill="#1a3a5c">App 4</text>
+  <rect x="440" y="240" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
+  <text x="480" y="259" text-anchor="middle" font-size="9" fill="#1a3a5c">App 5</text>
+
+  <!-- MCP standard -->
+  <rect x="555" y="90" width="50" height="185" rx="6" fill="#3d7ab5" stroke="none"/>
+  <text x="580" y="185" text-anchor="middle" font-size="11" font-weight="600" fill="#fff" transform="rotate(-90,580,185)">MCP</text>
+
+  <!-- Tools -->
+  <rect x="640" y="100" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
+  <text x="680" y="119" text-anchor="middle" font-size="9" fill="#1a3a5c">Database</text>
+  <rect x="640" y="145" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
+  <text x="680" y="164" text-anchor="middle" font-size="9" fill="#1a3a5c">Search</text>
+  <rect x="640" y="190" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
+  <text x="680" y="209" text-anchor="middle" font-size="9" fill="#1a3a5c">Email</text>
+  <rect x="640" y="235" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
+  <text x="680" y="254" text-anchor="middle" font-size="9" fill="#1a3a5c">Calendar</text>
+
+  <!-- Clean lines: apps to MCP -->
+  <g stroke="#3d7ab5" stroke-width="1.2">
+    <line x1="520" y1="95" x2="555" y2="140"/>
+    <line x1="520" y1="135" x2="555" y2="160"/>
+    <line x1="520" y1="175" x2="555" y2="180"/>
+    <line x1="520" y1="215" x2="555" y2="200"/>
+    <line x1="520" y1="255" x2="555" y2="230"/>
+  </g>
+
+  <!-- Clean lines: MCP to tools -->
+  <g stroke="#7eb3d8" stroke-width="1.2">
+    <line x1="605" y1="140" x2="640" y2="115"/>
+    <line x1="605" y1="160" x2="640" y2="160"/>
+    <line x1="605" y1="200" x2="640" y2="205"/>
+    <line x1="605" y1="230" x2="640" y2="250"/>
+  </g>
+
+  <!-- Bottom label -->
+  <text x="185" y="310" text-anchor="middle" font-size="10" fill="#999">Every app writes custom code for every tool</text>
+  <text x="595" y="310" text-anchor="middle" font-size="10" fill="#999">Each side implements the standard once</text>
+
+</svg>

--- a/public/assets/diagrams/mcp-lifecycle.svg
+++ b/public/assets/diagrams/mcp-lifecycle.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 300" width="780" height="300" style="background:#fff;font-family:system-ui,-apple-system,sans-serif;">
+
+  <rect width="780" height="300" fill="#ffffff"/>
+
+  <defs>
+    <marker id="ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#3d7ab5"/>
+    </marker>
+    <marker id="ar-back" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#7eb3d8"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="390" y="28" text-anchor="middle" font-size="16" font-weight="600" fill="#1a1a1a">MCP Protocol Lifecycle</text>
+  <text x="390" y="48" text-anchor="middle" font-size="11" fill="#999">What happens when your agent connects to an MCP server</text>
+
+  <!-- Client box -->
+  <rect x="40" y="80" width="160" height="180" rx="8" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.5"/>
+  <text x="120" y="105" text-anchor="middle" font-size="13" font-weight="600" fill="#1a3a5c">Your Agent</text>
+  <text x="120" y="122" text-anchor="middle" font-size="9" fill="#6B7280">(MCP Client)</text>
+
+  <!-- Server box -->
+  <rect x="580" y="80" width="160" height="180" rx="8" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.5"/>
+  <text x="660" y="105" text-anchor="middle" font-size="13" font-weight="600" fill="#1a3a5c">MCP Server</text>
+  <text x="660" y="122" text-anchor="middle" font-size="9" fill="#6B7280">(Tools + Data)</text>
+
+  <!-- Step 1: Initialize -->
+  <rect x="260" y="72" width="260" height="36" rx="6" fill="#fff" stroke="#3d7ab5" stroke-width="1"/>
+  <circle cx="278" cy="90" r="11" fill="#3d7ab5"/>
+  <text x="278" y="94" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">1</text>
+  <text x="310" y="86" font-size="10" font-weight="600" fill="#1a3a5c">Initialize</text>
+  <text x="310" y="100" font-size="8.5" fill="#6B7280">Handshake: agree on capabilities</text>
+  <line x1="200" y1="90" x2="258" y2="90" stroke="#3d7ab5" stroke-width="1.5" marker-end="url(#ar)"/>
+  <line x1="522" y1="90" x2="580" y2="90" stroke="#3d7ab5" stroke-width="1.5" marker-end="url(#ar)"/>
+
+  <!-- Step 2: Discover -->
+  <rect x="260" y="120" width="260" height="36" rx="6" fill="#fff" stroke="#3d7ab5" stroke-width="1"/>
+  <circle cx="278" cy="138" r="11" fill="#3d7ab5"/>
+  <text x="278" y="142" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">2</text>
+  <text x="310" y="134" font-size="10" font-weight="600" fill="#1a3a5c">Discover</text>
+  <text x="310" y="148" font-size="8.5" fill="#6B7280">Client calls tools/list, gets available tools</text>
+  <line x1="200" y1="133" x2="258" y2="133" stroke="#3d7ab5" stroke-width="1.2" marker-end="url(#ar)"/>
+  <line x1="580" y1="143" x2="522" y2="143" stroke="#7eb3d8" stroke-width="1.2" marker-end="url(#ar-back)"/>
+
+  <!-- Step 3: Invoke -->
+  <rect x="260" y="168" width="260" height="36" rx="6" fill="#fff" stroke="#3d7ab5" stroke-width="1"/>
+  <circle cx="278" cy="186" r="11" fill="#3d7ab5"/>
+  <text x="278" y="190" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">3</text>
+  <text x="310" y="182" font-size="10" font-weight="600" fill="#1a3a5c">Invoke</text>
+  <text x="310" y="196" font-size="8.5" fill="#6B7280">LLM picks a tool, client sends tools/call</text>
+  <line x1="200" y1="181" x2="258" y2="181" stroke="#3d7ab5" stroke-width="1.2" marker-end="url(#ar)"/>
+  <line x1="580" y1="191" x2="522" y2="191" stroke="#7eb3d8" stroke-width="1.2" marker-end="url(#ar-back)"/>
+
+  <!-- Step 4: Repeat -->
+  <rect x="260" y="216" width="260" height="36" rx="6" fill="#fff" stroke="#3d7ab5" stroke-width="1"/>
+  <circle cx="278" cy="234" r="11" fill="#3d7ab5"/>
+  <text x="278" y="238" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">4</text>
+  <text x="310" y="230" font-size="10" font-weight="600" fill="#1a3a5c">Loop</text>
+  <text x="310" y="244" font-size="8.5" fill="#6B7280">Result goes back to LLM, which decides next step</text>
+
+  <!-- Loop arrow -->
+  <path d="M 390 252 L 390 270 L 180 270 L 180 175 L 200 175" fill="none" stroke="#3d7ab5" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <text x="280" y="283" text-anchor="middle" font-size="8.5" fill="#3d7ab5" font-style="italic">Agent loop continues until the LLM has enough info to answer</text>
+
+</svg>

--- a/public/assets/diagrams/memory-hierarchy.svg
+++ b/public/assets/diagrams/memory-hierarchy.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="480" viewBox="0 0 800 480" font-family="'IBM Plex Sans', sans-serif">
+  <defs>
+    <marker id="arrow-dark" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1a3a5c"/>
+    </marker>
+    <marker id="arrow-med" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#3d7ab5"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="480" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="34" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a1a">Memory Hierarchy — Four-Layer Architecture</text>
+  <line x1="100" y1="48" x2="700" y2="48" stroke="#7eb3d8" stroke-width="1"/>
+
+  <!-- Layer 1: Context Window (top) -->
+  <rect x="140" y="68" width="520" height="80" rx="10" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="170" y="92" font-size="11" font-weight="bold" fill="#1a3a5c" letter-spacing="1">LAYER 1</text>
+  <text x="400" y="108" text-anchor="middle" font-size="16" font-weight="bold" fill="#1a3a5c">Context Window</text>
+  <text x="400" y="128" text-anchor="middle" font-size="12" fill="#6b7280">Ephemeral, per-request. Grows per step.</text>
+  <text x="400" y="142" text-anchor="middle" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#6b7280">system_prompt + messages + tool_results</text>
+
+  <!-- Arrow Layer 1 → 2 -->
+  <line x1="400" y1="148" x2="400" y2="176" stroke="#3d7ab5" stroke-width="2" stroke-dasharray="4,3" marker-end="url(#arrow-med)"/>
+  <text x="420" y="166" font-size="10" fill="#6b7280">promote</text>
+
+  <!-- Layer 2: Session Memory (middle) -->
+  <rect x="140" y="178" width="520" height="80" rx="10" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="170" y="202" font-size="11" font-weight="bold" fill="#1a3a5c" letter-spacing="1">LAYER 2</text>
+  <text x="400" y="218" text-anchor="middle" font-size="16" font-weight="bold" fill="#1a3a5c">Session Memory</text>
+  <text x="400" y="238" text-anchor="middle" font-size="12" fill="#6b7280">Per-conversation. Persists across turns.</text>
+  <text x="400" y="252" text-anchor="middle" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#6b7280">conversation_history + summaries + corrections</text>
+
+  <!-- Arrow Layer 2 → 3a -->
+  <line x1="320" y1="258" x2="250" y2="296" stroke="#3d7ab5" stroke-width="2" stroke-dasharray="4,3" marker-end="url(#arrow-med)"/>
+  <text x="255" y="278" font-size="10" fill="#6b7280">persist</text>
+
+  <!-- Arrow Layer 2 → 3b -->
+  <line x1="480" y1="258" x2="550" y2="296" stroke="#3d7ab5" stroke-width="2" stroke-dasharray="4,3" marker-end="url(#arrow-med)"/>
+  <text x="530" y="278" font-size="10" fill="#6b7280">share</text>
+
+  <!-- Layer 3a: Long-Term Memory (bottom left) -->
+  <rect x="60" y="298" width="310" height="90" rx="10" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="90" y="322" font-size="11" font-weight="bold" fill="#1a3a5c" letter-spacing="1">LAYER 3a</text>
+  <text x="215" y="340" text-anchor="middle" font-size="16" font-weight="bold" fill="#1a3a5c">Long-Term Memory</text>
+  <text x="215" y="358" text-anchor="middle" font-size="12" fill="#6b7280">Cross-session. Persists across sessions.</text>
+  <text x="215" y="374" text-anchor="middle" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#6b7280">user_prefs + learned_corrections</text>
+
+  <!-- Layer 3b: Shared Memory (bottom right) -->
+  <rect x="430" y="298" width="310" height="90" rx="10" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="460" y="322" font-size="11" font-weight="bold" fill="#1a3a5c" letter-spacing="1">LAYER 3b</text>
+  <text x="585" y="340" text-anchor="middle" font-size="16" font-weight="bold" fill="#1a3a5c">Shared Memory</text>
+  <text x="585" y="358" text-anchor="middle" font-size="12" fill="#6b7280">Cross-agent. Visible to all agents.</text>
+  <text x="585" y="374" text-anchor="middle" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#6b7280">team_knowledge + global_facts</text>
+
+  <!-- Bidirectional arrows: Long-Term ↔ Context -->
+  <path d="M 140 298 Q 80 220 180 148" fill="none" stroke="#1a3a5c" stroke-width="1.5" stroke-dasharray="6,3" marker-end="url(#arrow-dark)"/>
+  <text x="88" y="218" font-size="10" fill="#1a3a5c" font-weight="bold">recall</text>
+
+  <!-- Bidirectional arrows: Shared ↔ Context -->
+  <path d="M 660 298 Q 720 220 620 148" fill="none" stroke="#1a3a5c" stroke-width="1.5" stroke-dasharray="6,3" marker-end="url(#arrow-dark)"/>
+  <text x="690" y="218" font-size="10" fill="#1a3a5c" font-weight="bold">inject</text>
+
+  <!-- Lifetime labels on right side -->
+  <text x="690" y="112" font-size="10" fill="#3d7ab5" font-weight="bold">~1 request</text>
+  <text x="690" y="222" font-size="10" fill="#3d7ab5" font-weight="bold">~1 conversation</text>
+  <text x="215" y="406" text-anchor="middle" font-size="10" fill="#3d7ab5" font-weight="bold">weeks → months</text>
+  <text x="585" y="406" text-anchor="middle" font-size="10" fill="#3d7ab5" font-weight="bold">indefinite</text>
+
+  <!-- Legend -->
+  <rect x="60" y="428" width="680" height="36" rx="6" fill="#f9fafb" stroke="#e8f0f7" stroke-width="1"/>
+  <line x1="82" y1="448" x2="112" y2="448" stroke="#3d7ab5" stroke-width="2" stroke-dasharray="4,3"/>
+  <text x="118" y="452" font-size="11" fill="#1a1a1a">Data flow</text>
+  <line x1="200" y1="448" x2="230" y2="448" stroke="#1a3a5c" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="236" y="452" font-size="11" fill="#1a1a1a">Recall / injection</text>
+  <rect x="370" y="440" width="16" height="16" rx="3" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="392" y="452" font-size="11" fill="#1a1a1a">Memory layer</text>
+  <text x="530" y="452" font-size="11" fill="#6b7280">Each layer has increasing persistence and decreasing access speed.</text>
+</svg>

--- a/public/assets/diagrams/message-contract-flow.svg
+++ b/public/assets/diagrams/message-contract-flow.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="300" viewBox="0 0 800 300" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+    <marker id="arrowhead-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="300" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Typed Message Contract Flow</text>
+  <line x1="60" y1="42" x2="740" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- ===== Row 1: Orchestrator -> Retriever -> Orchestrator ===== -->
+
+  <!-- Orchestrator (left, row 1) -->
+  <rect x="20" y="60" width="120" height="52" rx="8" fill="#1D4ED8" stroke="#1E40AF" stroke-width="2"/>
+  <text x="80" y="84" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">Orchestrator</text>
+  <text x="80" y="100" text-anchor="middle" font-size="10" fill="#BFDBFE">coordinates</text>
+
+  <!-- Arrow: Orchestrator -> RetrieverAgent -->
+  <line x1="140" y1="86" x2="228" y2="86" stroke="#2563EB" stroke-width="1.5" marker-end="url(#arrowhead-blue)"/>
+  <!-- Label above arrow -->
+  <rect x="148" y="68" width="72" height="16" rx="4" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1"/>
+  <text x="184" y="80" text-anchor="middle" font-size="9" fill="#1D4ED8">RetrievalRequest</text>
+
+  <!-- RetrieverAgent -->
+  <rect x="228" y="60" width="124" height="52" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="290" y="84" text-anchor="middle" font-size="12" font-weight="bold" fill="#1D4ED8">RetrieverAgent</text>
+  <text x="290" y="100" text-anchor="middle" font-size="10" fill="#6B7280">vector search</text>
+
+  <!-- Arrow: RetrieverAgent -> Orchestrator (return) -->
+  <line x1="352" y1="86" x2="440" y2="86" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <!-- Label above arrow -->
+  <rect x="357" y="68" width="78" height="16" rx="4" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="396" y="80" text-anchor="middle" font-size="9" fill="#374151">RetrievalResult</text>
+
+  <!-- Orchestrator (center) -->
+  <rect x="440" y="60" width="120" height="52" rx="8" fill="#1D4ED8" stroke="#1E40AF" stroke-width="2"/>
+  <text x="500" y="84" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">Orchestrator</text>
+  <text x="500" y="100" text-anchor="middle" font-size="10" fill="#BFDBFE">aggregates</text>
+
+  <!-- Arrow: Orchestrator -> ReasoningAgent -->
+  <line x1="560" y1="86" x2="648" y2="86" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <!-- Label above arrow -->
+  <rect x="563" y="68" width="78" height="16" rx="4" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1"/>
+  <text x="602" y="80" text-anchor="middle" font-size="9" fill="#92400E">ReasoningRequest</text>
+
+  <!-- ReasoningAgent -->
+  <rect x="648" y="60" width="128" height="52" rx="8" fill="#ffffff" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="712" y="84" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">ReasoningAgent</text>
+  <text x="712" y="100" text-anchor="middle" font-size="10" fill="#6B7280">synthesize</text>
+
+  <!-- ===== Row 2: ReasoningAgent -> Orchestrator -> Verifier -> Orchestrator ===== -->
+
+  <!-- Arrow: ReasoningAgent -> Orchestrator (return, going down) -->
+  <path d="M 712 112 C 712 148, 500 148, 500 168" fill="none" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <!-- Label for return -->
+  <rect x="580" y="138" width="78" height="16" rx="4" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="619" y="150" text-anchor="middle" font-size="9" fill="#374151">ReasoningResult</text>
+
+  <!-- Orchestrator (row 2) -->
+  <rect x="440" y="168" width="120" height="52" rx="8" fill="#1D4ED8" stroke="#1E40AF" stroke-width="2"/>
+  <text x="500" y="192" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">Orchestrator</text>
+  <text x="500" y="208" text-anchor="middle" font-size="10" fill="#BFDBFE">evaluates</text>
+
+  <!-- Arrow: Orchestrator -> VerifierAgent -->
+  <line x1="440" y1="194" x2="352" y2="194" stroke="#10B981" stroke-width="1.5" marker-end="url(#arrowhead-green)"/>
+  <!-- Label above arrow -->
+  <rect x="358" y="176" width="76" height="16" rx="4" fill="#F0FDF4" stroke="#10B981" stroke-width="1"/>
+  <text x="396" y="188" text-anchor="middle" font-size="9" fill="#065F46">VerificationRequest</text>
+
+  <!-- VerifierAgent -->
+  <rect x="228" y="168" width="124" height="52" rx="8" fill="#ffffff" stroke="#10B981" stroke-width="1.5"/>
+  <text x="290" y="192" text-anchor="middle" font-size="12" font-weight="bold" fill="#065F46">VerifierAgent</text>
+  <text x="290" y="208" text-anchor="middle" font-size="10" fill="#6B7280">fact-check</text>
+
+  <!-- Arrow: VerifierAgent -> Orchestrator (return) -->
+  <line x1="228" y1="194" x2="140" y2="194" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <!-- Label above arrow -->
+  <rect x="143" y="176" width="78" height="16" rx="4" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="182" y="188" text-anchor="middle" font-size="9" fill="#374151">VerificationResult</text>
+
+  <!-- Orchestrator (final, row 2 left) -->
+  <rect x="20" y="168" width="120" height="52" rx="8" fill="#1D4ED8" stroke="#1E40AF" stroke-width="2"/>
+  <text x="80" y="192" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">Orchestrator</text>
+  <text x="80" y="208" text-anchor="middle" font-size="10" fill="#BFDBFE">final answer</text>
+
+  <!-- Legend -->
+  <rect x="20" y="250" width="760" height="36" rx="8" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="40" y="270" font-size="11" font-weight="bold" fill="#374151">Message Types:</text>
+  <rect x="145" y="260" width="10" height="10" rx="2" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1"/>
+  <text x="160" y="270" font-size="10" fill="#1D4ED8">RetrievalRequest / Result</text>
+  <rect x="310" y="260" width="10" height="10" rx="2" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1"/>
+  <text x="325" y="270" font-size="10" fill="#92400E">ReasoningRequest / Result</text>
+  <rect x="485" y="260" width="10" height="10" rx="2" fill="#F0FDF4" stroke="#10B981" stroke-width="1"/>
+  <text x="500" y="270" font-size="10" fill="#065F46">VerificationRequest / Result</text>
+  <text x="670" y="270" font-size="10" fill="#6B7280">All typed via Pydantic</text>
+</svg>

--- a/public/assets/diagrams/multi-agent-coordination.svg
+++ b/public/assets/diagrams/multi-agent-coordination.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="520" viewBox="0 0 800 520" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+    <marker id="arrowhead-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#EF4444"/>
+    </marker>
+    <marker id="arrowhead-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="520" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="36" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Multi-Agent Coordination Pattern</text>
+  <line x1="100" y1="48" x2="700" y2="48" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- User Query (top) -->
+  <rect x="310" y="68" width="180" height="52" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="400" y="90" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">User Query</text>
+  <text x="400" y="108" text-anchor="middle" font-size="11" fill="#6B7280">incoming request</text>
+
+  <!-- Arrow: User Query -> Coordinator -->
+  <line x1="400" y1="120" x2="400" y2="158" stroke="#2563EB" stroke-width="1.5" marker-end="url(#arrowhead-blue)"/>
+
+  <!-- Coordinator Agent (center) -->
+  <rect x="280" y="158" width="240" height="64" rx="8" fill="#1D4ED8" stroke="#1E40AF" stroke-width="2"/>
+  <text x="400" y="185" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">CoordinatorAgent</text>
+  <text x="400" y="204" text-anchor="middle" font-size="11" fill="#BFDBFE">plans · dispatches · aggregates</text>
+
+  <!-- Arrow: Coordinator -> RetrieverAgent -->
+  <line x1="310" y1="222" x2="170" y2="298" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="218" y="258" text-anchor="middle" font-size="11" fill="#6B7280">fetch docs</text>
+
+  <!-- Arrow: Coordinator -> ReasoningAgent -->
+  <line x1="400" y1="222" x2="400" y2="298" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="430" y="262" text-anchor="middle" font-size="11" fill="#6B7280">reason</text>
+
+  <!-- Arrow: Coordinator -> VerifierAgent -->
+  <line x1="490" y1="222" x2="630" y2="298" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="582" y="258" text-anchor="middle" font-size="11" fill="#6B7280">verify</text>
+
+  <!-- RetrieverAgent -->
+  <rect x="60" y="298" width="200" height="64" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="160" y="325" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">RetrieverAgent</text>
+  <text x="160" y="344" text-anchor="middle" font-size="11" fill="#6B7280">vector search · reranking</text>
+
+  <!-- ReasoningAgent -->
+  <rect x="300" y="298" width="200" height="64" rx="8" fill="#ffffff" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="400" y="325" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">ReasoningAgent</text>
+  <text x="400" y="344" text-anchor="middle" font-size="11" fill="#6B7280">chain-of-thought · synthesis</text>
+
+  <!-- VerifierAgent -->
+  <rect x="540" y="298" width="200" height="64" rx="8" fill="#ffffff" stroke="#10B981" stroke-width="1.5"/>
+  <text x="640" y="325" text-anchor="middle" font-size="14" font-weight="bold" fill="#065F46">VerifierAgent</text>
+  <text x="640" y="344" text-anchor="middle" font-size="11" fill="#6B7280">fact-check · confidence score</text>
+
+  <!-- Verification loop: VerifierAgent -> ReasoningAgent (dashed feedback) -->
+  <!-- Loop path goes below the boxes -->
+  <path d="M 640 362 C 640 430, 400 430, 400 362" fill="none" stroke="#EF4444" stroke-width="1.5" stroke-dasharray="6,4" marker-end="url(#arrowhead-red)"/>
+  <text x="520" y="448" text-anchor="middle" font-size="11" fill="#EF4444">feedback: re-reason</text>
+  <text x="520" y="462" text-anchor="middle" font-size="11" fill="#EF4444">(low confidence loop)</text>
+
+  <!-- Arrows back to Coordinator: RetrieverAgent and VerifierAgent (after pass) -->
+  <line x1="160" y1="298" x2="310" y2="222" stroke="#6B7280" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrowhead)"/>
+  <line x1="640" y1="298" x2="490" y2="222" stroke="#10B981" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrowhead-green)"/>
+  <text x="590" y="262" text-anchor="middle" font-size="11" fill="#10B981">verified</text>
+
+  <!-- Final Answer -->
+  <rect x="310" y="480" width="180" height="28" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="400" y="499" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Final Answer</text>
+
+  <!-- Arrow: Coordinator -> Final Answer -->
+  <line x1="400" y1="222" x2="400" y2="478" stroke="#10B981" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowhead-green)"/>
+</svg>

--- a/public/assets/diagrams/multi-agent-cost.svg
+++ b/public/assets/diagrams/multi-agent-cost.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="350" viewBox="0 0 700 350" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arrowhead-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#EF4444"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="700" height="350" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="350" y="36" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Cost Multiplication: Single vs. Multi-Agent</text>
+  <line x1="60" y1="48" x2="640" y2="48" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- ===== LEFT PANEL: Single Agent ===== -->
+  <rect x="30" y="60" width="270" height="200" rx="12" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1.5"/>
+  <text x="165" y="84" text-anchor="middle" font-size="14" font-weight="bold" fill="#374151">Single Agent</text>
+
+  <!-- 1 model call box -->
+  <rect x="80" y="100" width="170" height="52" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="165" y="122" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">1 Model Call</text>
+  <text x="165" y="139" text-anchor="middle" font-size="11" fill="#6B7280">retrieve + reason + answer</text>
+
+  <!-- Label row -->
+  <rect x="55" y="175" width="220" height="62" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1"/>
+  <text x="165" y="196" text-anchor="middle" font-size="12" font-weight="bold" fill="#065F46">1x tokens</text>
+  <text x="165" y="213" text-anchor="middle" font-size="12" font-weight="bold" fill="#065F46">1x latency</text>
+  <text x="165" y="228" text-anchor="middle" font-size="11" fill="#6B7280">baseline cost</text>
+
+  <!-- Divider -->
+  <line x1="350" y1="65" x2="350" y2="255" stroke="#D1D5DB" stroke-width="2" stroke-dasharray="6,4"/>
+
+  <!-- ===== RIGHT PANEL: Multi-Agent ===== -->
+  <rect x="400" y="60" width="270" height="200" rx="12" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1.5"/>
+  <text x="535" y="84" text-anchor="middle" font-size="14" font-weight="bold" fill="#374151">Multi-Agent (3 roles)</text>
+
+  <!-- Retriever box -->
+  <rect x="415" y="96" width="140" height="40" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="485" y="113" text-anchor="middle" font-size="12" font-weight="bold" fill="#1D4ED8">RetrieverAgent</text>
+  <text x="485" y="128" text-anchor="middle" font-size="10" fill="#6B7280">model call 1</text>
+
+  <!-- Arrow down -->
+  <line x1="485" y1="136" x2="485" y2="148" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Reasoner box -->
+  <rect x="415" y="148" width="140" height="40" rx="8" fill="#ffffff" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="485" y="165" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">ReasoningAgent</text>
+  <text x="485" y="180" text-anchor="middle" font-size="10" fill="#6B7280">model call 2</text>
+
+  <!-- Arrow down -->
+  <line x1="485" y1="188" x2="485" y2="200" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Verifier box -->
+  <rect x="415" y="200" width="140" height="40" rx="8" fill="#ffffff" stroke="#10B981" stroke-width="1.5"/>
+  <text x="485" y="217" text-anchor="middle" font-size="12" font-weight="bold" fill="#065F46">VerifierAgent</text>
+  <text x="485" y="232" text-anchor="middle" font-size="10" fill="#6B7280">model call 3</text>
+
+  <!-- Verification retry dashed loop -->
+  <path d="M 555 220 C 590 220, 590 168, 555 168" fill="none" stroke="#EF4444" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowhead-red)"/>
+  <text x="598" y="197" text-anchor="middle" font-size="9" fill="#EF4444" transform="rotate(90 598 197)">retry</text>
+  <text x="609" y="197" text-anchor="middle" font-size="9" fill="#EF4444" transform="rotate(90 609 197)">+call 4</text>
+
+  <!-- Label row -->
+  <rect x="55" y="275" width="220" height="52" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1"/>
+  <text x="165" y="298" text-anchor="middle" font-size="12" font-weight="bold" fill="#065F46">1x tokens · 1x latency</text>
+  <text x="165" y="315" text-anchor="middle" font-size="11" fill="#6B7280">baseline</text>
+
+  <rect x="425" y="275" width="245" height="52" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1"/>
+  <text x="548" y="298" text-anchor="middle" font-size="12" font-weight="bold" fill="#991B1B">3-5x tokens · 3-5x latency</text>
+  <text x="548" y="315" text-anchor="middle" font-size="11" fill="#6B7280">with verification retry</text>
+</svg>

--- a/public/assets/diagrams/multi-agent-error-amplification.svg
+++ b/public/assets/diagrams/multi-agent-error-amplification.svg
@@ -1,0 +1,134 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 460" width="820" height="460" style="background:#fff;font-family:'IBM Plex Sans',system-ui,sans-serif;">
+
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#374151"/>
+    </marker>
+    <marker id="arrowhead-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#b91c1c"/>
+    </marker>
+    <marker id="arrowhead-thin" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#6b7280"/>
+    </marker>
+  </defs>
+
+  <rect width="820" height="460" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="410" y="34" text-anchor="middle" font-size="18" font-weight="500" fill="#1a1a1a" font-family="Fraunces, Georgia, serif">Error amplification across three architectures</text>
+  <text x="410" y="56" text-anchor="middle" font-size="12" fill="#6b6b6b">MAST (Mar 2025) and DeepMind (Dec 2025) on multi-agent failure modes</text>
+
+  <!-- Divider lines between columns -->
+  <line x1="280" y1="80" x2="280" y2="400" stroke="#e8e8e8" stroke-width="1"/>
+  <line x1="555" y1="80" x2="555" y2="400" stroke="#e8e8e8" stroke-width="1"/>
+
+  <!-- ========== Column 1: Single agent ========== -->
+  <g>
+    <text x="140" y="100" text-anchor="middle" font-size="13" font-weight="600" fill="#1a1a1a" letter-spacing="0.02em">SINGLE AGENT</text>
+
+    <rect x="85" y="135" width="110" height="60" rx="4" fill="#EFF6FF" stroke="#1e40af" stroke-width="1.5"/>
+    <text x="140" y="170" text-anchor="middle" font-size="13" fill="#1a1a1a">Agent</text>
+
+    <!-- One small error dot inside -->
+    <circle cx="170" cy="155" r="4.5" fill="#b91c1c" opacity="0.9"/>
+
+    <!-- Arrow down -->
+    <line x1="140" y1="200" x2="140" y2="245" stroke="#374151" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+    <!-- Output -->
+    <rect x="100" y="250" width="80" height="36" rx="3" fill="#fafaf8" stroke="#9ca3af" stroke-width="1"/>
+    <text x="140" y="273" text-anchor="middle" font-size="11" fill="#374151">Output</text>
+
+    <!-- Amplification number -->
+    <text x="140" y="345" text-anchor="middle" font-size="38" font-weight="500" fill="#1a1a1a" font-family="Fraunces, Georgia, serif">1x</text>
+    <text x="140" y="370" text-anchor="middle" font-size="11" fill="#6b6b6b">error stays localized</text>
+  </g>
+
+  <!-- ========== Column 2: Hierarchical with verifier ========== -->
+  <g>
+    <text x="417" y="100" text-anchor="middle" font-size="13" font-weight="600" fill="#1a1a1a" letter-spacing="0.02em">HIERARCHICAL WITH VERIFIER</text>
+
+    <!-- Orchestrator -->
+    <rect x="360" y="120" width="115" height="40" rx="4" fill="#ECFDF5" stroke="#047857" stroke-width="1.5"/>
+    <text x="417" y="145" text-anchor="middle" font-size="12" fill="#1a1a1a">Orchestrator</text>
+
+    <!-- Workers -->
+    <rect x="310" y="185" width="85" height="36" rx="3" fill="#EFF6FF" stroke="#1e40af" stroke-width="1.2"/>
+    <text x="352" y="208" text-anchor="middle" font-size="11" fill="#1a1a1a">Worker</text>
+    <circle cx="380" cy="194" r="4.5" fill="#b91c1c" opacity="0.9"/>
+
+    <rect x="440" y="185" width="85" height="36" rx="3" fill="#EFF6FF" stroke="#1e40af" stroke-width="1.2"/>
+    <text x="482" y="208" text-anchor="middle" font-size="11" fill="#1a1a1a">Worker</text>
+
+    <!-- Orchestrator to workers -->
+    <line x1="392" y1="160" x2="352" y2="185" stroke="#6b7280" stroke-width="1" marker-end="url(#arrowhead-thin)"/>
+    <line x1="442" y1="160" x2="482" y2="185" stroke="#6b7280" stroke-width="1" marker-end="url(#arrowhead-thin)"/>
+
+    <!-- Verifier -->
+    <rect x="360" y="245" width="115" height="36" rx="3" fill="#FFFBEB" stroke="#b45309" stroke-width="1.5"/>
+    <text x="417" y="268" text-anchor="middle" font-size="11" fill="#1a1a1a">Verifier</text>
+
+    <!-- Workers to verifier -->
+    <line x1="352" y1="221" x2="385" y2="245" stroke="#6b7280" stroke-width="1" marker-end="url(#arrowhead-thin)"/>
+    <line x1="482" y1="221" x2="450" y2="245" stroke="#6b7280" stroke-width="1" marker-end="url(#arrowhead-thin)"/>
+
+    <!-- Retry feedback to orchestrator (dashed red) -->
+    <path d="M 360 263 Q 290 263 290 140 Q 290 120 310 120" fill="none" stroke="#b91c1c" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrowhead-red)"/>
+    <text x="260" y="195" text-anchor="middle" font-size="10" fill="#b91c1c" font-style="italic" font-family="Fraunces, Georgia, serif">retry</text>
+
+    <!-- Amplification number -->
+    <text x="417" y="345" text-anchor="middle" font-size="38" font-weight="500" fill="#1a1a1a" font-family="Fraunces, Georgia, serif">&lt; 2x</text>
+    <text x="417" y="370" text-anchor="middle" font-size="11" fill="#6b6b6b">verifier catches it</text>
+  </g>
+
+  <!-- ========== Column 3: Free-form coordination ========== -->
+  <g>
+    <text x="687" y="100" text-anchor="middle" font-size="13" font-weight="600" fill="#1a1a1a" letter-spacing="0.02em">FREE-FORM COORDINATION</text>
+
+    <!-- Web of agents with growing error -->
+    <line x1="687" y1="140" x2="630" y2="180" stroke="#9ca3af" stroke-width="1"/>
+    <line x1="687" y1="140" x2="744" y2="180" stroke="#9ca3af" stroke-width="1"/>
+    <line x1="687" y1="140" x2="655" y2="240" stroke="#9ca3af" stroke-width="1"/>
+    <line x1="687" y1="140" x2="719" y2="240" stroke="#9ca3af" stroke-width="1"/>
+    <line x1="630" y1="180" x2="744" y2="180" stroke="#9ca3af" stroke-width="1"/>
+    <line x1="630" y1="180" x2="655" y2="240" stroke="#9ca3af" stroke-width="1"/>
+    <line x1="744" y1="180" x2="719" y2="240" stroke="#9ca3af" stroke-width="1"/>
+    <line x1="655" y1="240" x2="719" y2="240" stroke="#9ca3af" stroke-width="1"/>
+    <line x1="630" y1="180" x2="719" y2="240" stroke="#9ca3af" stroke-width="1" opacity="0.5"/>
+    <line x1="744" y1="180" x2="655" y2="240" stroke="#9ca3af" stroke-width="1" opacity="0.5"/>
+
+    <!-- Agent A: small error -->
+    <circle cx="687" cy="140" r="22" fill="#FEF2F2" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="687" y="144" text-anchor="middle" font-size="11" fill="#1a1a1a">A</text>
+    <circle cx="700" cy="132" r="3" fill="#b91c1c"/>
+
+    <!-- Agent B: medium -->
+    <circle cx="630" cy="180" r="22" fill="#FEF2F2" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="630" y="184" text-anchor="middle" font-size="11" fill="#1a1a1a">B</text>
+    <circle cx="640" cy="173" r="5" fill="#b91c1c"/>
+
+    <!-- Agent C: medium -->
+    <circle cx="744" cy="180" r="22" fill="#FEF2F2" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="744" y="184" text-anchor="middle" font-size="11" fill="#1a1a1a">C</text>
+    <circle cx="755" cy="172" r="7" fill="#b91c1c"/>
+
+    <!-- Agent D: larger -->
+    <circle cx="655" cy="240" r="22" fill="#FEF2F2" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="655" y="244" text-anchor="middle" font-size="11" fill="#1a1a1a">D</text>
+    <circle cx="667" cy="232" r="9" fill="#b91c1c"/>
+
+    <!-- Agent E: largest -->
+    <circle cx="719" cy="240" r="22" fill="#FEF2F2" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="719" y="244" text-anchor="middle" font-size="11" fill="#1a1a1a">E</text>
+    <circle cx="731" cy="232" r="11" fill="#b91c1c"/>
+
+    <!-- Amplification number -->
+    <text x="687" y="345" text-anchor="middle" font-size="38" font-weight="500" fill="#b91c1c" font-family="Fraunces, Georgia, serif">17.2x</text>
+    <text x="687" y="370" text-anchor="middle" font-size="11" fill="#6b6b6b">error compounds across nodes</text>
+  </g>
+
+  <!-- Bottom caption -->
+  <rect x="60" y="402" width="700" height="40" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1" rx="3"/>
+  <text x="410" y="426" text-anchor="middle" font-size="12" fill="#374151" font-style="italic" font-family="Fraunces, Georgia, serif">Hierarchical orchestration with a verifier kept amplification under 2x. Unstructured peer-to-peer networks did not.</text>
+
+</svg>

--- a/public/assets/diagrams/observe-think-act.svg
+++ b/public/assets/diagrams/observe-think-act.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="450" viewBox="0 0 500 450" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arr-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="500" height="450" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="250" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">The Observe-Think-Act Loop</text>
+  <line x1="40" y1="42" x2="460" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Center label -->
+  <circle cx="250" cy="248" r="46" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="2"/>
+  <text x="250" y="244" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">Agent</text>
+  <text x="250" y="260" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">Loop</text>
+
+  <!-- TOP: OBSERVE -->
+  <rect x="130" y="60" width="240" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
+  <text x="250" y="86" text-anchor="middle" font-size="15" font-weight="bold" fill="#1D4ED8">OBSERVE</text>
+  <text x="250" y="104" text-anchor="middle" font-size="11" fill="#6B7280">Read context and tool results</text>
+  <text x="250" y="120" text-anchor="middle" font-size="11" fill="#6B7280">from previous step</text>
+
+  <!-- BOTTOM-RIGHT: THINK -->
+  <rect x="300" y="304" width="172" height="72" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="2"/>
+  <text x="386" y="330" text-anchor="middle" font-size="15" font-weight="bold" fill="#92400E">THINK</text>
+  <text x="386" y="348" text-anchor="middle" font-size="11" fill="#6B7280">Model reasons over</text>
+  <text x="386" y="364" text-anchor="middle" font-size="11" fill="#6B7280">accumulated evidence</text>
+
+  <!-- BOTTOM-LEFT: ACT -->
+  <rect x="28" y="304" width="172" height="72" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="114" y="330" text-anchor="middle" font-size="15" font-weight="bold" fill="#B91C1C">ACT</text>
+  <text x="114" y="348" text-anchor="middle" font-size="11" fill="#6B7280">Call tool or produce</text>
+  <text x="114" y="364" text-anchor="middle" font-size="11" fill="#6B7280">final answer</text>
+
+  <!-- Arrow: OBSERVE → THINK (top-center down-right) -->
+  <path d="M340,132 Q420,200 420,302" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="408" y="218" font-size="11" fill="#6B7280" text-anchor="start">LLM call</text>
+
+  <!-- Arrow: THINK → ACT (bottom-right to bottom-left) -->
+  <line x1="298" y1="342" x2="202" y2="342" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="250" y="334" text-anchor="middle" font-size="11" fill="#6B7280">tool call</text>
+
+  <!-- Arrow: ACT → OBSERVE (bottom-left back up to top-center) -->
+  <path d="M80,302 Q80,200 160,132" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="55" y="218" font-size="11" fill="#6B7280" text-anchor="middle">result</text>
+  <text x="55" y="232" font-size="11" fill="#6B7280" text-anchor="middle">in context</text>
+
+  <!-- STOP exit arrow from ACT -->
+  <line x1="114" y1="376" x2="114" y2="416" stroke="#10B981" stroke-width="2" marker-end="url(#arr-green)"/>
+  <rect x="50" y="416" width="130" height="28" rx="6" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="115" y="434" text-anchor="middle" font-size="12" font-weight="bold" fill="#065F46">Final Answer</text>
+  <text x="30" y="398" font-size="10" fill="#10B981">answer ready</text>
+
+  <!-- Budget exhausted note -->
+  <text x="250" y="434" text-anchor="middle" font-size="10" fill="#9CA3AF">Loop exits when answer ready or step budget exhausted</text>
+</svg>

--- a/public/assets/diagrams/poisoning-attack-flow.svg
+++ b/public/assets/diagrams/poisoning-attack-flow.svg
@@ -1,0 +1,132 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="440" viewBox="0 0 800 440" font-family="'IBM Plex Sans', sans-serif">
+  <defs>
+    <marker id="arr-p-dk" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1a3a5c"/>
+    </marker>
+    <marker id="arr-p-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#dc2626"/>
+    </marker>
+    <marker id="arr-p-grn" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#059669"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="440" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="34" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a1a">Memory Poisoning Attack — Injection and Retrieval</text>
+  <line x1="80" y1="48" x2="720" y2="48" stroke="#7eb3d8" stroke-width="1"/>
+
+  <!-- ═══ PHASE 1: ATTACK (top row) ═══ -->
+  <text x="60" y="78" font-size="12" font-weight="bold" fill="#dc2626" letter-spacing="1">PHASE 1: POISONING</text>
+
+  <!-- Attacker -->
+  <rect x="40" y="92" width="130" height="56" rx="8" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
+  <text x="105" y="116" text-anchor="middle" font-size="13" font-weight="bold" fill="#991b1b">Attacker</text>
+  <text x="105" y="132" text-anchor="middle" font-size="10" fill="#6b7280">Crafted query</text>
+
+  <!-- Arrow: Attacker → Agent -->
+  <line x1="170" y1="120" x2="218" y2="120" stroke="#dc2626" stroke-width="2" marker-end="url(#arr-p-red)"/>
+
+  <!-- Agent processes -->
+  <rect x="220" y="92" width="140" height="56" rx="8" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="290" y="116" text-anchor="middle" font-size="13" font-weight="bold" fill="#1a3a5c">Agent</text>
+  <text x="290" y="132" text-anchor="middle" font-size="10" fill="#6b7280">Processes query</text>
+
+  <!-- Arrow: Agent → False correction -->
+  <line x1="360" y1="120" x2="408" y2="120" stroke="#dc2626" stroke-width="2" marker-end="url(#arr-p-red)"/>
+
+  <!-- False correction -->
+  <rect x="410" y="88" width="180" height="64" rx="8" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
+  <text x="500" y="112" text-anchor="middle" font-size="12" font-weight="bold" fill="#991b1b">False Correction</text>
+  <text x="500" y="128" text-anchor="middle" font-size="10" font-family="'IBM Plex Mono', monospace" fill="#1a1a1a">"SLA is 99.0%"</text>
+  <text x="500" y="142" text-anchor="middle" font-size="10" fill="#6b7280">(actual: 99.9%)</text>
+
+  <!-- Arrow: False correction → Memory -->
+  <line x1="590" y1="120" x2="628" y2="120" stroke="#dc2626" stroke-width="2" marker-end="url(#arr-p-red)"/>
+
+  <!-- Memory store -->
+  <rect x="630" y="92" width="130" height="56" rx="8" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="695" y="112" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a3a5c">Memory Store</text>
+  <text x="695" y="130" text-anchor="middle" font-size="10" fill="#dc2626" font-weight="bold">Poisoned!</text>
+
+  <!-- Divider -->
+  <line x1="40" y1="170" x2="760" y2="170" stroke="#e8f0f7" stroke-width="2" stroke-dasharray="8,4"/>
+
+  <!-- ═══ PHASE 2: EXPLOITATION (middle row) ═══ -->
+  <text x="60" y="196" font-size="12" font-weight="bold" fill="#1a3a5c" letter-spacing="1">PHASE 2: EXPLOITATION</text>
+
+  <!-- Legitimate user -->
+  <rect x="40" y="210" width="130" height="56" rx="8" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="105" y="234" text-anchor="middle" font-size="13" font-weight="bold" fill="#1a3a5c">Legit User</text>
+  <text x="105" y="250" text-anchor="middle" font-size="10" fill="#6b7280">"What is our SLA?"</text>
+
+  <!-- Arrow: User → Agent -->
+  <line x1="170" y1="238" x2="218" y2="238" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-p-dk)"/>
+
+  <!-- Agent -->
+  <rect x="220" y="210" width="140" height="56" rx="8" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="290" y="234" text-anchor="middle" font-size="13" font-weight="bold" fill="#1a3a5c">Agent</text>
+  <text x="290" y="250" text-anchor="middle" font-size="10" fill="#6b7280">Retrieves context</text>
+
+  <!-- Arrow: Agent → Memory -->
+  <line x1="360" y1="238" x2="500" y2="238" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-p-dk)"/>
+  <text x="430" y="232" text-anchor="middle" font-size="10" fill="#6b7280">query memory</text>
+
+  <!-- Memory returns poison -->
+  <rect x="502" y="210" width="160" height="56" rx="8" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
+  <text x="582" y="230" text-anchor="middle" font-size="12" font-weight="bold" fill="#991b1b">Poisoned Memory</text>
+  <text x="582" y="248" text-anchor="middle" font-size="10" font-family="'IBM Plex Mono', monospace" fill="#1a1a1a">"SLA is 99.0%"</text>
+  <text x="582" y="260" text-anchor="middle" font-size="10" fill="#dc2626">trusted as correction</text>
+
+  <!-- Arrow: Memory → Wrong answer -->
+  <line x1="662" y1="238" x2="695" y2="238" stroke="#dc2626" stroke-width="2" marker-end="url(#arr-p-red)"/>
+
+  <!-- Wrong answer -->
+  <rect x="697" y="214" width="80" height="48" rx="8" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
+  <text x="737" y="236" text-anchor="middle" font-size="11" font-weight="bold" fill="#991b1b">Wrong</text>
+  <text x="737" y="250" text-anchor="middle" font-size="11" font-weight="bold" fill="#991b1b">Answer</text>
+
+  <!-- Divider -->
+  <line x1="40" y1="286" x2="760" y2="286" stroke="#e8f0f7" stroke-width="2" stroke-dasharray="8,4"/>
+
+  <!-- ═══ DEFENSE LAYER ═══ -->
+  <text x="60" y="312" font-size="12" font-weight="bold" fill="#059669" letter-spacing="1">DEFENSE: MEMORY VALIDATOR</text>
+
+  <!-- Replayed attack path with defense -->
+  <rect x="40" y="326" width="130" height="50" rx="8" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="105" y="348" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a3a5c">Agent</text>
+  <text x="105" y="362" text-anchor="middle" font-size="10" fill="#6b7280">Wants to store</text>
+
+  <!-- Arrow to validator -->
+  <line x1="170" y1="351" x2="228" y2="351" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-p-dk)"/>
+
+  <!-- MemoryValidator -->
+  <rect x="230" y="322" width="200" height="58" rx="8" fill="#f0fdf4" stroke="#059669" stroke-width="2"/>
+  <text x="330" y="344" text-anchor="middle" font-size="13" font-weight="bold" fill="#065f46">MemoryValidator</text>
+  <text x="330" y="360" text-anchor="middle" font-size="10" fill="#6b7280">Cross-checks against evidence</text>
+  <text x="330" y="374" text-anchor="middle" font-size="10" font-family="'IBM Plex Mono', monospace" fill="#059669">validate(correction, sources)</text>
+
+  <!-- Arrow: Validator rejects -->
+  <line x1="430" y1="340" x2="488" y2="340" stroke="#dc2626" stroke-width="2" marker-end="url(#arr-p-red)"/>
+
+  <!-- Rejected -->
+  <rect x="490" y="326" width="120" height="50" rx="8" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
+  <text x="550" y="348" text-anchor="middle" font-size="12" font-weight="bold" fill="#991b1b">REJECTED</text>
+  <text x="550" y="362" text-anchor="middle" font-size="10" fill="#6b7280">No evidence match</text>
+
+  <!-- Arrow: Validator passes -->
+  <line x1="430" y1="362" x2="488" y2="380" stroke="#059669" stroke-width="2" marker-end="url(#arr-p-grn)"/>
+
+  <!-- Accepted -->
+  <rect x="490" y="376" width="120" height="40" rx="8" fill="#f0fdf4" stroke="#059669" stroke-width="2"/>
+  <text x="550" y="400" text-anchor="middle" font-size="12" font-weight="bold" fill="#065f46">ACCEPTED</text>
+
+  <!-- Arrow: Accepted → Memory -->
+  <line x1="610" y1="396" x2="648" y2="396" stroke="#059669" stroke-width="1.5" marker-end="url(#arr-p-grn)"/>
+
+  <!-- Memory store (clean) -->
+  <rect x="650" y="376" width="110" height="40" rx="8" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="705" y="400" text-anchor="middle" font-size="11" font-weight="bold" fill="#1a3a5c">Memory</text>
+</svg>

--- a/public/assets/diagrams/risk-tier-matrix.svg
+++ b/public/assets/diagrams/risk-tier-matrix.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400" font-family="Arial, Helvetica, sans-serif">
+  <!-- Background -->
+  <rect width="600" height="400" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="300" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Risk Tier vs. Confidence Matrix</text>
+  <line x1="60" y1="42" x2="540" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- ===== Matrix area: x=80..540, y=60..320 ===== -->
+
+  <!-- Zone 1: Low Risk + Low Conf = yellow (review recommended) -->
+  <rect x="80" y="220" width="230" height="100" rx="0" fill="#FEF9C3" stroke="none"/>
+  <!-- Zone 2: Low Risk + High Conf = green (auto-approve) -->
+  <rect x="310" y="220" width="230" height="100" rx="0" fill="#D1FAE5" stroke="none"/>
+  <!-- Zone 3: Medium Risk + Low Conf = orange-yellow (review recommended) -->
+  <rect x="80" y="150" width="230" height="70" rx="0" fill="#FEF3C7" stroke="none"/>
+  <!-- Zone 4: Medium Risk + High Conf = light green (review recommended) -->
+  <rect x="310" y="150" width="230" height="70" rx="0" fill="#ECFDF5" stroke="none"/>
+  <!-- Zone 5: High Risk + Low Conf = red (human required) -->
+  <rect x="80" y="100" width="230" height="50" rx="0" fill="#FEE2E2" stroke="none"/>
+  <!-- Zone 6: High Risk + High Conf = orange (human required) -->
+  <rect x="310" y="100" width="230" height="50" rx="0" fill="#FFEDD5" stroke="none"/>
+  <!-- Zone 7: Critical Risk (full width) = dark red (always escalate) -->
+  <rect x="80" y="60" width="460" height="40" rx="0" fill="#991B1B" stroke="none"/>
+
+  <!-- Matrix outer border -->
+  <rect x="80" y="60" width="460" height="260" fill="none" stroke="#374151" stroke-width="2"/>
+
+  <!-- Vertical divider (Low/High confidence split at x=310) -->
+  <line x1="310" y1="60" x2="310" y2="320" stroke="#374151" stroke-width="1.5" stroke-dasharray="4,3"/>
+
+  <!-- Horizontal dividers -->
+  <!-- Critical / High at y=100 -->
+  <line x1="80" y1="100" x2="540" y2="100" stroke="#374151" stroke-width="1.5"/>
+  <!-- High / Medium at y=150 -->
+  <line x1="80" y1="150" x2="540" y2="150" stroke="#374151" stroke-width="1" stroke-dasharray="4,3"/>
+  <!-- Medium / Low at y=220 -->
+  <line x1="80" y1="220" x2="540" y2="220" stroke="#374151" stroke-width="1" stroke-dasharray="4,3"/>
+
+  <!-- Zone labels -->
+  <!-- Critical row -->
+  <text x="310" y="78" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">Critical — Always Escalate (regardless of confidence)</text>
+
+  <!-- High Risk + Low Conf -->
+  <text x="195" y="122" text-anchor="middle" font-size="11" font-weight="bold" fill="#991B1B">Human Required</text>
+  <text x="195" y="137" text-anchor="middle" font-size="10" fill="#6B7280">high risk, low confidence</text>
+
+  <!-- High Risk + High Conf -->
+  <text x="425" y="122" text-anchor="middle" font-size="11" font-weight="bold" fill="#C2410C">Human Required</text>
+  <text x="425" y="137" text-anchor="middle" font-size="10" fill="#6B7280">high risk (always review)</text>
+
+  <!-- Medium Risk + Low Conf -->
+  <text x="195" y="183" text-anchor="middle" font-size="11" font-weight="bold" fill="#B45309">Review Recommended</text>
+  <text x="195" y="198" text-anchor="middle" font-size="10" fill="#6B7280">medium risk, low confidence</text>
+
+  <!-- Medium Risk + High Conf -->
+  <text x="425" y="183" text-anchor="middle" font-size="11" font-weight="bold" fill="#065F46">Review Recommended</text>
+  <text x="425" y="198" text-anchor="middle" font-size="10" fill="#6B7280">monitor escalation rate</text>
+
+  <!-- Low Risk + Low Conf -->
+  <text x="195" y="258" text-anchor="middle" font-size="11" font-weight="bold" fill="#B45309">Review Recommended</text>
+  <text x="195" y="273" text-anchor="middle" font-size="10" fill="#6B7280">confidence below threshold</text>
+
+  <!-- Low Risk + High Conf -->
+  <text x="425" y="258" text-anchor="middle" font-size="12" font-weight="bold" fill="#065F46">Auto-Approve</text>
+  <text x="425" y="273" text-anchor="middle" font-size="10" fill="#6B7280">low risk, high confidence</text>
+
+  <!-- X-axis label -->
+  <text x="310" y="345" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">Confidence</text>
+  <!-- X-axis tick labels -->
+  <text x="100" y="338" text-anchor="middle" font-size="11" fill="#6B7280">Low</text>
+  <text x="310" y="338" text-anchor="middle" font-size="11" fill="#6B7280">Threshold</text>
+  <text x="530" y="338" text-anchor="middle" font-size="11" fill="#6B7280">High</text>
+  <!-- X-axis arrow -->
+  <line x1="80" y1="330" x2="535" y2="330" stroke="#374151" stroke-width="1.5"/>
+  <polygon points="535,326 545,330 535,334" fill="#374151"/>
+
+  <!-- Y-axis label -->
+  <text x="30" y="190" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151" transform="rotate(-90 30 190)">Risk Level</text>
+  <!-- Y-axis tick labels -->
+  <text x="68" y="323" text-anchor="end" font-size="11" fill="#6B7280">Low</text>
+  <text x="68" y="230" text-anchor="end" font-size="11" fill="#6B7280">Med</text>
+  <text x="68" y="155" text-anchor="end" font-size="11" fill="#6B7280">High</text>
+  <text x="68" y="80" text-anchor="end" font-size="11" fill="#991B1B">Critical</text>
+  <!-- Y-axis arrow -->
+  <line x1="72" y1="325" x2="72" y2="63" stroke="#374151" stroke-width="1.5"/>
+  <polygon points="68,63 72,53 76,63" fill="#374151"/>
+
+  <!-- Legend -->
+  <rect x="80" y="356" width="460" height="34" rx="8" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1"/>
+  <rect x="96" y="366" width="14" height="14" rx="2" fill="#D1FAE5" stroke="#10B981" stroke-width="1"/>
+  <text x="115" y="377" font-size="10" fill="#065F46">Auto-Approve</text>
+  <rect x="196" y="366" width="14" height="14" rx="2" fill="#FEF9C3" stroke="#F59E0B" stroke-width="1"/>
+  <text x="215" y="377" font-size="10" fill="#B45309">Review Recommended</text>
+  <rect x="336" y="366" width="14" height="14" rx="2" fill="#FEE2E2" stroke="#EF4444" stroke-width="1"/>
+  <text x="355" y="377" font-size="10" fill="#991B1B">Human Required</text>
+  <rect x="456" y="366" width="14" height="14" rx="2" fill="#991B1B" stroke="#7F1D1D" stroke-width="1"/>
+  <text x="475" y="377" font-size="10" fill="#991B1B">Always Escalate</text>
+</svg>

--- a/public/assets/diagrams/shared-memory-scopes.svg
+++ b/public/assets/diagrams/shared-memory-scopes.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="480" viewBox="0 0 800 480" font-family="'IBM Plex Sans', sans-serif">
+  <defs>
+    <marker id="arr-s-dk" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1a3a5c"/>
+    </marker>
+    <marker id="arr-s-md" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#3d7ab5"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="480" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="34" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a1a">Shared Memory Scopes — Access Control</text>
+  <line x1="100" y1="48" x2="700" y2="48" stroke="#7eb3d8" stroke-width="1"/>
+
+  <!-- ═══ GLOBAL SCOPE (outermost) ═══ -->
+  <rect x="40" y="60" width="720" height="340" rx="14" fill="#e8f0f7" stroke="#7eb3d8" stroke-width="2"/>
+  <text x="70" y="82" font-size="11" font-weight="bold" fill="#3d7ab5" letter-spacing="1">GLOBAL SCOPE</text>
+  <text x="400" y="82" text-anchor="middle" font-size="12" fill="#6b7280">All agents can read. Only admin writes.</text>
+
+  <!-- Global content examples -->
+  <rect x="540" y="90" width="190" height="56" rx="6" fill="#ffffff" stroke="#7eb3d8" stroke-width="1.5"/>
+  <text x="635" y="112" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a3a5c">Global Facts</text>
+  <text x="635" y="128" text-anchor="middle" font-size="10" font-family="'IBM Plex Mono', monospace" fill="#6b7280">company_policies, holidays</text>
+  <text x="635" y="140" text-anchor="middle" font-size="10" fill="#6b7280">R: all agents | W: admin</text>
+
+  <!-- ═══ TEAM SCOPE (middle) ═══ -->
+  <rect x="80" y="100" width="440" height="280" rx="12" fill="#ffffff" stroke="#3d7ab5" stroke-width="2"/>
+  <text x="110" y="122" font-size="11" font-weight="bold" fill="#1a3a5c" letter-spacing="1">TEAM SCOPE</text>
+  <text x="300" y="122" text-anchor="middle" font-size="12" fill="#6b7280">Pipeline agents can read/write.</text>
+
+  <!-- Team content -->
+  <rect x="340" y="134" width="160" height="50" rx="6" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.5"/>
+  <text x="420" y="154" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a3a5c">Team Knowledge</text>
+  <text x="420" y="170" text-anchor="middle" font-size="10" font-family="'IBM Plex Mono', monospace" fill="#6b7280">shared_corrections</text>
+  <text x="420" y="180" text-anchor="middle" font-size="10" fill="#6b7280">R/W: pipeline agents</text>
+
+  <!-- ═══ AGENT SCOPES (innermost) ═══ -->
+  <!-- Agent A -->
+  <rect x="110" y="150" width="180" height="210" rx="10" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="134" y="172" font-size="11" font-weight="bold" fill="#1a3a5c" letter-spacing="1">AGENT SCOPE</text>
+  <text x="200" y="194" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">Agent A</text>
+  <text x="200" y="210" text-anchor="middle" font-size="11" fill="#6b7280">Retriever</text>
+
+  <!-- Agent A private memory -->
+  <rect x="126" y="222" width="148" height="44" rx="6" fill="#ffffff" stroke="#1a3a5c" stroke-width="1.5"/>
+  <text x="200" y="240" text-anchor="middle" font-size="11" font-weight="bold" fill="#1a3a5c">Private Memory</text>
+  <text x="200" y="256" text-anchor="middle" font-size="10" font-family="'IBM Plex Mono', monospace" fill="#6b7280">query_cache, prefs</text>
+
+  <!-- Agent A access label -->
+  <text x="200" y="284" text-anchor="middle" font-size="10" fill="#6b7280">R/W: self only</text>
+
+  <!-- Agent A write arrow to team -->
+  <line x1="290" y1="244" x2="338" y2="160" stroke="#3d7ab5" stroke-width="1.5" marker-end="url(#arr-s-md)"/>
+  <text x="326" y="210" font-size="9" fill="#3d7ab5" font-weight="bold">write</text>
+
+  <!-- Agent B -->
+  <rect x="340" y="200" width="160" height="160" rx="10" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="364" y="222" font-size="11" font-weight="bold" fill="#1a3a5c" letter-spacing="1">AGENT SCOPE</text>
+  <text x="420" y="242" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">Agent B</text>
+  <text x="420" y="258" text-anchor="middle" font-size="11" fill="#6b7280">Reasoner</text>
+
+  <!-- Agent B private memory -->
+  <rect x="356" y="268" width="128" height="44" rx="6" fill="#ffffff" stroke="#1a3a5c" stroke-width="1.5"/>
+  <text x="420" y="286" text-anchor="middle" font-size="11" font-weight="bold" fill="#1a3a5c">Private Memory</text>
+  <text x="420" y="302" text-anchor="middle" font-size="10" font-family="'IBM Plex Mono', monospace" fill="#6b7280">reasoning_log</text>
+
+  <!-- Agent B read from team -->
+  <line x1="420" y1="200" x2="420" y2="186" stroke="#1a3a5c" stroke-width="1.5" marker-end="url(#arr-s-dk)"/>
+  <text x="434" y="196" font-size="9" fill="#1a3a5c" font-weight="bold">read</text>
+
+  <!-- Agent B read from global -->
+  <path d="M 500 300 Q 540 300 540 160 Q 540 110 540 100" fill="none" stroke="#7eb3d8" stroke-width="1.5" marker-end="url(#arr-s-dk)"/>
+  <text x="548" y="200" font-size="9" fill="#7eb3d8" font-weight="bold">read</text>
+
+  <!-- ═══ OPTIMISTIC CONCURRENCY ═══ -->
+  <rect x="40" y="410" width="720" height="56" rx="8" fill="#f9fafb" stroke="#e8f0f7" stroke-width="1.5"/>
+  <text x="70" y="432" font-size="12" font-weight="bold" fill="#1a3a5c">Optimistic Concurrency</text>
+  <text x="70" y="450" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#1a1a1a">write(key, value, v1)</text>
+  <line x1="240" y1="445" x2="290" y2="445" stroke="#1a3a5c" stroke-width="1.5" marker-end="url(#arr-s-dk)"/>
+  <text x="310" y="450" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#1a1a1a">check_version(v1)</text>
+  <line x1="440" y1="445" x2="490" y2="445" stroke="#1a3a5c" stroke-width="1.5" marker-end="url(#arr-s-dk)"/>
+  <text x="510" y="450" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#1a1a1a">update(key, value, v2)</text>
+  <text x="510" y="432" font-size="10" fill="#6b7280">If v1 matches current, commit. Otherwise retry.</text>
+</svg>

--- a/public/assets/diagrams/single-turn-ceiling.svg
+++ b/public/assets/diagrams/single-turn-ceiling.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="300" viewBox="0 0 720 300" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arr-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#22c55e"/>
+    </marker>
+    <marker id="arr-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#EF4444"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="720" height="300" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="360" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">The Single-Turn Ceiling</text>
+  <line x1="40" y1="42" x2="680" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Subtitle -->
+  <text x="360" y="62" text-anchor="middle" font-size="12" fill="#6B7280">Tool-using LLM calls are powerful. But they hit a hard limit: one turn, one result, no iteration.</text>
+
+  <!-- Flow: left to right -->
+  <!-- Step 1: User Query -->
+  <rect x="30" y="90" width="110" height="60" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="85" y="115" text-anchor="middle" font-size="12" font-weight="bold" fill="#1D4ED8">User Query</text>
+  <text x="85" y="132" text-anchor="middle" font-size="10" fill="#6B7280">"Research and</text>
+  <text x="85" y="144" text-anchor="middle" font-size="10" fill="#6B7280">summarize X"</text>
+
+  <!-- Arrow -->
+  <line x1="141" y1="120" x2="168" y2="120" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Step 2: Model -->
+  <rect x="170" y="90" width="100" height="60" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="220" y="118" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">Model</text>
+  <text x="220" y="135" text-anchor="middle" font-size="10" fill="#6B7280">picks a tool</text>
+  <text x="220" y="148" text-anchor="middle" font-size="10" fill="#6B7280">to call</text>
+
+  <!-- Arrow -->
+  <line x1="271" y1="120" x2="298" y2="120" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Step 3: Tool Call -->
+  <rect x="300" y="90" width="100" height="60" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+  <text x="350" y="118" text-anchor="middle" font-size="12" font-weight="bold" fill="#5B21B6">Tool Call</text>
+  <text x="350" y="135" text-anchor="middle" font-size="10" fill="#6B7280">search()</text>
+  <text x="350" y="148" text-anchor="middle" font-size="10" fill="#6B7280">executed</text>
+
+  <!-- Arrow -->
+  <line x1="401" y1="120" x2="428" y2="120" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Step 4: Result -->
+  <rect x="430" y="90" width="100" height="60" rx="8" fill="#F0FDF4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="480" y="118" text-anchor="middle" font-size="12" font-weight="bold" fill="#15803D">Result</text>
+  <text x="480" y="135" text-anchor="middle" font-size="10" fill="#6B7280">returned to</text>
+  <text x="480" y="148" text-anchor="middle" font-size="10" fill="#6B7280">model once</text>
+
+  <!-- Arrow pointing to wall -->
+  <line x1="531" y1="120" x2="556" y2="120" stroke="#EF4444" stroke-width="1.5" marker-end="url(#arr-red)"/>
+
+  <!-- THE WALL -->
+  <rect x="558" y="72" width="18" height="114" rx="2" fill="#EF4444" opacity="0.85"/>
+  <!-- Wall hatch marks -->
+  <line x1="558" y1="82" x2="576" y2="96" stroke="#B91C1C" stroke-width="1.5"/>
+  <line x1="558" y1="100" x2="576" y2="114" stroke="#B91C1C" stroke-width="1.5"/>
+  <line x1="558" y1="118" x2="576" y2="132" stroke="#B91C1C" stroke-width="1.5"/>
+  <line x1="558" y1="136" x2="576" y2="150" stroke="#B91C1C" stroke-width="1.5"/>
+  <line x1="558" y1="154" x2="576" y2="168" stroke="#B91C1C" stroke-width="1.5"/>
+
+  <!-- Wall label -->
+  <text x="567" y="198" text-anchor="middle" font-size="10" font-weight="bold" fill="#B91C1C" transform="rotate(90, 567, 198)">CAN'T ITERATE</text>
+
+  <!-- What's blocked (faded, past the wall) -->
+  <rect x="590" y="90" width="100" height="60" rx="8" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.5"/>
+  <text x="640" y="115" text-anchor="middle" font-size="11" fill="#9CA3AF" opacity="0.6">Another</text>
+  <text x="640" y="130" text-anchor="middle" font-size="11" fill="#9CA3AF" opacity="0.6">search?</text>
+  <text x="640" y="145" text-anchor="middle" font-size="11" fill="#9CA3AF" opacity="0.6">Retry?</text>
+  <!-- X through blocked box -->
+  <line x1="592" y1="92" x2="688" y2="148" stroke="#EF4444" stroke-width="2" opacity="0.5"/>
+  <line x1="688" y1="92" x2="592" y2="148" stroke="#EF4444" stroke-width="2" opacity="0.5"/>
+
+  <!-- Arrow pointing right past wall (agents start here) -->
+  <path d="M680,120 L700,120" stroke="#22c55e" stroke-width="2" stroke-dasharray="3,2"/>
+
+  <!-- Arrow from bottom of flow pointing forward -->
+  <text x="640" y="168" text-anchor="middle" font-size="11" font-weight="bold" fill="#22c55e">Agents start here</text>
+  <line x1="580" y1="176" x2="700" y2="176" stroke="#22c55e" stroke-width="2" marker-end="url(#arr-green)"/>
+  <text x="640" y="196" text-anchor="middle" font-size="10" fill="#15803D">loop · retry · branch · decide</text>
+
+  <!-- Labels below flow -->
+  <text x="85" y="168" text-anchor="middle" font-size="10" fill="#6B7280">input</text>
+  <text x="220" y="168" text-anchor="middle" font-size="10" fill="#6B7280">reason</text>
+  <text x="350" y="168" text-anchor="middle" font-size="10" fill="#6B7280">act</text>
+  <text x="480" y="168" text-anchor="middle" font-size="10" fill="#6B7280">observe</text>
+
+  <!-- What single-turn can't do -->
+  <rect x="30" y="220" width="500" height="58" rx="6" fill="#FEF2F2" stroke="#FCA5A5" stroke-width="1"/>
+  <text x="40" y="240" font-size="11" font-weight="bold" fill="#B91C1C">Single-turn tool use cannot:</text>
+  <text x="40" y="258" font-size="11" fill="#374151">  - Search, read results, decide to search again with a refined query</text>
+  <text x="40" y="272" font-size="11" fill="#374151">  - Handle errors by retrying with different parameters</text>
+
+  <!-- Caption -->
+  <text x="360" y="292" text-anchor="middle" font-size="11" fill="#9CA3AF">Iteration is the core capability agents add. Everything else follows from that.</text>
+</svg>

--- a/public/assets/diagrams/single-vs-multi-agent.svg
+++ b/public/assets/diagrams/single-vs-multi-agent.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="560" viewBox="0 0 800 560" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+    <marker id="arrowhead-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#EF4444"/>
+    </marker>
+    <marker id="arrowhead-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="560" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="36" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Single-Agent vs. Multi-Agent Architecture</text>
+  <line x1="100" y1="48" x2="700" y2="48" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- ===== LEFT PANEL: Single Agent ===== -->
+  <rect x="20" y="62" width="360" height="474" rx="12" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1.5"/>
+  <text x="200" y="88" text-anchor="middle" font-size="15" font-weight="bold" fill="#374151">Single Agent</text>
+
+  <!-- Query -->
+  <rect x="110" y="104" width="180" height="44" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="200" y="122" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">Query</text>
+  <text x="200" y="138" text-anchor="middle" font-size="11" fill="#6B7280">user request</text>
+
+  <!-- Arrow -->
+  <line x1="200" y1="148" x2="200" y2="176" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Retrieve -->
+  <rect x="110" y="176" width="180" height="44" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="200" y="198" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">Retrieve</text>
+  <text x="200" y="213" text-anchor="middle" font-size="11" fill="#6B7280">vector search</text>
+
+  <!-- Arrow -->
+  <line x1="200" y1="220" x2="200" y2="248" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Reason -->
+  <rect x="110" y="248" width="180" height="44" rx="8" fill="#ffffff" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="200" y="270" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">Reason</text>
+  <text x="200" y="285" text-anchor="middle" font-size="11" fill="#6B7280">LLM chain-of-thought</text>
+
+  <!-- Arrow -->
+  <line x1="200" y1="292" x2="200" y2="320" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Answer -->
+  <rect x="110" y="320" width="180" height="44" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="200" y="342" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Answer</text>
+  <text x="200" y="358" text-anchor="middle" font-size="11" fill="#6B7280">direct output</text>
+
+  <!-- Overhead label -->
+  <rect x="70" y="398" width="260" height="52" rx="8" fill="#FFF7ED" stroke="#F59E0B" stroke-width="1"/>
+  <text x="200" y="420" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">Overhead: Low</text>
+  <text x="200" y="437" text-anchor="middle" font-size="11" fill="#6B7280">1 model call · no coordination</text>
+  <text x="200" y="452" text-anchor="middle" font-size="11" fill="#6B7280">fast · no verification step</text>
+
+  <!-- Divider -->
+  <line x1="400" y1="68" x2="400" y2="530" stroke="#D1D5DB" stroke-width="2" stroke-dasharray="6,4"/>
+
+  <!-- ===== RIGHT PANEL: Multi-Agent ===== -->
+  <rect x="420" y="62" width="360" height="474" rx="12" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1.5"/>
+  <text x="600" y="88" text-anchor="middle" font-size="15" font-weight="bold" fill="#374151">Multi-Agent</text>
+
+  <!-- Query -->
+  <rect x="510" y="104" width="180" height="44" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="600" y="122" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">Query</text>
+  <text x="600" y="138" text-anchor="middle" font-size="11" fill="#6B7280">user request</text>
+
+  <!-- Arrow -->
+  <line x1="600" y1="148" x2="600" y2="176" stroke="#2563EB" stroke-width="1.5" marker-end="url(#arrowhead-blue)"/>
+
+  <!-- Coordinator -->
+  <rect x="510" y="176" width="180" height="44" rx="8" fill="#1D4ED8" stroke="#1E40AF" stroke-width="1.5"/>
+  <text x="600" y="198" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">Coordinator</text>
+  <text x="600" y="213" text-anchor="middle" font-size="11" fill="#BFDBFE">plans · dispatches</text>
+
+  <!-- Arrow -->
+  <line x1="600" y1="220" x2="600" y2="248" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Retriever -->
+  <rect x="510" y="248" width="180" height="40" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="600" y="267" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">RetrieverAgent</text>
+  <text x="600" y="282" text-anchor="middle" font-size="11" fill="#6B7280">fetch · rerank</text>
+
+  <!-- Arrow -->
+  <line x1="600" y1="288" x2="600" y2="312" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Reasoner -->
+  <rect x="510" y="312" width="180" height="40" rx="8" fill="#ffffff" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="600" y="331" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">ReasoningAgent</text>
+  <text x="600" y="346" text-anchor="middle" font-size="11" fill="#6B7280">synthesize</text>
+
+  <!-- Arrow -->
+  <line x1="600" y1="352" x2="600" y2="376" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Verifier -->
+  <rect x="510" y="376" width="180" height="40" rx="8" fill="#ffffff" stroke="#10B981" stroke-width="1.5"/>
+  <text x="600" y="395" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">VerifierAgent</text>
+  <text x="600" y="410" text-anchor="middle" font-size="11" fill="#6B7280">fact-check · score</text>
+
+  <!-- Verify loop (dashed back to Reasoner) -->
+  <path d="M 690 396 C 730 396, 730 332, 690 332" fill="none" stroke="#EF4444" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowhead-red)"/>
+  <text x="745" y="368" text-anchor="middle" font-size="10" fill="#EF4444" transform="rotate(90 745 368)">re-reason</text>
+
+  <!-- Arrow: Verifier -> Answer -->
+  <line x1="600" y1="416" x2="600" y2="454" stroke="#10B981" stroke-width="1.5" marker-end="url(#arrowhead-green)"/>
+
+  <!-- Answer -->
+  <rect x="510" y="454" width="180" height="36" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="600" y="472" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Verified Answer</text>
+  <text x="600" y="487" text-anchor="middle" font-size="11" fill="#6B7280">with confidence score</text>
+
+  <!-- Overhead label for multi -->
+  <!-- (placed below answer via the panel bottom section) -->
+  <!-- Bottom comparison bar -->
+  <rect x="40" y="542" width="320" height="4" rx="2" fill="#10B981"/>
+  <text x="200" y="555" text-anchor="middle" font-size="11" fill="#065F46">Lower latency · higher error rate</text>
+
+  <rect x="440" y="542" width="320" height="4" rx="2" fill="#3B82F6"/>
+  <text x="600" y="555" text-anchor="middle" font-size="11" fill="#1D4ED8">Higher overhead · lower error rate</text>
+</svg>

--- a/public/assets/diagrams/state-management.svg
+++ b/public/assets/diagrams/state-management.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="350" viewBox="0 0 700 350" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arr-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="700" height="350" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="350" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Three Types of Agent State</text>
+  <line x1="40" y1="42" x2="660" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Timeline background (conversation span) -->
+  <rect x="28" y="60" width="644" height="180" rx="10" fill="#EFF6FF" stroke="#93C5FD" stroke-width="1.5"/>
+  <text x="48" y="80" font-size="11" font-weight="bold" fill="#2563EB" letter-spacing="1">SESSION STATE — spans the full conversation</text>
+
+  <!-- SessionState inner box -->
+  <rect x="44" y="90" width="612" height="136" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1"/>
+  <text x="350" y="116" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Session State</text>
+  <text x="350" y="134" text-anchor="middle" font-size="11" fill="#6B7280">Conversation history · query-answer pairs · turn count</text>
+  <text x="350" y="152" text-anchor="middle" font-size="11" fill="#6B7280">Persists across all queries in a session</text>
+
+  <!-- TaskState inner box (inside session) -->
+  <!-- Timeline background (task span) -->
+  <rect x="120" y="160" width="460" height="50" rx="8" fill="#FFF7ED" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="350" y="180" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">Task State — spans one query</text>
+  <text x="350" y="198" text-anchor="middle" font-size="11" fill="#6B7280">Steps taken · current result · confidence · budget remaining · complete/over-budget flags</text>
+
+  <!-- Arrow: Session feeds into Task -->
+  <line x1="350" y1="226" x2="350" y2="252" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="362" y="244" font-size="10" fill="#6B7280">new task</text>
+
+  <!-- WorkingMemory box (inside task, narrowest) -->
+  <rect x="200" y="254" width="300" height="54" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="350" y="276" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Working Memory — spans one step</text>
+  <text x="350" y="294" text-anchor="middle" font-size="11" fill="#6B7280">Intermediate results · tool outputs · gathered evidence</text>
+
+  <!-- Span indicators below -->
+  <line x1="28" y1="318" x2="672" y2="318" stroke="#93C5FD" stroke-width="2"/>
+  <text x="350" y="314" text-anchor="middle" font-size="10" fill="#3B82F6">← Session spans full conversation →</text>
+
+  <line x1="120" y1="328" x2="580" y2="328" stroke="#F59E0B" stroke-width="2"/>
+  <text x="350" y="324" text-anchor="middle" font-size="10" fill="#F59E0B">← Task spans one query →</text>
+
+  <line x1="200" y1="338" x2="500" y2="338" stroke="#10B981" stroke-width="2"/>
+  <text x="350" y="348" text-anchor="middle" font-size="10" fill="#10B981">← Working memory: one step →</text>
+</svg>

--- a/public/assets/diagrams/system-architecture.svg
+++ b/public/assets/diagrams/system-architecture.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="580" viewBox="0 0 800 580" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="580" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="36" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Document Intelligence Agent — System Architecture</text>
+  <line x1="100" y1="48" x2="700" y2="48" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- ── Layer 1: Document Layer ── -->
+  <rect x="40" y="66" width="720" height="110" rx="12" fill="#EFF6FF" stroke="#93C5FD" stroke-width="1.5"/>
+  <text x="58" y="86" font-size="12" font-weight="bold" fill="#2563EB" letter-spacing="1">DOCUMENT LAYER</text>
+
+  <!-- Loader -->
+  <rect x="80" y="96" width="160" height="60" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="160" y="122" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Loader</text>
+  <text x="160" y="140" text-anchor="middle" font-size="11" fill="#6B7280">PDF · HTML · Markdown</text>
+
+  <!-- Chunker -->
+  <rect x="320" y="96" width="160" height="60" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="400" y="122" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Chunker</text>
+  <text x="400" y="140" text-anchor="middle" font-size="11" fill="#6B7280">Semantic · Fixed · Sliding</text>
+
+  <!-- Vector Index -->
+  <rect x="560" y="96" width="160" height="60" rx="8" fill="#ffffff" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="640" y="122" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Vector Index</text>
+  <text x="640" y="140" text-anchor="middle" font-size="11" fill="#6B7280">FAISS · Weaviate · pgvector</text>
+
+  <!-- Arrows within Document Layer -->
+  <line x1="240" y1="126" x2="318" y2="126" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="480" y1="126" x2="558" y2="126" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- ── Interlayer Arrow 1→2 ── -->
+  <line x1="400" y1="176" x2="400" y2="202" stroke="#2563EB" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowhead-blue)"/>
+
+  <!-- ── Layer 2: Retrieval Layer ── -->
+  <rect x="40" y="202" width="720" height="110" rx="12" fill="#F0FDF4" stroke="#6EE7B7" stroke-width="1.5"/>
+  <text x="58" y="222" font-size="12" font-weight="bold" fill="#059669" letter-spacing="1">RETRIEVAL LAYER</text>
+
+  <!-- Query Processing -->
+  <rect x="140" y="232" width="190" height="60" rx="8" fill="#ffffff" stroke="#10B981" stroke-width="1.5"/>
+  <text x="235" y="258" text-anchor="middle" font-size="14" font-weight="bold" fill="#065F46">Query Processing</text>
+  <text x="235" y="276" text-anchor="middle" font-size="11" fill="#6B7280">Embed · Expand · Rewrite</text>
+
+  <!-- Similarity Search -->
+  <rect x="470" y="232" width="190" height="60" rx="8" fill="#ffffff" stroke="#10B981" stroke-width="1.5"/>
+  <text x="565" y="258" text-anchor="middle" font-size="14" font-weight="bold" fill="#065F46">Similarity Search</text>
+  <text x="565" y="276" text-anchor="middle" font-size="11" fill="#6B7280">Top-k · MMR · Reranker</text>
+
+  <!-- Arrow within Retrieval -->
+  <line x1="330" y1="262" x2="468" y2="262" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- ── Interlayer Arrow 2→3 ── -->
+  <line x1="400" y1="312" x2="400" y2="338" stroke="#2563EB" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowhead-blue)"/>
+
+  <!-- ── Layer 3: Reasoning Layer ── -->
+  <rect x="40" y="338" width="720" height="110" rx="12" fill="#FFF7ED" stroke="#FCD34D" stroke-width="1.5"/>
+  <text x="58" y="358" font-size="12" font-weight="bold" fill="#B45309" letter-spacing="1">REASONING LAYER</text>
+
+  <!-- Context Pipeline -->
+  <rect x="80" y="368" width="170" height="60" rx="8" fill="#ffffff" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="165" y="394" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Context Pipeline</text>
+  <text x="165" y="412" text-anchor="middle" font-size="11" fill="#6B7280">Assemble · Truncate · Format</text>
+
+  <!-- Model -->
+  <rect x="315" y="368" width="170" height="60" rx="8" fill="#ffffff" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="400" y="394" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Model</text>
+  <text x="400" y="412" text-anchor="middle" font-size="11" fill="#6B7280">GPT-4 · Claude · Gemini</text>
+
+  <!-- Tool Registry -->
+  <rect x="550" y="368" width="170" height="60" rx="8" fill="#ffffff" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="635" y="394" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Tool Registry</text>
+  <text x="635" y="412" text-anchor="middle" font-size="11" fill="#6B7280">Schema · Dispatch · Guard</text>
+
+  <!-- Arrows within Reasoning -->
+  <line x1="250" y1="398" x2="313" y2="398" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="485" y1="398" x2="548" y2="398" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <!-- ── Interlayer Arrow 3→4 ── -->
+  <line x1="400" y1="448" x2="400" y2="474" stroke="#2563EB" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowhead-blue)"/>
+
+  <!-- ── Layer 4: Evaluation Layer ── -->
+  <rect x="40" y="474" width="720" height="88" rx="12" fill="#F5F3FF" stroke="#C4B5FD" stroke-width="1.5"/>
+  <text x="58" y="494" font-size="12" font-weight="bold" fill="#7C3AED" letter-spacing="1">EVALUATION LAYER</text>
+
+  <!-- Eval Harness -->
+  <rect x="80" y="504" width="170" height="46" rx="8" fill="#ffffff" stroke="#8B5CF6" stroke-width="1.5"/>
+  <text x="165" y="523" text-anchor="middle" font-size="14" font-weight="bold" fill="#5B21B6">Eval Harness</text>
+  <text x="165" y="540" text-anchor="middle" font-size="11" fill="#6B7280">Faithfulness · Relevance</text>
+
+  <!-- Tracer -->
+  <rect x="315" y="504" width="170" height="46" rx="8" fill="#ffffff" stroke="#8B5CF6" stroke-width="1.5"/>
+  <text x="400" y="523" text-anchor="middle" font-size="14" font-weight="bold" fill="#5B21B6">Tracer</text>
+  <text x="400" y="540" text-anchor="middle" font-size="11" fill="#6B7280">Spans · Latency · Tokens</text>
+
+  <!-- Cost Profiler -->
+  <rect x="550" y="504" width="170" height="46" rx="8" fill="#ffffff" stroke="#8B5CF6" stroke-width="1.5"/>
+  <text x="635" y="523" text-anchor="middle" font-size="14" font-weight="bold" fill="#5B21B6">Cost Profiler</text>
+  <text x="635" y="540" text-anchor="middle" font-size="11" fill="#6B7280">$ per Query · Budget Gate</text>
+
+  <!-- Layer label on right side -->
+  <text x="775" y="130" text-anchor="middle" font-size="10" fill="#9CA3AF" transform="rotate(90 775 130)">INGEST</text>
+  <text x="775" y="266" text-anchor="middle" font-size="10" fill="#9CA3AF" transform="rotate(90 775 266)">FETCH</text>
+  <text x="775" y="402" text-anchor="middle" font-size="10" fill="#9CA3AF" transform="rotate(90 775 402)">GENERATE</text>
+  <text x="775" y="520" text-anchor="middle" font-size="10" fill="#9CA3AF" transform="rotate(90 775 520)">OBSERVE</text>
+</svg>

--- a/public/assets/diagrams/system-types-spectrum.svg
+++ b/public/assets/diagrams/system-types-spectrum.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="300" viewBox="0 0 800 300" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr-gray" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#9CA3AF"/>
+    </marker>
+    <linearGradient id="spectrumGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#93C5FD;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#EF4444;stop-opacity:0.7"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="300" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Five System Types: The Autonomy Spectrum</text>
+  <line x1="60" y1="42" x2="740" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Gradient bar -->
+  <rect x="60" y="56" width="680" height="10" rx="5" fill="url(#spectrumGrad)"/>
+
+  <!-- Spectrum endpoints -->
+  <text x="60" y="82" text-anchor="middle" font-size="11" fill="#6B7280">Least autonomous</text>
+  <text x="740" y="82" text-anchor="middle" font-size="11" fill="#6B7280">Most autonomous</text>
+
+  <!-- Box 1: LLM App -->
+  <rect x="28" y="92" width="128" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="92" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">LLM App</text>
+  <text x="92" y="130" text-anchor="middle" font-size="10" fill="#6B7280">Single call</text>
+  <text x="92" y="148" text-anchor="middle" font-size="10" fill="#6B7280">No autonomy —</text>
+  <text x="92" y="160" text-anchor="middle" font-size="10" fill="#6B7280">code controls all</text>
+
+  <!-- Arrow 1→2 -->
+  <line x1="157" y1="128" x2="183" y2="128" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+
+  <!-- Box 2: Workflow -->
+  <rect x="184" y="92" width="128" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="248" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">Workflow</text>
+  <text x="248" y="130" text-anchor="middle" font-size="10" fill="#6B7280">Fixed pipeline</text>
+  <text x="248" y="148" text-anchor="middle" font-size="10" fill="#6B7280">Code routes steps —</text>
+  <text x="248" y="160" text-anchor="middle" font-size="10" fill="#6B7280">model executes each</text>
+
+  <!-- Arrow 2→3 -->
+  <line x1="313" y1="128" x2="339" y2="128" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+
+  <!-- Box 3: Tool-Using -->
+  <rect x="340" y="92" width="128" height="72" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="404" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">Tool-Using</text>
+  <text x="404" y="130" text-anchor="middle" font-size="10" fill="#6B7280">Model picks tools</text>
+  <text x="404" y="148" text-anchor="middle" font-size="10" fill="#6B7280">Model selects actions —</text>
+  <text x="404" y="160" text-anchor="middle" font-size="10" fill="#6B7280">one turn only</text>
+
+  <!-- Arrow 3→4 -->
+  <line x1="469" y1="128" x2="495" y2="128" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+
+  <!-- Box 4: Agent -->
+  <rect x="496" y="92" width="128" height="72" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="560" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#B91C1C">Agent</text>
+  <text x="560" y="130" text-anchor="middle" font-size="10" fill="#6B7280">Autonomous loop</text>
+  <text x="560" y="148" text-anchor="middle" font-size="10" fill="#6B7280">Model directs loop —</text>
+  <text x="560" y="160" text-anchor="middle" font-size="10" fill="#6B7280">multi-step decisions</text>
+
+  <!-- Arrow 4→5 -->
+  <line x1="625" y1="128" x2="651" y2="128" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+
+  <!-- Box 5: Multi-Agent -->
+  <rect x="652" y="92" width="128" height="72" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="716" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#B91C1C">Multi-Agent</text>
+  <text x="716" y="130" text-anchor="middle" font-size="10" fill="#6B7280">Coordinated agents</text>
+  <text x="716" y="148" text-anchor="middle" font-size="10" fill="#6B7280">Multiple loops —</text>
+  <text x="716" y="160" text-anchor="middle" font-size="10" fill="#6B7280">distributed decisions</text>
+
+  <!-- Bottom properties row label -->
+  <text x="400" y="196" text-anchor="middle" font-size="11" font-weight="bold" fill="#9CA3AF">KEY PROPERTIES</text>
+
+  <!-- Property row: Autonomy -->
+  <text x="92"  y="218" text-anchor="middle" font-size="11" fill="#374151">None</text>
+  <text x="248" y="218" text-anchor="middle" font-size="11" fill="#374151">None</text>
+  <text x="404" y="218" text-anchor="middle" font-size="11" fill="#374151">Single-turn</text>
+  <text x="560" y="218" text-anchor="middle" font-size="11" fill="#374151">Multi-turn</text>
+  <text x="716" y="218" text-anchor="middle" font-size="11" fill="#374151">Multi-loop</text>
+
+  <text x="14" y="218" font-size="10" font-weight="bold" fill="#6B7280">Autonomy</text>
+
+  <!-- Property row: Testability -->
+  <text x="92"  y="238" text-anchor="middle" font-size="11" fill="#10B981">Easy</text>
+  <text x="248" y="238" text-anchor="middle" font-size="11" fill="#10B981">Easy</text>
+  <text x="404" y="238" text-anchor="middle" font-size="11" fill="#F59E0B">Moderate</text>
+  <text x="560" y="238" text-anchor="middle" font-size="11" fill="#EF4444">Hard</text>
+  <text x="716" y="238" text-anchor="middle" font-size="11" fill="#EF4444">Very hard</text>
+
+  <text x="14" y="238" font-size="10" font-weight="bold" fill="#6B7280">Testability</text>
+
+  <!-- Property row: Cost -->
+  <text x="92"  y="258" text-anchor="middle" font-size="11" fill="#10B981">High</text>
+  <text x="248" y="258" text-anchor="middle" font-size="11" fill="#10B981">High</text>
+  <text x="404" y="258" text-anchor="middle" font-size="11" fill="#F59E0B">Moderate</text>
+  <text x="560" y="258" text-anchor="middle" font-size="11" fill="#EF4444">Low</text>
+  <text x="716" y="258" text-anchor="middle" font-size="11" fill="#EF4444">Very low</text>
+
+  <text x="5" y="258" font-size="10" font-weight="bold" fill="#6B7280">Predictability</text>
+
+  <!-- Horizontal separator -->
+  <line x1="28" y1="206" x2="780" y2="206" stroke="#E5E7EB" stroke-width="1"/>
+  <line x1="28" y1="270" x2="780" y2="270" stroke="#E5E7EB" stroke-width="1"/>
+
+  <!-- Bottom guidance -->
+  <text x="400" y="290" text-anchor="middle" font-size="11" fill="#6B7280">Engineering principle: start at the left. Move right only when the simpler pattern cannot solve your problem.</text>
+</svg>

--- a/public/assets/diagrams/three-failure-modes.svg
+++ b/public/assets/diagrams/three-failure-modes.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="720" height="360" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="360" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Three Failure Modes Every Agent Engineer Faces</text>
+  <line x1="40" y1="42" x2="680" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- ====== PANEL 1: Infinite Loop ====== -->
+  <rect x="30" y="58" width="206" height="264" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="133" y="82" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Infinite Loop</text>
+  <line x1="50" y1="90" x2="216" y2="90" stroke="#FCA5A5" stroke-width="1"/>
+
+  <!-- Circular spinning arrows (conceptual) -->
+  <circle cx="133" cy="170" r="50" fill="none" stroke="#EF4444" stroke-width="3" stroke-dasharray="10,5"/>
+  <!-- Arrow on circle -->
+  <path d="M133,120 A50,50 0 1,1 83,170" fill="none" stroke="#EF4444" stroke-width="3"/>
+  <polygon points="78,162 83,175 93,167" fill="#EF4444"/>
+  <!-- Inner text -->
+  <text x="133" y="165" text-anchor="middle" font-size="11" font-weight="bold" fill="#B91C1C">search →</text>
+  <text x="133" y="180" text-anchor="middle" font-size="11" fill="#B91C1C">read →</text>
+  <text x="133" y="195" text-anchor="middle" font-size="11" fill="#B91C1C">search →</text>
+
+  <!-- Budget counter -->
+  <rect x="60" y="238" width="148" height="28" rx="6" fill="#FEE2E2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="134" y="257" text-anchor="middle" font-size="12" font-weight="bold" fill="#B91C1C">Budget: 5/5 exhausted</text>
+
+  <text x="133" y="290" text-anchor="middle" font-size="11" fill="#374151">Agent never decides</text>
+  <text x="133" y="306" text-anchor="middle" font-size="11" fill="#374151">it has enough info.</text>
+  <text x="133" y="323" text-anchor="middle" font-size="10" fill="#9CA3AF">Fix: hard step limit</text>
+  <text x="133" y="337" text-anchor="middle" font-size="10" fill="#22c55e">in your orchestration code</text>
+
+  <!-- ====== PANEL 2: Hallucinated Tool ====== -->
+  <rect x="257" y="58" width="206" height="264" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="360" y="82" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Hallucinated Tool</text>
+  <line x1="277" y1="90" x2="443" y2="90" stroke="#FCA5A5" stroke-width="1"/>
+
+  <!-- Speech bubble with fake tool call -->
+  <rect x="284" y="104" width="152" height="72" rx="8" fill="#FEE2E2" stroke="#EF4444" stroke-width="1.5"/>
+  <!-- Speech bubble tail -->
+  <polygon points="330,176 344,190 358,176" fill="#FEE2E2"/>
+  <text x="360" y="128" text-anchor="middle" font-size="11" font-weight="bold" fill="#B91C1C">Model says:</text>
+  <text x="360" y="145" text-anchor="middle" font-size="11" fill="#374151">call:</text>
+  <text x="360" y="161" text-anchor="middle" font-size="11" font-weight="bold" fill="#5B21B6">analyze_sentiment()</text>
+
+  <!-- Red X below -->
+  <circle cx="360" cy="216" r="22" fill="#FEE2E2" stroke="#EF4444" stroke-width="2"/>
+  <line x1="346" y1="202" x2="374" y2="230" stroke="#EF4444" stroke-width="3" stroke-linecap="round"/>
+  <line x1="374" y1="202" x2="346" y2="230" stroke="#EF4444" stroke-width="3" stroke-linecap="round"/>
+
+  <text x="360" y="256" text-anchor="middle" font-size="11" fill="#374151">Tool doesn't exist.</text>
+  <text x="360" y="272" text-anchor="middle" font-size="11" fill="#374151">Runtime error.</text>
+  <text x="360" y="290" text-anchor="middle" font-size="11" fill="#374151">Agent halts.</text>
+  <text x="360" y="310" text-anchor="middle" font-size="10" fill="#9CA3AF">Fix: strict tool schema</text>
+  <text x="360" y="325" text-anchor="middle" font-size="10" fill="#22c55e">validation before dispatch</text>
+
+  <!-- ====== PANEL 3: Confident Wrong Answer ====== -->
+  <rect x="484" y="58" width="206" height="264" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="587" y="82" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Confident Wrong Answer</text>
+  <line x1="504" y1="90" x2="670" y2="90" stroke="#FCA5A5" stroke-width="1"/>
+
+  <!-- Checkmark on red background - looks right but isn't -->
+  <rect x="537" y="108" width="100" height="100" rx="10" fill="#DC2626"/>
+  <!-- Big green checkmark over red -->
+  <circle cx="587" cy="158" r="36" fill="#22c55e" opacity="0.9"/>
+  <polyline points="568,158 582,172 610,144" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Ironically wrong -->
+  <text x="587" y="230" text-anchor="middle" font-size="11" fill="#374151">Model returns answer</text>
+  <text x="587" y="247" text-anchor="middle" font-size="11" fill="#374151">with full confidence.</text>
+  <text x="587" y="264" text-anchor="middle" font-size="12" font-weight="bold" fill="#B91C1C">It is wrong.</text>
+  <text x="587" y="282" text-anchor="middle" font-size="11" fill="#374151">No error raised.</text>
+  <text x="587" y="300" text-anchor="middle" font-size="10" fill="#9CA3AF">Fix: output validation,</text>
+  <text x="587" y="315" text-anchor="middle" font-size="10" fill="#22c55e">evals, human review</text>
+
+  <!-- Caption -->
+  <text x="360" y="345" text-anchor="middle" font-size="11" fill="#374151">These three failure modes account for most agent production incidents. Build for all three.</text>
+  <text x="360" y="358" text-anchor="middle" font-size="11" fill="#9CA3AF">Step limits · schema validation · output verification</text>
+</svg>

--- a/public/assets/diagrams/three-way-comparison.svg
+++ b/public/assets/diagrams/three-way-comparison.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="380" viewBox="0 0 720 380" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="720" height="380" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="360" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Framework Comparison: Raw vs. ADK vs. LangChain</text>
+  <line x1="40" y1="42" x2="680" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- ====== CARD 1: Raw Python ====== -->
+  <rect x="30" y="58" width="200" height="288" rx="10" fill="#F9FAFB" stroke="#6B7280" stroke-width="2"/>
+  <!-- Header -->
+  <rect x="30" y="58" width="200" height="52" rx="10" fill="#374151"/>
+  <rect x="30" y="90" width="200" height="20" fill="#374151"/>
+  <text x="130" y="84" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">Raw Python</text>
+  <text x="130" y="100" text-anchor="middle" font-size="11" fill="#9CA3AF">Direct API calls</text>
+
+  <!-- Metrics -->
+  <text x="48" y="132" font-size="11" font-weight="bold" fill="#6B7280">CODE VOLUME</text>
+  <rect x="46" y="140" width="168" height="32" rx="4" fill="#ffffff" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="130" y="162" text-anchor="middle" font-size="15" font-weight="bold" fill="#374151">~100 lines</text>
+
+  <text x="48" y="192" font-size="11" font-weight="bold" fill="#6B7280">DEBUGGABILITY</text>
+  <rect x="46" y="200" width="168" height="32" rx="4" fill="#DCFCE7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="130" y="222" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">High</text>
+
+  <text x="48" y="252" font-size="11" font-weight="bold" fill="#6B7280">VENDOR LOCK-IN</text>
+  <rect x="46" y="260" width="168" height="32" rx="4" fill="#DCFCE7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="130" y="282" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">None</text>
+
+  <text x="48" y="312" font-size="11" font-weight="bold" fill="#6B7280">BUILT-IN TRACING</text>
+  <rect x="46" y="320" width="168" height="20" rx="4" fill="#FEE2E2" stroke="#EF4444" stroke-width="1"/>
+  <text x="130" y="335" text-anchor="middle" font-size="12" fill="#B91C1C">You build it yourself</text>
+
+  <!-- ====== CARD 2: ADK ====== -->
+  <rect x="260" y="58" width="200" height="288" rx="10" fill="#F9FAFB" stroke="#3B82F6" stroke-width="2"/>
+  <!-- Header -->
+  <rect x="260" y="58" width="200" height="52" rx="10" fill="#1D4ED8"/>
+  <rect x="260" y="90" width="200" height="20" fill="#1D4ED8"/>
+  <text x="360" y="84" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">Google ADK</text>
+  <text x="360" y="100" text-anchor="middle" font-size="11" fill="#BFDBFE">Structured agent framework</text>
+
+  <!-- Metrics -->
+  <text x="278" y="132" font-size="11" font-weight="bold" fill="#6B7280">CODE VOLUME</text>
+  <rect x="276" y="140" width="168" height="32" rx="4" fill="#ffffff" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="360" y="162" text-anchor="middle" font-size="15" font-weight="bold" fill="#374151">~40 lines</text>
+
+  <text x="278" y="192" font-size="11" font-weight="bold" fill="#6B7280">DEBUGGABILITY</text>
+  <rect x="276" y="200" width="168" height="32" rx="4" fill="#FEF9C3" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="360" y="222" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Medium</text>
+
+  <text x="278" y="252" font-size="11" font-weight="bold" fill="#6B7280">VENDOR LOCK-IN</text>
+  <rect x="276" y="260" width="168" height="32" rx="4" fill="#FEF9C3" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="360" y="282" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Google ecosystem</text>
+
+  <text x="278" y="312" font-size="11" font-weight="bold" fill="#6B7280">BUILT-IN TRACING</text>
+  <rect x="276" y="320" width="168" height="20" rx="4" fill="#DCFCE7" stroke="#22c55e" stroke-width="1"/>
+  <text x="360" y="335" text-anchor="middle" font-size="12" fill="#15803D">Yes — full traces + evals</text>
+
+  <!-- ====== CARD 3: LangChain ====== -->
+  <rect x="490" y="58" width="200" height="288" rx="10" fill="#F9FAFB" stroke="#8B5CF6" stroke-width="2"/>
+  <!-- Header -->
+  <rect x="490" y="58" width="200" height="52" rx="10" fill="#5B21B6"/>
+  <rect x="490" y="90" width="200" height="20" fill="#5B21B6"/>
+  <text x="590" y="84" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">LangChain</text>
+  <text x="590" y="100" text-anchor="middle" font-size="11" fill="#DDD6FE">Ecosystem framework</text>
+
+  <!-- Metrics -->
+  <text x="508" y="132" font-size="11" font-weight="bold" fill="#6B7280">CODE VOLUME</text>
+  <rect x="506" y="140" width="168" height="32" rx="4" fill="#ffffff" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="590" y="162" text-anchor="middle" font-size="15" font-weight="bold" fill="#374151">~35 lines</text>
+
+  <text x="508" y="192" font-size="11" font-weight="bold" fill="#6B7280">DEBUGGABILITY</text>
+  <rect x="506" y="200" width="168" height="32" rx="4" fill="#FEE2E2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="590" y="222" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Low</text>
+
+  <text x="508" y="252" font-size="11" font-weight="bold" fill="#6B7280">VENDOR LOCK-IN</text>
+  <rect x="506" y="260" width="168" height="32" rx="4" fill="#FEF9C3" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="590" y="282" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">LangChain abstractions</text>
+
+  <text x="508" y="312" font-size="11" font-weight="bold" fill="#6B7280">BUILT-IN TRACING</text>
+  <rect x="506" y="320" width="168" height="20" rx="4" fill="#DCFCE7" stroke="#22c55e" stroke-width="1"/>
+  <text x="590" y="335" text-anchor="middle" font-size="12" fill="#15803D">LangSmith (separate)</text>
+
+  <!-- Caption -->
+  <text x="360" y="364" text-anchor="middle" font-size="11" fill="#374151">Fewer lines of code is not the goal. Fewer lines of code you understand is better than fewer total lines.</text>
+  <text x="360" y="378" text-anchor="middle" font-size="11" fill="#9CA3AF">Optimize for debuggability, not brevity.</text>
+</svg>

--- a/public/assets/diagrams/token-cost-calculator.svg
+++ b/public/assets/diagrams/token-cost-calculator.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="400" viewBox="0 0 620 400" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="arr-down" markerWidth="7" markerHeight="10" refX="3.5" refY="9" orient="auto">
+      <polygon points="0 0, 3.5 10, 7 0" fill="#9CA3AF"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="620" height="400" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="310" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Token Cost: From One Call to Production Scale</text>
+  <line x1="40" y1="42" x2="580" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Section header: Single Call -->
+  <text x="60" y="68" font-size="12" font-weight="bold" fill="#6B7280">SINGLE API CALL</text>
+
+  <!-- Table header -->
+  <rect x="40" y="74" width="540" height="28" rx="4" fill="#F3F4F6"/>
+  <text x="80" y="93" font-size="11" font-weight="bold" fill="#374151">Component</text>
+  <text x="290" y="93" text-anchor="middle" font-size="11" font-weight="bold" fill="#374151">Tokens</text>
+  <text x="440" y="93" text-anchor="middle" font-size="11" font-weight="bold" fill="#374151">Cost (GPT-4o est.)</text>
+
+  <!-- Row 1: Prompt -->
+  <rect x="40" y="102" width="540" height="36" rx="0" fill="#EFF6FF"/>
+  <line x1="40" y1="138" x2="580" y2="138" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="80" y="126" font-size="13" fill="#374151">Prompt (input)</text>
+  <text x="290" y="126" text-anchor="middle" font-size="13" fill="#374151">1,200</text>
+  <text x="440" y="126" text-anchor="middle" font-size="13" font-weight="bold" fill="#3B82F6">$0.003</text>
+
+  <!-- Row 2: Completion -->
+  <rect x="40" y="138" width="540" height="36" rx="0" fill="#ffffff"/>
+  <line x1="40" y1="174" x2="580" y2="174" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="80" y="162" font-size="13" fill="#374151">Completion (output)</text>
+  <text x="290" y="162" text-anchor="middle" font-size="13" fill="#374151">400</text>
+  <text x="440" y="162" text-anchor="middle" font-size="13" font-weight="bold" fill="#3B82F6">$0.004</text>
+
+  <!-- Total per call row -->
+  <rect x="40" y="174" width="540" height="36" rx="0" fill="#F0FDF4"/>
+  <line x1="40" y1="210" x2="580" y2="210" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="80" y="198" font-size="13" font-weight="bold" fill="#15803D">Total per call</text>
+  <text x="290" y="198" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">1,600</text>
+  <text x="440" y="198" text-anchor="middle" font-size="15" font-weight="bold" fill="#15803D">$0.007</text>
+
+  <!-- Border around table -->
+  <rect x="40" y="74" width="540" height="136" rx="4" fill="none" stroke="#D1D5DB" stroke-width="1.5"/>
+
+  <!-- Arrow down -->
+  <line x1="310" y1="216" x2="310" y2="234" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arr-down)"/>
+
+  <!-- Section header: Scale -->
+  <text x="60" y="260" font-size="12" font-weight="bold" fill="#6B7280">SCALE UP TO PRODUCTION</text>
+
+  <!-- Scale rows -->
+  <rect x="40" y="266" width="540" height="32" rx="4" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1"/>
+  <text x="80" y="287" font-size="13" fill="#374151">x 5 calls per task</text>
+  <text x="440" y="287" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">$0.035 per task</text>
+
+  <rect x="40" y="306" width="540" height="32" rx="4" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="80" y="327" font-size="13" fill="#374151">x 1,000 tasks per day</text>
+  <text x="440" y="327" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">$35 / day</text>
+
+  <rect x="40" y="346" width="540" height="32" rx="4" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <text x="80" y="367" font-size="13" fill="#374151">x 30 days</text>
+  <text x="440" y="367" text-anchor="middle" font-size="16" font-weight="bold" fill="#B91C1C">$1,050 / month</text>
+
+  <!-- Caption -->
+  <text x="310" y="394" text-anchor="middle" font-size="11" fill="#9CA3AF">Token costs compound. Measure on day one — not after you deploy.</text>
+</svg>

--- a/public/assets/diagrams/tool-selection-comparison.svg
+++ b/public/assets/diagrams/tool-selection-comparison.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="680" height="380" viewBox="0 0 680 380" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="680" height="380" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="340" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Tool Selection: Why Descriptions Matter</text>
+  <line x1="40" y1="42" x2="640" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- LEFT PANEL: Good (green) -->
+  <rect x="30" y="56" width="300" height="296" rx="10" fill="#F0FDF4" stroke="#22c55e" stroke-width="2.5"/>
+  <text x="180" y="80" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">Good Tool Description</text>
+  <line x1="50" y1="88" x2="310" y2="88" stroke="#86EFAC" stroke-width="1"/>
+
+  <!-- Tool definition box -->
+  <rect x="48" y="98" width="264" height="68" rx="6" fill="#DCFCE7" stroke="#86EFAC" stroke-width="1"/>
+  <text x="70" y="116" font-size="10" font-weight="bold" fill="#15803D">Tool: calculator</text>
+  <text x="70" y="133" font-size="10" fill="#374151">"Performs arithmetic:</text>
+  <text x="70" y="148" font-size="10" fill="#374151"> addition, subtraction,</text>
+  <text x="70" y="163" font-size="10" fill="#374151"> multiplication, division."</text>
+
+  <!-- Arrow down -->
+  <line x1="180" y1="167" x2="180" y2="196" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Query -->
+  <rect x="48" y="198" width="264" height="36" rx="6" fill="#ffffff" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="180" y="221" text-anchor="middle" font-size="12" fill="#374151">Query: <tspan font-weight="bold">"What is 15 × 7?"</tspan></text>
+
+  <!-- Arrow down -->
+  <line x1="180" y1="235" x2="180" y2="264" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Model selects -->
+  <rect x="48" y="266" width="264" height="30" rx="6" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1"/>
+  <text x="180" y="286" text-anchor="middle" font-size="11" fill="#1D4ED8">Model selects: <tspan font-weight="bold">calculator</tspan></text>
+
+  <!-- Arrow down -->
+  <line x1="180" y1="297" x2="180" y2="316" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Result -->
+  <rect x="48" y="318" width="264" height="24" rx="6" fill="#DCFCE7" stroke="#22c55e" stroke-width="2"/>
+  <text x="180" y="334" text-anchor="middle" font-size="13" font-weight="bold" fill="#15803D">Result: 105  &#10003; Correct</text>
+
+<!-- RIGHT PANEL: Bad (red) -->
+  <rect x="350" y="56" width="300" height="296" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2.5"/>
+  <text x="500" y="80" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Vague Tool Description</text>
+  <line x1="370" y1="88" x2="630" y2="88" stroke="#FCA5A5" stroke-width="1"/>
+
+  <!-- Tool definition box -->
+  <rect x="368" y="98" width="264" height="68" rx="6" fill="#FEE2E2" stroke="#FCA5A5" stroke-width="1"/>
+  <text x="390" y="116" font-size="10" font-weight="bold" fill="#B91C1C">Tool: calculator</text>
+  <text x="390" y="133" font-size="10" fill="#374151">"A tool for processing</text>
+  <text x="390" y="148" font-size="10" fill="#374151"> numbers and returning</text>
+  <text x="390" y="163" font-size="10" fill="#374151"> information."</text>
+
+  <!-- Arrow down -->
+  <line x1="500" y1="167" x2="500" y2="196" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Query -->
+  <rect x="368" y="198" width="264" height="36" rx="6" fill="#ffffff" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="500" y="221" text-anchor="middle" font-size="12" fill="#374151">Query: <tspan font-weight="bold">"What is 15 × 7?"</tspan></text>
+
+  <!-- Arrow down -->
+  <line x1="500" y1="235" x2="500" y2="264" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Model selects wrong -->
+  <rect x="368" y="266" width="264" height="30" rx="6" fill="#FEE2E2" stroke="#EF4444" stroke-width="1"/>
+  <text x="500" y="286" text-anchor="middle" font-size="11" fill="#B91C1C">Model selects: <tspan font-weight="bold">web_search</tspan></text>
+
+  <!-- Arrow down -->
+  <line x1="500" y1="297" x2="500" y2="316" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Result -->
+  <rect x="368" y="318" width="264" height="24" rx="6" fill="#FEE2E2" stroke="#EF4444" stroke-width="2"/>
+  <text x="500" y="334" text-anchor="middle" font-size="12" font-weight="bold" fill="#B91C1C">Result: search snippets  &#10007; Wrong tool</text>
+
+  <!-- Caption -->
+  <text x="340" y="366" text-anchor="middle" font-size="11" fill="#374151">Tool selection is driven entirely by the description you write. Be precise and unambiguous.</text>
+  <text x="340" y="379" text-anchor="middle" font-size="11" fill="#9CA3AF">Treat tool descriptions as API contracts, not comments.</text>
+</svg>

--- a/public/assets/diagrams/trace-waterfall.svg
+++ b/public/assets/diagrams/trace-waterfall.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 350" width="800" height="350" style="background:#fff;font-family:system-ui,-apple-system,sans-serif;">
+
+  <!-- Background -->
+  <rect width="800" height="350" fill="#ffffff" rx="0"/>
+
+  <!-- Title -->
+  <text x="400" y="30" text-anchor="middle" font-size="16" font-weight="600" fill="#374151">Trace Waterfall: Agent Execution Decomposed into Spans</text>
+
+  <!-- Timeline header -->
+  <!-- X axis: 0ms to 1600ms, mapped to x=160 to x=760, width=600 -->
+  <!-- Labels -->
+  <text x="160" y="60" text-anchor="middle" font-size="11" fill="#6B7280">0ms</text>
+  <text x="235" y="60" text-anchor="middle" font-size="11" fill="#6B7280">200ms</text>
+  <text x="310" y="60" text-anchor="middle" font-size="11" fill="#6B7280">400ms</text>
+  <text x="385" y="60" text-anchor="middle" font-size="11" fill="#6B7280">600ms</text>
+  <text x="460" y="60" text-anchor="middle" font-size="11" fill="#6B7280">800ms</text>
+  <text x="535" y="60" text-anchor="middle" font-size="11" fill="#6B7280">1000ms</text>
+  <text x="610" y="60" text-anchor="middle" font-size="11" fill="#6B7280">1200ms</text>
+  <text x="685" y="60" text-anchor="middle" font-size="11" fill="#6B7280">1400ms</text>
+  <text x="760" y="60" text-anchor="middle" font-size="11" fill="#6B7280">1600ms</text>
+
+  <!-- Vertical grid lines -->
+  <line x1="160" y1="65" x2="160" y2="285" stroke="#D1D5DB" stroke-width="1"/>
+  <line x1="235" y1="65" x2="235" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="310" y1="65" x2="310" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="385" y1="65" x2="385" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="460" y1="65" x2="460" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="535" y1="65" x2="535" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="610" y1="65" x2="610" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="685" y1="65" x2="685" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="760" y1="65" x2="760" y2="285" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Span name column header -->
+  <text x="80" y="60" text-anchor="middle" font-size="11" font-weight="600" fill="#374151">Span</text>
+
+  <!-- Scale: 1ms = 600/1600 = 0.375px, x = 160 + (ms * 0.375) -->
+
+  <!-- Span 1: Retrieve (0-50ms) -->
+  <!-- x_start = 160, width = 50*0.375 = 18.75 -->
+  <text x="80" y="92" text-anchor="middle" font-size="12" fill="#374151">Retrieve</text>
+  <rect x="160" y="77" width="19" height="22" rx="4" fill="#3B82F6"/>
+  <text x="185" y="92" font-size="11" fill="#6B7280">50ms</text>
+
+  <!-- Span 2: Build Context (50-60ms) -->
+  <!-- x_start = 160 + 50*0.375 = 178.75, width = 10*0.375 = 3.75 -->
+  <text x="80" y="127" text-anchor="middle" font-size="12" fill="#374151">Build Context</text>
+  <rect x="179" y="112" width="4" height="22" rx="2" fill="#9CA3AF"/>
+  <text x="189" y="127" font-size="11" fill="#6B7280">10ms</text>
+
+  <!-- Span 3: Model Call #1 (60-800ms) -->
+  <!-- x_start = 160 + 60*0.375 = 182.5, width = 740*0.375 = 277.5 -->
+  <text x="80" y="162" text-anchor="middle" font-size="12" fill="#374151">Model Call #1</text>
+  <rect x="183" y="147" width="277" height="22" rx="4" fill="#2563EB"/>
+  <text x="184" y="162" font-size="10" fill="#DBEAFE" font-weight="500">  prompt: 2.1k tokens, completion: 340 tokens</text>
+  <text x="466" y="162" font-size="11" fill="#6B7280" dx="4">740ms</text>
+
+  <!-- Span 4: Tool: extract (800-900ms) -->
+  <!-- x_start = 160 + 800*0.375 = 460, width = 100*0.375 = 37.5 -->
+  <text x="80" y="197" text-anchor="middle" font-size="12" fill="#374151">Tool: extract</text>
+  <rect x="460" y="182" width="38" height="22" rx="4" fill="#10B981"/>
+  <text x="504" y="197" font-size="11" fill="#6B7280">100ms</text>
+
+  <!-- Span 5: Model Call #2 (900-1600ms) -->
+  <!-- x_start = 160 + 900*0.375 = 497.5, width = 700*0.375 = 262.5 -->
+  <text x="80" y="232" text-anchor="middle" font-size="12" fill="#374151">Model Call #2</text>
+  <rect x="498" y="217" width="262" height="22" rx="4" fill="#2563EB"/>
+  <text x="762" y="232" font-size="11" fill="#6B7280" dx="4">700ms</text>
+
+  <!-- Bottom axis line -->
+  <line x1="160" y1="290" x2="760" y2="290" stroke="#374151" stroke-width="1.5"/>
+
+  <!-- Total label -->
+  <text x="460" y="313" text-anchor="middle" font-size="13" font-weight="600" fill="#374151">Total: 1600ms</text>
+
+  <!-- Legend -->
+  <rect x="170" y="325" width="12" height="12" rx="2" fill="#2563EB"/>
+  <text x="186" y="335" font-size="11" fill="#374151">Model call</text>
+  <rect x="270" y="325" width="12" height="12" rx="2" fill="#10B981"/>
+  <text x="286" y="335" font-size="11" fill="#374151">Tool call</text>
+  <rect x="360" y="325" width="12" height="12" rx="2" fill="#9CA3AF"/>
+  <text x="376" y="335" font-size="11" fill="#374151">Processing</text>
+  <rect x="460" y="325" width="12" height="12" rx="2" fill="#3B82F6"/>
+  <text x="476" y="335" font-size="11" fill="#374151">Retrieval</text>
+
+</svg>

--- a/public/assets/diagrams/truncation-strategies.svg
+++ b/public/assets/diagrams/truncation-strategies.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="460" viewBox="0 0 800 460" font-family="'IBM Plex Sans', sans-serif">
+  <defs>
+    <marker id="arr-d" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1a3a5c"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="460" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="34" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a1a">Truncation Strategies — Same 5-Message Conversation</text>
+  <line x1="80" y1="48" x2="720" y2="48" stroke="#7eb3d8" stroke-width="1"/>
+
+  <!-- Column headers -->
+  <text x="145" y="76" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">Recency</text>
+  <text x="145" y="92" text-anchor="middle" font-size="11" fill="#6b7280">Keep newest N</text>
+
+  <text x="400" y="76" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">Importance</text>
+  <text x="400" y="92" text-anchor="middle" font-size="11" fill="#6b7280">Score and rank</text>
+
+  <text x="655" y="76" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">Compaction</text>
+  <text x="655" y="92" text-anchor="middle" font-size="11" fill="#6b7280">Summarize old turns</text>
+
+  <!-- Vertical dividers -->
+  <line x1="270" y1="60" x2="270" y2="420" stroke="#e8f0f7" stroke-width="1.5"/>
+  <line x1="530" y1="60" x2="530" y2="420" stroke="#e8f0f7" stroke-width="1.5"/>
+
+  <!-- ═══ RECENCY COLUMN ═══ -->
+  <!-- Msg 1: DROPPED -->
+  <rect x="40" y="110" width="210" height="42" rx="6" fill="#ffffff" stroke="#7eb3d8" stroke-width="1.5" opacity="0.4"/>
+  <line x1="40" y1="131" x2="250" y2="131" stroke="#ef4444" stroke-width="2"/>
+  <text x="145" y="126" text-anchor="middle" font-size="12" fill="#6b7280" opacity="0.5">M1: "Transfer $5K from acct #4421"</text>
+  <text x="145" y="140" text-anchor="middle" font-size="10" fill="#ef4444" font-weight="bold">DROPPED</text>
+  <!-- Critical marker -->
+  <rect x="40" y="106" width="52" height="14" rx="3" fill="#ef4444"/>
+  <text x="66" y="116" text-anchor="middle" font-size="9" fill="#ffffff" font-weight="bold">CRITICAL</text>
+
+  <!-- Msg 2: DROPPED -->
+  <rect x="40" y="160" width="210" height="42" rx="6" fill="#ffffff" stroke="#7eb3d8" stroke-width="1.5" opacity="0.4"/>
+  <line x1="40" y1="181" x2="250" y2="181" stroke="#ef4444" stroke-width="2"/>
+  <text x="145" y="178" text-anchor="middle" font-size="12" fill="#6b7280" opacity="0.5">M2: "Confirmed, processing"</text>
+  <text x="145" y="192" text-anchor="middle" font-size="10" fill="#ef4444" font-weight="bold">DROPPED</text>
+
+  <!-- Msg 3: KEPT -->
+  <rect x="40" y="210" width="210" height="42" rx="6" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="145" y="235" text-anchor="middle" font-size="12" fill="#1a1a1a">M3: "What's the balance?"</text>
+
+  <!-- Msg 4: KEPT -->
+  <rect x="40" y="260" width="210" height="42" rx="6" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="145" y="285" text-anchor="middle" font-size="12" fill="#1a1a1a">M4: "Balance is $12,300"</text>
+
+  <!-- Msg 5: KEPT -->
+  <rect x="40" y="310" width="210" height="42" rx="6" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="145" y="335" text-anchor="middle" font-size="12" fill="#1a1a1a">M5: "Undo last transfer"</text>
+
+  <!-- Problem annotation -->
+  <rect x="40" y="364" width="210" height="36" rx="6" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="145" y="386" text-anchor="middle" font-size="11" fill="#991b1b" font-weight="bold">Lost: account # and amount</text>
+
+  <!-- ═══ IMPORTANCE COLUMN ═══ -->
+  <!-- Msg 1: KEPT (high score) -->
+  <rect x="295" y="110" width="210" height="42" rx="6" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="400" y="135" text-anchor="middle" font-size="12" fill="#1a1a1a">M1: "Transfer $5K from acct #4421"</text>
+  <rect x="295" y="106" width="52" height="14" rx="3" fill="#1a3a5c"/>
+  <text x="321" y="116" text-anchor="middle" font-size="9" fill="#ffffff" font-weight="bold">score: 9</text>
+
+  <!-- Msg 2: KEPT -->
+  <rect x="295" y="160" width="210" height="42" rx="6" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="400" y="185" text-anchor="middle" font-size="12" fill="#1a1a1a">M2: "Confirmed, processing"</text>
+  <rect x="295" y="156" width="52" height="14" rx="3" fill="#3d7ab5"/>
+  <text x="321" y="166" text-anchor="middle" font-size="9" fill="#ffffff" font-weight="bold">score: 6</text>
+
+  <!-- Msg 3: DROPPED (low score) -->
+  <rect x="295" y="210" width="210" height="42" rx="6" fill="#ffffff" stroke="#7eb3d8" stroke-width="1.5" opacity="0.4"/>
+  <line x1="295" y1="231" x2="505" y2="231" stroke="#ef4444" stroke-width="2"/>
+  <text x="400" y="228" text-anchor="middle" font-size="12" fill="#6b7280" opacity="0.5">M3: "What's the balance?"</text>
+  <text x="400" y="242" text-anchor="middle" font-size="10" fill="#ef4444" font-weight="bold">DROPPED (score: 2)</text>
+
+  <!-- Msg 4: KEPT -->
+  <rect x="295" y="260" width="210" height="42" rx="6" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="400" y="285" text-anchor="middle" font-size="12" fill="#1a1a1a">M4: "Balance is $12,300"</text>
+  <rect x="295" y="256" width="52" height="14" rx="3" fill="#3d7ab5"/>
+  <text x="321" y="266" text-anchor="middle" font-size="9" fill="#ffffff" font-weight="bold">score: 7</text>
+
+  <!-- Msg 5: KEPT -->
+  <rect x="295" y="310" width="210" height="42" rx="6" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="400" y="335" text-anchor="middle" font-size="12" fill="#1a1a1a">M5: "Undo last transfer"</text>
+  <rect x="295" y="306" width="52" height="14" rx="3" fill="#1a3a5c"/>
+  <text x="321" y="316" text-anchor="middle" font-size="9" fill="#ffffff" font-weight="bold">score: 8</text>
+
+  <!-- Result annotation -->
+  <rect x="295" y="364" width="210" height="36" rx="6" fill="#f0fdf4" stroke="#10b981" stroke-width="1.5"/>
+  <text x="400" y="386" text-anchor="middle" font-size="11" fill="#065f46" font-weight="bold">Retains critical context</text>
+
+  <!-- ═══ COMPACTION COLUMN ═══ -->
+  <!-- Summary block for M1-M3 -->
+  <rect x="550" y="110" width="210" height="92" rx="6" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="2" stroke-dasharray="6,3"/>
+  <text x="655" y="135" text-anchor="middle" font-size="11" fill="#3d7ab5" font-weight="bold">[Summary]</text>
+  <text x="655" y="152" text-anchor="middle" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#1a1a1a">User transferred $5K from</text>
+  <text x="655" y="166" text-anchor="middle" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#1a1a1a">acct #4421. Balance: $12,300.</text>
+  <text x="655" y="186" text-anchor="middle" font-size="10" fill="#6b7280">M1 + M2 + M3 compressed</text>
+
+  <!-- Msg 4: KEPT -->
+  <rect x="550" y="260" width="210" height="42" rx="6" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="655" y="285" text-anchor="middle" font-size="12" fill="#1a1a1a">M4: "Balance is $12,300"</text>
+
+  <!-- Msg 5: KEPT -->
+  <rect x="550" y="310" width="210" height="42" rx="6" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="655" y="335" text-anchor="middle" font-size="12" fill="#1a1a1a">M5: "Undo last transfer"</text>
+
+  <!-- Arrow showing compression -->
+  <line x1="655" y1="206" x2="655" y2="255" stroke="#3d7ab5" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-d)"/>
+  <text x="670" y="232" font-size="10" fill="#3d7ab5">gap</text>
+
+  <!-- Result annotation -->
+  <rect x="550" y="364" width="210" height="36" rx="6" fill="#f0fdf4" stroke="#10b981" stroke-width="1.5"/>
+  <text x="655" y="386" text-anchor="middle" font-size="11" fill="#065f46" font-weight="bold">Best of both: saves tokens + facts</text>
+
+  <!-- Bottom legend -->
+  <rect x="60" y="416" width="680" height="30" rx="6" fill="#f9fafb" stroke="#e8f0f7" stroke-width="1"/>
+  <rect x="80" y="425" width="14" height="14" rx="3" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="100" y="436" font-size="11" fill="#1a1a1a">Kept</text>
+  <rect x="150" y="425" width="14" height="14" rx="3" fill="#ffffff" stroke="#7eb3d8" stroke-width="1.5" opacity="0.4"/>
+  <text x="170" y="436" font-size="11" fill="#1a1a1a">Dropped</text>
+  <rect x="240" y="425" width="14" height="14" rx="3" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="2" stroke-dasharray="4,2"/>
+  <text x="260" y="436" font-size="11" fill="#1a1a1a">Summary</text>
+  <text x="420" y="436" font-size="11" fill="#6b7280">Message 1 contains account number and transfer amount (critical for undo).</text>
+</svg>

--- a/public/assets/diagrams/trust-boundaries.svg
+++ b/public/assets/diagrams/trust-boundaries.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="560" viewBox="0 0 800 560" font-family="Arial, Helvetica, sans-serif">
+  <!-- Background -->
+  <rect width="800" height="560" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="34" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Agent Trust Boundaries</text>
+  <line x1="80" y1="46" x2="720" y2="46" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Zone 1: Outermost — UNTRUSTED (red tint) -->
+  <rect x="60" y="66" width="680" height="440" rx="20" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
+  <!-- Zone label: top-left inside band -->
+  <text x="82" y="91" font-size="11" font-weight="bold" fill="#EF4444" letter-spacing="0.5">UNTRUSTED</text>
+  <!-- Zone title inline -->
+  <text x="400" y="107" text-anchor="middle" font-size="15" font-weight="bold" fill="#B91C1C">External Input</text>
+  <!-- Components in outer zone (top and bottom bands) -->
+  <rect x="120" y="118" width="180" height="44" rx="8" fill="#ffffff" stroke="#FCA5A5" stroke-width="1.5"/>
+  <text x="210" y="136" text-anchor="middle" font-size="13" font-weight="bold" fill="#991B1B">User Queries</text>
+  <text x="210" y="153" text-anchor="middle" font-size="11" fill="#6B7280">Raw natural language</text>
+
+  <rect x="500" y="118" width="180" height="44" rx="8" fill="#ffffff" stroke="#FCA5A5" stroke-width="1.5"/>
+  <text x="590" y="136" text-anchor="middle" font-size="13" font-weight="bold" fill="#991B1B">Retrieved Documents</text>
+  <text x="590" y="153" text-anchor="middle" font-size="11" fill="#6B7280">External corpus data</text>
+
+  <!-- Zone 2: SEMI-TRUSTED (yellow tint) -->
+  <rect x="130" y="174" width="540" height="310" rx="16" fill="#FFFBEB" stroke="#F59E0B" stroke-width="2"/>
+  <text x="152" y="197" font-size="11" font-weight="bold" fill="#D97706" letter-spacing="0.5">SEMI-TRUSTED</text>
+  <text x="400" y="212" text-anchor="middle" font-size="15" font-weight="bold" fill="#92400E">Agent Reasoning</text>
+
+  <rect x="175" y="224" width="190" height="44" rx="8" fill="#ffffff" stroke="#FCD34D" stroke-width="1.5"/>
+  <text x="270" y="242" text-anchor="middle" font-size="13" font-weight="bold" fill="#78350F">Model Output</text>
+  <text x="270" y="259" text-anchor="middle" font-size="11" fill="#6B7280">Generated text · reasoning</text>
+
+  <rect x="435" y="224" width="190" height="44" rx="8" fill="#ffffff" stroke="#FCD34D" stroke-width="1.5"/>
+  <text x="530" y="242" text-anchor="middle" font-size="13" font-weight="bold" fill="#78350F">Tool Call Decisions</text>
+  <text x="530" y="259" text-anchor="middle" font-size="11" fill="#6B7280">Inferred arguments · intent</text>
+
+  <!-- Zone 3: ENFORCED (green tint) -->
+  <rect x="200" y="280" width="400" height="178" rx="14" fill="#F0FDF4" stroke="#10B981" stroke-width="2"/>
+  <text x="222" y="301" font-size="11" font-weight="bold" fill="#059669" letter-spacing="0.5">ENFORCED</text>
+  <text x="400" y="316" text-anchor="middle" font-size="15" font-weight="bold" fill="#065F46">Tool Execution</text>
+
+  <rect x="228" y="328" width="155" height="44" rx="8" fill="#ffffff" stroke="#6EE7B7" stroke-width="1.5"/>
+  <text x="305" y="346" text-anchor="middle" font-size="12" font-weight="bold" fill="#064E3B">Registry Validation</text>
+  <text x="305" y="362" text-anchor="middle" font-size="11" fill="#6B7280">Schema · signature check</text>
+
+  <rect x="418" y="328" width="155" height="44" rx="8" fill="#ffffff" stroke="#6EE7B7" stroke-width="1.5"/>
+  <text x="495" y="346" text-anchor="middle" font-size="12" font-weight="bold" fill="#064E3B">Permission Check</text>
+  <text x="495" y="362" text-anchor="middle" font-size="11" fill="#6B7280">Allow · deny · scope</text>
+
+  <rect x="310" y="386" width="180" height="44" rx="8" fill="#ffffff" stroke="#6EE7B7" stroke-width="1.5"/>
+  <text x="400" y="404" text-anchor="middle" font-size="12" font-weight="bold" fill="#064E3B">Side-Effect Classification</text>
+  <text x="400" y="420" text-anchor="middle" font-size="11" fill="#6B7280">Read-only · write · irreversible</text>
+
+  <!-- Zone 4: Core — TRUSTED (deep green) -->
+  <rect x="270" y="438" width="260" height="68" rx="12" fill="#ECFDF5" stroke="#059669" stroke-width="2.5"/>
+  <text x="292" y="457" font-size="11" font-weight="bold" fill="#059669" letter-spacing="0.5">TRUSTED</text>
+  <text x="400" y="468" text-anchor="middle" font-size="15" font-weight="bold" fill="#064E3B">Policy Layer</text>
+  <text x="400" y="484" text-anchor="middle" font-size="11" fill="#374151">Permission Policy  ·  Approval Gates</text>
+  <text x="400" y="498" text-anchor="middle" font-size="11" fill="#374151">Audit Log  ·  Rate Limits</text>
+
+  <!-- Legend -->
+  <rect x="62" y="520" width="675" height="28" rx="6" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1"/>
+  <rect x="76" y="530" width="12" height="12" rx="2" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="94" y="541" font-size="11" fill="#374151">Untrusted</text>
+  <rect x="168" y="530" width="12" height="12" rx="2" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="186" y="541" font-size="11" fill="#374151">Semi-Trusted</text>
+  <rect x="276" y="530" width="12" height="12" rx="2" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="294" y="541" font-size="11" fill="#374151">Enforced Controls</text>
+  <rect x="404" y="530" width="12" height="12" rx="2" fill="#ECFDF5" stroke="#059669" stroke-width="2"/>
+  <text x="422" y="541" font-size="11" fill="#374151">Trusted Core</text>
+  <text x="590" y="541" font-size="11" fill="#9CA3AF">Each inner zone enforces the outer zone's outputs.</text>
+</svg>

--- a/public/assets/diagrams/two-pass-retrieval.svg
+++ b/public/assets/diagrams/two-pass-retrieval.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="420" viewBox="0 0 800 420" font-family="'IBM Plex Sans', sans-serif">
+  <defs>
+    <marker id="arr-dk" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1a3a5c"/>
+    </marker>
+    <marker id="arr-md" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#3d7ab5"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="420" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="34" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a1a">Two-Pass Retrieval — Memory-Augmented RAG</text>
+  <line x1="100" y1="48" x2="700" y2="48" stroke="#7eb3d8" stroke-width="1"/>
+
+  <!-- Query box (left) -->
+  <rect x="40" y="140" width="140" height="60" rx="8" fill="#1a3a5c" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="110" y="166" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">User Query</text>
+  <text x="110" y="183" text-anchor="middle" font-size="11" fill="#7eb3d8">"What is our SLA?"</text>
+
+  <!-- Pass 1: Document Retrieval (top path) -->
+  <rect x="260" y="70" width="220" height="70" rx="8" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="290" y="90" font-size="11" font-weight="bold" fill="#3d7ab5" letter-spacing="1">PASS 1</text>
+  <text x="370" y="110" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">Document Retrieval</text>
+  <text x="370" y="128" text-anchor="middle" font-size="11" fill="#6b7280">Vector search over corpus</text>
+
+  <!-- Arrow: Query → Pass 1 -->
+  <line x1="180" y1="155" x2="258" y2="110" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-dk)"/>
+
+  <!-- Pass 2: Memory Check (bottom path) -->
+  <rect x="260" y="200" width="220" height="70" rx="8" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="290" y="220" font-size="11" font-weight="bold" fill="#3d7ab5" letter-spacing="1">PASS 2</text>
+  <text x="370" y="240" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">Memory Check</text>
+  <text x="370" y="258" text-anchor="middle" font-size="11" fill="#6b7280">Search past corrections</text>
+
+  <!-- Arrow: Query → Pass 2 -->
+  <line x1="180" y1="185" x2="258" y2="230" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-dk)"/>
+
+  <!-- Documents result -->
+  <rect x="540" y="70" width="120" height="70" rx="8" fill="#ffffff" stroke="#7eb3d8" stroke-width="2"/>
+  <text x="600" y="96" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a3a5c">Documents</text>
+  <text x="600" y="112" text-anchor="middle" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#6b7280">doc_1.md</text>
+  <text x="600" y="126" text-anchor="middle" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#6b7280">doc_2.md</text>
+
+  <!-- Arrow: Pass 1 → Documents -->
+  <line x1="480" y1="105" x2="538" y2="105" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-dk)"/>
+
+  <!-- Memory result -->
+  <rect x="540" y="200" width="120" height="70" rx="8" fill="#ffffff" stroke="#7eb3d8" stroke-width="2"/>
+  <text x="600" y="226" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a3a5c">Corrections</text>
+  <text x="600" y="242" text-anchor="middle" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#6b7280">"SLA is 99.9%</text>
+  <text x="600" y="256" text-anchor="middle" font-size="11" font-family="'IBM Plex Mono', monospace" fill="#6b7280">not 99.5%"</text>
+
+  <!-- Arrow: Pass 2 → Corrections -->
+  <line x1="480" y1="235" x2="538" y2="235" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-dk)"/>
+
+  <!-- Memory reshapes retrieval (cross arrow) -->
+  <path d="M 540 215 Q 510 170 480 130" fill="none" stroke="#3d7ab5" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#arr-md)"/>
+  <rect x="485" y="155" width="120" height="28" rx="4" fill="#ffffff" stroke="#3d7ab5" stroke-width="1.5"/>
+  <text x="545" y="173" text-anchor="middle" font-size="10" fill="#3d7ab5" font-weight="bold">retrieval instruction</text>
+  <text x="545" y="184" text-anchor="middle" font-size="9" fill="#6b7280">"prioritize SLA docs"</text>
+
+  <!-- Combined Context box -->
+  <rect x="300" y="310" width="200" height="60" rx="8" fill="#e8f0f7" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="400" y="336" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">Combined Context</text>
+  <text x="400" y="354" text-anchor="middle" font-size="11" fill="#6b7280">docs + corrections + query</text>
+
+  <!-- Arrow: Documents → Combined -->
+  <line x1="600" y1="140" x2="600" y2="290" stroke="#7eb3d8" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="600" y1="290" x2="502" y2="330" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-dk)"/>
+
+  <!-- Arrow: Corrections → Combined -->
+  <line x1="600" y1="270" x2="502" y2="340" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-dk)"/>
+
+  <!-- Agent box -->
+  <rect x="560" y="310" width="140" height="60" rx="8" fill="#1a3a5c" stroke="#1a3a5c" stroke-width="2"/>
+  <text x="630" y="336" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">Agent</text>
+  <text x="630" y="354" text-anchor="middle" font-size="11" fill="#7eb3d8">Generates answer</text>
+
+  <!-- Arrow: Combined → Agent -->
+  <line x1="500" y1="340" x2="558" y2="340" stroke="#1a3a5c" stroke-width="2" marker-end="url(#arr-dk)"/>
+
+  <!-- Legend -->
+  <rect x="60" y="388" width="680" height="24" rx="6" fill="#f9fafb" stroke="#e8f0f7" stroke-width="1"/>
+  <text x="80" y="404" font-size="11" fill="#1a1a1a" font-weight="bold">Key insight:</text>
+  <text x="165" y="404" font-size="11" fill="#6b7280">Memory from Pass 2 can reshape Pass 1 retrieval, correcting known errors before they reach the model.</text>
+</svg>

--- a/public/assets/diagrams/workflow-vs-agent.svg
+++ b/public/assets/diagrams/workflow-vs-agent.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="560" viewBox="0 0 800 560" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    </marker>
+    <marker id="arr-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
+    </marker>
+    <marker id="arr-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#EF4444"/>
+    </marker>
+    <marker id="arr-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="560" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="400" y="34" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Workflow vs. Agent: Control Flow Comparison</text>
+  <line x1="60" y1="46" x2="740" y2="46" stroke="#D1D5DB" stroke-width="1"/>
+
+  <!-- Divider -->
+  <line x1="400" y1="60" x2="400" y2="540" stroke="#E5E7EB" stroke-width="2" stroke-dasharray="6,4"/>
+
+  <!-- ══ LEFT SIDE: Workflow ══ -->
+  <text x="200" y="76" text-anchor="middle" font-size="16" font-weight="bold" fill="#374151">Workflow</text>
+  <text x="200" y="94" text-anchor="middle" font-size="12" fill="#9CA3AF">Linear · Deterministic · No Memory</text>
+
+  <!-- Step 1: Retrieve -->
+  <rect x="100" y="112" width="200" height="54" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="200" y="136" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">1. Retrieve</text>
+  <text x="200" y="153" text-anchor="middle" font-size="11" fill="#6B7280">Top-k chunks from index</text>
+
+  <!-- Arrow -->
+  <line x1="200" y1="166" x2="200" y2="194" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Step 2: Build Context -->
+  <rect x="100" y="196" width="200" height="54" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="200" y="220" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">2. Build Context</text>
+  <text x="200" y="237" text-anchor="middle" font-size="11" fill="#6B7280">Assemble prompt + chunks</text>
+
+  <!-- Arrow -->
+  <line x1="200" y1="250" x2="200" y2="278" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Step 3: Generate Answer -->
+  <rect x="100" y="280" width="200" height="54" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
+  <text x="200" y="304" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">3. Generate Answer</text>
+  <text x="200" y="321" text-anchor="middle" font-size="11" fill="#6B7280">Single LLM call → output</text>
+
+  <!-- Terminal output -->
+  <rect x="130" y="368" width="140" height="36" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="200" y="391" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Answer</text>
+
+  <!-- Arrow to output -->
+  <line x1="200" y1="334" x2="200" y2="366" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Characteristic annotations -->
+  <rect x="70" y="428" width="260" height="88" rx="6" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="200" y="447" text-anchor="middle" font-size="11" font-weight="bold" fill="#6B7280">Characteristics</text>
+  <text x="88" y="465" font-size="11" fill="#374151">- Fixed execution path</text>
+  <text x="88" y="481" font-size="11" fill="#374151">- No decision making</text>
+  <text x="88" y="497" font-size="11" fill="#374151">- No query refinement</text>
+  <text x="88" y="513" font-size="11" fill="#374151">- Predictable cost</text>
+
+  <!-- ══ RIGHT SIDE: Agent ══ -->
+  <text x="600" y="76" text-anchor="middle" font-size="16" font-weight="bold" fill="#374151">Agent</text>
+  <text x="600" y="94" text-anchor="middle" font-size="12" fill="#9CA3AF">Adaptive · Decision Loop · Self-Correcting</text>
+
+  <!-- Step 1: Retrieve -->
+  <rect x="500" y="112" width="200" height="54" rx="8" fill="#FFF7ED" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="600" y="136" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">1. Retrieve</text>
+  <text x="600" y="153" text-anchor="middle" font-size="11" fill="#6B7280">Query → candidate chunks</text>
+
+  <!-- Arrow -->
+  <line x1="600" y1="166" x2="600" y2="194" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Step 2: Think -->
+  <rect x="500" y="196" width="200" height="54" rx="8" fill="#FFF7ED" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="600" y="220" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">2. Think</text>
+  <text x="600" y="237" text-anchor="middle" font-size="11" fill="#6B7280">Assess quality · check gaps</text>
+
+  <!-- Arrow -->
+  <line x1="600" y1="250" x2="600" y2="278" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Diamond: Decide -->
+  <polygon points="600,284 660,318 600,352 540,318" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
+  <text x="600" y="314" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">Decide</text>
+  <text x="600" y="330" text-anchor="middle" font-size="10" fill="#92400E">Sufficient?</text>
+
+  <!-- Budget Check diamond (inline label) -->
+  <text x="672" y="312" font-size="10" fill="#EF4444">Budget</text>
+  <text x="672" y="325" font-size="10" fill="#EF4444">Check</text>
+
+  <!-- YES → Answer -->
+  <line x1="600" y1="352" x2="600" y2="380" stroke="#10B981" stroke-width="2" marker-end="url(#arr-green)"/>
+  <text x="612" y="372" font-size="11" fill="#059669">yes</text>
+
+  <rect x="530" y="382" width="140" height="36" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
+  <text x="600" y="405" text-anchor="middle" font-size="13" font-weight="bold" fill="#065F46">Answer</text>
+
+  <!-- NO → Refine Query (loop back) -->
+  <text x="480" y="316" text-anchor="middle" font-size="11" fill="#EF4444">no</text>
+  <!-- Refine Query box -->
+  <rect x="415" y="270" width="118" height="40" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+  <text x="474" y="287" text-anchor="middle" font-size="12" font-weight="bold" fill="#B91C1C">Refine Query</text>
+  <text x="474" y="303" text-anchor="middle" font-size="10" fill="#6B7280">Rewrite · Decompose</text>
+
+  <!-- Arrow: Decide left to Refine -->
+  <line x1="540" y1="318" x2="535" y2="318" stroke="#EF4444" stroke-width="1.5" marker-end="url(#arr-red)"/>
+
+  <!-- Loop back arrow from Refine to Retrieve -->
+  <path d="M474,270 L474,138 L498,138" fill="none" stroke="#EF4444" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arr-red)"/>
+  <text x="450" y="200" font-size="10" fill="#EF4444" transform="rotate(-90 450 200)">loop back</text>
+
+  <!-- Escalate exit path -->
+  <line x1="660" y1="318" x2="730" y2="318" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="730" y="300" width="55" height="36" rx="6" fill="#F3F4F6" stroke="#9CA3AF" stroke-width="1.5"/>
+  <text x="757" y="321" text-anchor="middle" font-size="11" font-weight="bold" fill="#374151">Escalate</text>
+
+  <!-- Characteristic annotations -->
+  <rect x="470" y="428" width="260" height="88" rx="6" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1"/>
+  <text x="600" y="447" text-anchor="middle" font-size="11" font-weight="bold" fill="#6B7280">Characteristics</text>
+  <text x="488" y="465" font-size="11" fill="#374151">- Dynamic execution path</text>
+  <text x="488" y="481" font-size="11" fill="#374151">- Self-evaluates retrieval quality</text>
+  <text x="488" y="497" font-size="11" fill="#374151">- Retries with refined queries</text>
+  <text x="488" y="513" font-size="11" fill="#374151">- Variable cost (budget needed)</text>
+</svg>

--- a/src/components/islands/CommandPalette.svelte
+++ b/src/components/islands/CommandPalette.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+  /**
+   * CommandPalette — Cmd+K Pagefind-powered fuzzy search.
+   * Mounted globally via PageLayout. Slides in from top with backdrop blur.
+   * Svelte 5 runes API.
+   */
+
+  interface SearchResult {
+    url: string;
+    title: string;
+    excerpt: string;
+  }
+
+  let isOpen = $state(false);
+  let query = $state('');
+  let results = $state<SearchResult[]>([]);
+  let activeIdx = $state(0);
+  let pagefindLoaded = $state(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let pagefind: any = null;
+
+  // Lazy-load Pagefind only when the palette is first opened.
+  async function loadPagefind() {
+    if (pagefindLoaded) return;
+    try {
+      pagefind = await import(/* @vite-ignore */ '/agentic-ai/pagefind/pagefind.js');
+      pagefindLoaded = true;
+    } catch (e) {
+      console.error('CommandPalette: Pagefind load failed', e);
+    }
+  }
+
+  async function runSearch() {
+    if (!query.trim() || !pagefind) {
+      results = [];
+      return;
+    }
+    try {
+      const r = await pagefind.search(query);
+      const top10 = r.results.slice(0, 10);
+      const datas = await Promise.all(top10.map((x: { data: () => Promise<SearchResult> }) => x.data()));
+      results = datas;
+      activeIdx = 0;
+    } catch (e) {
+      console.error('CommandPalette: search failed', e);
+    }
+  }
+
+  function open() {
+    isOpen = true;
+    loadPagefind();
+    setTimeout(() => {
+      document.getElementById('cmdk-input')?.focus();
+    }, 50);
+  }
+
+  function close() {
+    isOpen = false;
+    query = '';
+    results = [];
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (isOpen) close();
+      else open();
+      return;
+    }
+    if (!isOpen) return;
+    if (e.key === 'Escape') close();
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      activeIdx = Math.min(activeIdx + 1, results.length - 1);
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      activeIdx = Math.max(activeIdx - 1, 0);
+    }
+    if (e.key === 'Enter' && results[activeIdx]) {
+      window.location.href = results[activeIdx].url;
+    }
+  }
+
+  $effect(() => {
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  });
+
+  $effect(() => {
+    if (isOpen) runSearch();
+  });
+</script>
+
+{#if isOpen}
+  <div class="cmdk" role="dialog" aria-modal="true" aria-label="Search">
+    <div class="cmdk__backdrop" onclick={close} role="presentation"></div>
+    <div class="cmdk__panel">
+      <input
+        id="cmdk-input"
+        type="search"
+        placeholder="Search this site (Cmd+K)…"
+        bind:value={query}
+        class="cmdk__input"
+        autocomplete="off"
+      />
+      {#if results.length > 0}
+        <ul class="cmdk__results">
+          {#each results as r, i}
+            <li class:cmdk__result--active={i === activeIdx}>
+              <a href={r.url} class="cmdk__result">
+                <div class="cmdk__result-title">{r.title}</div>
+                <div class="cmdk__result-excerpt" innerHTML={r.excerpt}></div>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      {:else if query.length > 0 && pagefindLoaded}
+        <p class="cmdk__empty">No results.</p>
+      {:else if !pagefindLoaded}
+        <p class="cmdk__empty">Loading search…</p>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .cmdk {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 12vh;
+  }
+
+  .cmdk__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(26, 26, 26, 0.4);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    animation: cmdk-fade 200ms ease-out;
+  }
+
+  .cmdk__panel {
+    position: relative;
+    width: 100%;
+    max-width: 680px;
+    margin: 0 24px;
+    background: var(--paper, #fafaf8);
+    border-radius: var(--radius-md, 4px);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
+    overflow: hidden;
+    animation: cmdk-slide 250ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+
+  @keyframes cmdk-fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  @keyframes cmdk-slide {
+    from { opacity: 0; transform: translateY(-12px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .cmdk__input {
+    width: 100%;
+    padding: 20px 24px;
+    border: 0;
+    background: transparent;
+    font-family: var(--font-body, system-ui);
+    font-size: 18px;
+    color: var(--fg, #1a1a1a);
+    border-bottom: 1px solid var(--fg-faint, #e8e8e8);
+  }
+
+  .cmdk__input:focus {
+    outline: none;
+  }
+
+  .cmdk__results {
+    list-style: none;
+    margin: 0;
+    padding: 8px 0;
+    max-height: 60vh;
+    overflow-y: auto;
+  }
+
+  .cmdk__result {
+    display: block;
+    padding: 12px 24px;
+    color: var(--fg, #1a1a1a);
+    text-decoration: none;
+  }
+
+  .cmdk__result--active .cmdk__result,
+  .cmdk__result:hover {
+    background: var(--paper-recess, #f5f5f3);
+  }
+
+  .cmdk__result-title {
+    font-family: var(--font-display, serif);
+    font-weight: 500;
+    font-size: 16px;
+    margin-bottom: 4px;
+  }
+
+  .cmdk__result-excerpt {
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--fg-light, #6b6b6b);
+  }
+
+  .cmdk__result-excerpt :global(mark) {
+    background: var(--brick-wash, rgba(155, 74, 63, 0.15));
+    color: var(--brick, #9b4a3f);
+    font-weight: 500;
+    padding: 0 1px;
+  }
+
+  .cmdk__empty {
+    padding: 24px;
+    color: var(--fg-light, #6b6b6b);
+    font-style: italic;
+    text-align: center;
+    font-family: var(--font-mono, monospace);
+    font-size: 13px;
+  }
+</style>

--- a/src/components/islands/CommandPalette.svelte
+++ b/src/components/islands/CommandPalette.svelte
@@ -71,10 +71,12 @@
     if (e.key === 'Escape') close();
     if (e.key === 'ArrowDown') {
       e.preventDefault();
+      if (results.length === 0) return;
       activeIdx = Math.min(activeIdx + 1, results.length - 1);
     }
     if (e.key === 'ArrowUp') {
       e.preventDefault();
+      if (results.length === 0) return;
       activeIdx = Math.max(activeIdx - 1, 0);
     }
     if (e.key === 'Enter' && results[activeIdx]) {

--- a/src/components/islands/D3Chart.svelte
+++ b/src/components/islands/D3Chart.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  /**
+   * D3Chart — bar / compare chart Svelte 5 island.
+   * Loads chart data from a static JSON URL OR receives inline data prop.
+   * Renders SVG with brick-red accent on the "winning" datum.
+   */
+  import { scaleLinear, scaleBand, max, formatTick } from '~/lib/d3-helpers';
+
+  interface DataPoint {
+    label: string;
+    value: number;
+    accent?: boolean;
+  }
+
+  interface ComparePoint {
+    label: string;
+    a: number;
+    b: number;
+  }
+
+  type ChartData = DataPoint[] | ComparePoint[];
+
+  let {
+    type = 'bar',
+    data,
+    src,
+    height = 240,
+    unit = '',
+    aLabel = 'A',
+    bLabel = 'B',
+  }: {
+    type?: 'bar' | 'compare';
+    data?: ChartData;
+    src?: string;
+    height?: number;
+    unit?: '%' | '×' | 'pp' | '';
+    aLabel?: string;
+    bLabel?: string;
+  } = $props();
+
+  let loadedData = $state<ChartData | null>(data ?? null);
+
+  $effect(() => {
+    if (!src || loadedData) return;
+    let aborted = false;
+    fetch(src)
+      .then((r) => r.json())
+      .then((d: ChartData) => {
+        if (!aborted) loadedData = d;
+      })
+      .catch((e) => console.error('D3Chart: load failed', src, e));
+    return () => { aborted = true; };
+  });
+
+  // Layout
+  const margin = { top: 12, right: 20, bottom: 36, left: 44 };
+  const width = 720;
+  const innerW = width - margin.left - margin.right;
+  const innerH = $derived(height - margin.top - margin.bottom);
+
+  // Bar chart scales
+  const barScales = $derived.by(() => {
+    if (!loadedData || type !== 'bar') return null;
+    const points = loadedData as DataPoint[];
+    const x = scaleBand<string>().domain(points.map((p) => p.label)).range([0, innerW]).padding(0.2);
+    const yMax = (max(points, (p) => p.value) ?? 0) * 1.1;
+    const y = scaleLinear().domain([0, yMax]).range([innerH, 0]);
+    return { x, y, points };
+  });
+
+  // Compare chart scales
+  const compareScales = $derived.by(() => {
+    if (!loadedData || type !== 'compare') return null;
+    const points = loadedData as ComparePoint[];
+    const x = scaleBand<string>().domain(points.map((p) => p.label)).range([0, innerW]).padding(0.25);
+    const yMax = (max(points, (p) => Math.max(p.a, p.b)) ?? 0) * 1.1;
+    const y = scaleLinear().domain([0, yMax]).range([innerH, 0]);
+    return { x, y, points };
+  });
+</script>
+
+{#if !loadedData}
+  <div class="d3-chart d3-chart--loading">Loading chart…</div>
+{:else}
+  <figure class="d3-chart">
+    <svg viewBox="0 0 {width} {height}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Chart">
+      <g transform="translate({margin.left}, {margin.top})">
+        {#if type === 'bar' && barScales}
+          {@const s = barScales}
+          {#each s.points as p}
+            {@const bw = s.x.bandwidth()}
+            {@const bx = s.x(p.label) ?? 0}
+            <rect
+              x={bx}
+              y={s.y(p.value)}
+              width={bw}
+              height={innerH - s.y(p.value)}
+              fill={p.accent ? '#9b4a3f' : '#1a1a1a'}
+            />
+            <text x={bx + bw / 2} y={innerH + 16} text-anchor="middle" font-size="11" fill="#6b6b6b">{p.label}</text>
+            <text x={bx + bw / 2} y={s.y(p.value) - 4} text-anchor="middle" font-size="11" fill="#1a1a1a" font-weight="500">
+              {formatTick(p.value, unit)}
+            </text>
+          {/each}
+        {/if}
+        {#if type === 'compare' && compareScales}
+          {@const s = compareScales}
+          {#each s.points as p}
+            {@const bw = s.x.bandwidth() / 2 - 2}
+            {@const bx = s.x(p.label) ?? 0}
+            <rect x={bx} y={s.y(p.a)} width={bw} height={innerH - s.y(p.a)} fill="#1a1a1a" />
+            <rect x={bx + bw + 4} y={s.y(p.b)} width={bw} height={innerH - s.y(p.b)} fill="#9b4a3f" />
+            <text x={bx + s.x.bandwidth() / 2} y={innerH + 16} text-anchor="middle" font-size="11" fill="#6b6b6b">{p.label}</text>
+          {/each}
+        {/if}
+      </g>
+    </svg>
+    {#if type === 'compare'}
+      <figcaption class="d3-chart__legend">
+        <span class="d3-chart__legend-dot d3-chart__legend-dot--a"></span> {aLabel}
+        <span class="d3-chart__legend-dot d3-chart__legend-dot--b"></span> {bLabel}
+      </figcaption>
+    {/if}
+  </figure>
+{/if}
+
+<style>
+  .d3-chart {
+    margin: var(--space-5, 24px) 0;
+    padding: 16px;
+    border: 1px solid var(--fg-faint, #e8e8e8);
+    border-radius: var(--radius-md, 4px);
+    background: var(--paper-bright, #fff);
+  }
+
+  .d3-chart--loading {
+    color: var(--fg-light, #6b6b6b);
+    font-style: italic;
+    text-align: center;
+    padding: 32px 16px;
+  }
+
+  .d3-chart svg {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .d3-chart__legend {
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+    margin-top: 12px;
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    color: var(--fg-light, #6b6b6b);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .d3-chart__legend-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    margin-right: 4px;
+    vertical-align: middle;
+  }
+
+  .d3-chart__legend-dot--a { background: #1a1a1a; }
+  .d3-chart__legend-dot--b { background: #9b4a3f; }
+</style>

--- a/src/components/islands/D3Chart.svelte
+++ b/src/components/islands/D3Chart.svelte
@@ -44,7 +44,10 @@
     if (!src || loadedData) return;
     let aborted = false;
     fetch(src)
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(`D3Chart: HTTP ${r.status} for ${src}`);
+        return r.json();
+      })
       .then((d: ChartData) => {
         if (!aborted) loadedData = d;
       })

--- a/src/components/universal/ArchitectureDiagram.astro
+++ b/src/components/universal/ArchitectureDiagram.astro
@@ -1,0 +1,60 @@
+---
+/**
+ * ArchitectureDiagram — wraps an SVG architecture diagram with caption + frame.
+ * Used by ProjectLayout for the main system diagram.
+ */
+interface Props {
+  src: string;
+  alt: string;
+  caption?: string;
+  traceIn?: boolean;
+}
+
+const { src, alt, caption, traceIn = true } = Astro.props;
+---
+
+<figure class:list={['architecture', traceIn && 'architecture--trace-in']}>
+  <img src={src} alt={alt} class="architecture__svg" loading="lazy" />
+  {caption && <figcaption class="architecture__caption">{caption}</figcaption>}
+</figure>
+
+<style>
+  .architecture {
+    margin: var(--space-5) 0;
+    padding: var(--space-5);
+    background: var(--paper-bright);
+    border: 1px solid var(--fg-faint);
+    border-radius: var(--radius-md);
+  }
+
+  .architecture__svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+
+  .architecture__caption {
+    margin-top: var(--space-3);
+    text-align: center;
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    color: var(--fg-light);
+  }
+
+  @supports (animation-timeline: view()) {
+    .architecture--trace-in .architecture__svg {
+      animation: arch-trace-in linear;
+      animation-timeline: view();
+      animation-range: cover 0% cover 30%;
+    }
+
+    @keyframes arch-trace-in {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .architecture--trace-in .architecture__svg { animation: none; }
+  }
+</style>

--- a/src/components/universal/DownloadList.astro
+++ b/src/components/universal/DownloadList.astro
@@ -1,0 +1,79 @@
+---
+/**
+ * DownloadList — Evidence page download artifacts (CSV / JSON / harness).
+ */
+interface Download {
+  label: string;
+  href: string;
+}
+
+interface Props {
+  items: Download[];
+}
+
+const { items } = Astro.props;
+---
+
+<section class="downloads">
+  <h2 class="downloads__heading">Downloads</h2>
+  <ul class="downloads__list">
+    {items.map((d) => (
+      <li>
+        <a href={d.href} class="downloads__link" download>
+          <span class="downloads__icon" aria-hidden="true">↓</span>
+          <span>{d.label}</span>
+        </a>
+      </li>
+    ))}
+  </ul>
+</section>
+
+<style>
+  .downloads {
+    margin: var(--space-5) 0;
+  }
+
+  .downloads__heading {
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+    margin: 0 0 var(--space-3);
+    font-weight: 500;
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+
+  .downloads__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+  }
+
+  .downloads__link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--ink);
+    border-radius: var(--radius-md);
+    color: var(--fg);
+    text-decoration: none;
+    font-family: var(--font-mono);
+    font-size: var(--meta-1);
+    transition: background var(--dur-micro) var(--ease-out), color var(--dur-micro) var(--ease-out);
+  }
+
+  .downloads__link:hover {
+    background: var(--ink);
+    color: var(--paper);
+  }
+
+  .downloads__icon {
+    font-size: var(--meta-1);
+  }
+</style>

--- a/src/components/universal/EvalStats.astro
+++ b/src/components/universal/EvalStats.astro
@@ -1,0 +1,76 @@
+---
+/**
+ * EvalStats — Project page 3-stat row: accuracy / avg cost / p50 latency.
+ */
+interface Stats {
+  accuracy: string;
+  avgCost: string;
+  latencyP50: string;
+}
+
+interface Props {
+  stats: Stats;
+}
+
+const { stats } = Astro.props;
+---
+
+<section class="eval-stats" aria-label="Evaluation metrics">
+  <div class="eval-stats__inner">
+    <div class="eval-stats__stat">
+      <div class="eval-stats__value eval-stats__value--accent">{stats.accuracy}</div>
+      <div class="eval-stats__label">Accuracy</div>
+    </div>
+    <div class="eval-stats__stat">
+      <div class="eval-stats__value">{stats.avgCost}</div>
+      <div class="eval-stats__label">Avg cost</div>
+    </div>
+    <div class="eval-stats__stat">
+      <div class="eval-stats__value">{stats.latencyP50}</div>
+      <div class="eval-stats__label">Latency p50</div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .eval-stats {
+    margin: var(--space-5) 0;
+  }
+
+  .eval-stats__inner {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-1);
+    background: var(--fg-faint);
+    border: 1px solid var(--fg-faint);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+  }
+
+  .eval-stats__stat {
+    text-align: center;
+    padding: var(--space-5) var(--space-3);
+    background: var(--paper);
+  }
+
+  .eval-stats__value {
+    font-family: var(--font-display);
+    font-size: clamp(24px, 3vw, 32px);
+    font-weight: 500;
+    line-height: 1;
+    color: var(--fg);
+  }
+
+  .eval-stats__value--accent {
+    color: var(--brick);
+  }
+
+  .eval-stats__label {
+    margin-top: var(--space-2);
+    font-family: var(--font-mono);
+    font-size: var(--meta-3);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+  }
+</style>

--- a/src/components/universal/HeroStatGrid.astro
+++ b/src/components/universal/HeroStatGrid.astro
@@ -1,0 +1,76 @@
+---
+/**
+ * HeroStatGrid — Evidence page hero with 2 (or more) giant stats side-by-side.
+ * One default color (ink), one accent (brick-red) by convention.
+ */
+interface Stat {
+  value: string;
+  label: string;
+  color?: 'default' | 'accent';
+}
+
+interface Props {
+  items: Stat[];
+}
+
+const { items } = Astro.props;
+---
+
+<section class="hero-stat-grid">
+  <div class="hero-stat-grid__inner">
+    {items.map((stat) => (
+      <div class:list={['hero-stat-grid__stat', stat.color === 'accent' && 'hero-stat-grid__stat--accent']}>
+        <div class="hero-stat-grid__value">{stat.value}</div>
+        <div class="hero-stat-grid__label">{stat.label}</div>
+      </div>
+    ))}
+  </div>
+</section>
+
+<style>
+  .hero-stat-grid {
+    margin: var(--space-5) 0 var(--space-7);
+  }
+
+  .hero-stat-grid__inner {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--space-1);
+    background: var(--fg-faint);
+    border: 1px solid var(--fg-faint);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+  }
+
+  .hero-stat-grid__stat {
+    text-align: center;
+    padding: var(--space-6) var(--space-4);
+    background: var(--paper);
+  }
+
+  .hero-stat-grid__stat--accent {
+    background: var(--brick-wash);
+  }
+
+  .hero-stat-grid__value {
+    font-family: var(--font-display);
+    font-size: clamp(36px, 5vw, 56px);
+    font-weight: 500;
+    line-height: 1;
+    color: var(--fg);
+    letter-spacing: var(--tracking-tight);
+  }
+
+  .hero-stat-grid__stat--accent .hero-stat-grid__value {
+    color: var(--brick);
+  }
+
+  .hero-stat-grid__label {
+    margin-top: var(--space-3);
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+  }
+</style>

--- a/src/components/universal/HypothesisBlock.astro
+++ b/src/components/universal/HypothesisBlock.astro
@@ -1,0 +1,38 @@
+---
+/**
+ * HypothesisBlock — Lab Report hypothesis statement with brick-red rule.
+ */
+---
+
+<aside class="hypothesis-block">
+  <div class="hypothesis-block__label">Hypothesis</div>
+  <p class="hypothesis-block__body"><slot /></p>
+</aside>
+
+<style>
+  .hypothesis-block {
+    margin: var(--space-5) 0;
+    padding: var(--space-4) var(--space-5);
+    background: var(--brick-wash);
+    border-left: 3px solid var(--brick);
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  }
+
+  .hypothesis-block__label {
+    font-family: var(--font-mono);
+    font-size: var(--meta-3);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--brick);
+    margin-bottom: var(--space-2);
+    font-weight: 600;
+  }
+
+  .hypothesis-block__body {
+    font-family: var(--font-display);
+    font-size: var(--display-3);
+    line-height: var(--lh-snug);
+    color: var(--fg);
+    margin: 0;
+  }
+</style>

--- a/src/components/universal/HypothesisBlock.astro
+++ b/src/components/universal/HypothesisBlock.astro
@@ -6,7 +6,7 @@
 
 <aside class="hypothesis-block">
   <div class="hypothesis-block__label">Hypothesis</div>
-  <p class="hypothesis-block__body"><slot /></p>
+  <div class="hypothesis-block__body"><slot /></div>
 </aside>
 
 <style>

--- a/src/components/universal/MethodBlock.astro
+++ b/src/components/universal/MethodBlock.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * MethodBlock — Evidence page methodology description.
+ */
+---
+
+<section class="method-block">
+  <h2 class="method-block__heading">Method</h2>
+  <div class="method-block__body">
+    <slot />
+  </div>
+</section>
+
+<style>
+  .method-block {
+    margin: var(--space-5) 0;
+  }
+
+  .method-block__heading {
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+    margin: 0 0 var(--space-3);
+    font-weight: 500;
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+
+  .method-block__body {
+    font-size: var(--body-1);
+    line-height: var(--lh-base);
+  }
+
+  .method-block__body :global(p) {
+    margin: 0 0 var(--space-3);
+  }
+
+  .method-block__body :global(p:last-child) {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/components/universal/ProductCardHero.astro
+++ b/src/components/universal/ProductCardHero.astro
@@ -2,6 +2,7 @@
 /**
  * ProductCardHero — Project page 4-quadrant hero.
  * Run it / Read case study / See failures / View code as 4 cards.
+ * Each quadrant only renders if the corresponding prop is provided.
  * Run It and View Code are external links (target=_blank); others are in-page anchors.
  */
 interface Props {
@@ -11,26 +12,30 @@ interface Props {
   codeRepo?: string;
 }
 
-const { runIt, caseStudy = '#case-study', failures = '#failures', codeRepo } = Astro.props;
+const { runIt, caseStudy, failures, codeRepo } = Astro.props;
 ---
 
 <div class="product-card-hero">
   {runIt && (
-    <a href={runIt} class="product-card-hero__quadrant product-card-hero__quadrant--primary" target="_blank" rel="noopener">
+    <a href={runIt} class="product-card-hero__quadrant product-card-hero__quadrant--primary" target="_blank" rel="noopener noreferrer">
       <div class="product-card-hero__icon" aria-hidden="true">▷</div>
       <div class="product-card-hero__label">Run it</div>
     </a>
   )}
-  <a href={caseStudy} class="product-card-hero__quadrant">
-    <div class="product-card-hero__icon" aria-hidden="true">→</div>
-    <div class="product-card-hero__label">Read case study</div>
-  </a>
-  <a href={failures} class="product-card-hero__quadrant">
-    <div class="product-card-hero__icon" aria-hidden="true">⚠</div>
-    <div class="product-card-hero__label">See failures</div>
-  </a>
+  {caseStudy && (
+    <a href={caseStudy} class="product-card-hero__quadrant">
+      <div class="product-card-hero__icon" aria-hidden="true">→</div>
+      <div class="product-card-hero__label">Read case study</div>
+    </a>
+  )}
+  {failures && (
+    <a href={failures} class="product-card-hero__quadrant">
+      <div class="product-card-hero__icon" aria-hidden="true">⚠</div>
+      <div class="product-card-hero__label">See failures</div>
+    </a>
+  )}
   {codeRepo && (
-    <a href={codeRepo} class="product-card-hero__quadrant" target="_blank" rel="noopener">
+    <a href={codeRepo} class="product-card-hero__quadrant" target="_blank" rel="noopener noreferrer">
       <div class="product-card-hero__icon" aria-hidden="true">{`</>`}</div>
       <div class="product-card-hero__label">View code</div>
     </a>

--- a/src/components/universal/ProductCardHero.astro
+++ b/src/components/universal/ProductCardHero.astro
@@ -1,0 +1,94 @@
+---
+/**
+ * ProductCardHero — Project page 4-quadrant hero.
+ * Run it / Read case study / See failures / View code as 4 cards.
+ * Run It and View Code are external links (target=_blank); others are in-page anchors.
+ */
+interface Props {
+  runIt?: string;
+  caseStudy?: string;
+  failures?: string;
+  codeRepo?: string;
+}
+
+const { runIt, caseStudy = '#case-study', failures = '#failures', codeRepo } = Astro.props;
+---
+
+<div class="product-card-hero">
+  {runIt && (
+    <a href={runIt} class="product-card-hero__quadrant product-card-hero__quadrant--primary" target="_blank" rel="noopener">
+      <div class="product-card-hero__icon" aria-hidden="true">▷</div>
+      <div class="product-card-hero__label">Run it</div>
+    </a>
+  )}
+  <a href={caseStudy} class="product-card-hero__quadrant">
+    <div class="product-card-hero__icon" aria-hidden="true">→</div>
+    <div class="product-card-hero__label">Read case study</div>
+  </a>
+  <a href={failures} class="product-card-hero__quadrant">
+    <div class="product-card-hero__icon" aria-hidden="true">⚠</div>
+    <div class="product-card-hero__label">See failures</div>
+  </a>
+  {codeRepo && (
+    <a href={codeRepo} class="product-card-hero__quadrant" target="_blank" rel="noopener">
+      <div class="product-card-hero__icon" aria-hidden="true">{`</>`}</div>
+      <div class="product-card-hero__label">View code</div>
+    </a>
+  )}
+</div>
+
+<style>
+  .product-card-hero {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-1);
+    background: var(--fg-faint);
+    border: 1px solid var(--fg-faint);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    margin: var(--space-5) 0 var(--space-6);
+  }
+
+  .product-card-hero__quadrant {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    padding: var(--space-5) var(--space-4);
+    background: var(--paper);
+    color: var(--fg);
+    text-decoration: none;
+    transition: background var(--dur-micro) var(--ease-out);
+  }
+
+  .product-card-hero__quadrant:hover {
+    background: var(--paper-recess);
+  }
+
+  .product-card-hero__quadrant--primary {
+    background: var(--ink);
+    color: var(--paper);
+  }
+
+  .product-card-hero__quadrant--primary:hover {
+    background: var(--brick);
+  }
+
+  .product-card-hero__icon {
+    font-size: 22px;
+    line-height: 1;
+    font-family: var(--font-mono);
+  }
+
+  .product-card-hero__label {
+    font-family: var(--font-mono);
+    font-size: var(--meta-1);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+  }
+
+  @media (max-width: 600px) {
+    .product-card-hero { grid-template-columns: 1fr; }
+  }
+</style>

--- a/src/components/universal/Provenance.astro
+++ b/src/components/universal/Provenance.astro
@@ -1,0 +1,55 @@
+---
+/**
+ * Provenance — Evidence page provenance strip: when measured, model used.
+ */
+interface Props {
+  measuredOn: Date;
+  model?: string;
+}
+
+const { measuredOn, model } = Astro.props;
+const dateStr = measuredOn.toISOString().slice(0, 10);
+---
+
+<aside class="provenance">
+  <span class="provenance__label">Measured</span>
+  <span class="provenance__date">{dateStr}</span>
+  {model && (
+    <>
+      <span class="provenance__sep">·</span>
+      <span class="provenance__model">{model}</span>
+    </>
+  )}
+</aside>
+
+<style>
+  .provenance {
+    margin: var(--space-4) 0;
+    padding: var(--space-3) var(--space-4);
+    background: var(--paper-recess);
+    border-radius: var(--radius-md);
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    color: var(--fg-light);
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .provenance__label {
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--brick);
+    font-weight: 600;
+  }
+
+  .provenance__date,
+  .provenance__model {
+    color: var(--fg);
+  }
+
+  .provenance__sep {
+    color: var(--fg-lighter);
+  }
+</style>

--- a/src/components/universal/ReproduceStrip.astro
+++ b/src/components/universal/ReproduceStrip.astro
@@ -14,8 +14,8 @@ const { repo, data, seed } = Astro.props;
 <aside class="reproduce-strip">
   <div class="reproduce-strip__label">↓ Reproduce</div>
   <div class="reproduce-strip__links">
-    <a href={repo} target="_blank" rel="noopener" class="reproduce-strip__link">Code</a>
-    <a href={data} target="_blank" rel="noopener" class="reproduce-strip__link">Data</a>
+    <a href={repo} target="_blank" rel="noopener noreferrer" class="reproduce-strip__link">Code</a>
+    <a href={data} target="_blank" rel="noopener noreferrer" class="reproduce-strip__link">Data</a>
     {seed !== undefined && <span class="reproduce-strip__seed">seed = {seed}</span>}
   </div>
 </aside>

--- a/src/components/universal/ReproduceStrip.astro
+++ b/src/components/universal/ReproduceStrip.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * ReproduceStrip — Lab Report bottom strip with repo + data + seed.
+ */
+interface Props {
+  repo: string;
+  data: string;
+  seed?: number;
+}
+
+const { repo, data, seed } = Astro.props;
+---
+
+<aside class="reproduce-strip">
+  <div class="reproduce-strip__label">↓ Reproduce</div>
+  <div class="reproduce-strip__links">
+    <a href={repo} target="_blank" rel="noopener" class="reproduce-strip__link">Code</a>
+    <a href={data} target="_blank" rel="noopener" class="reproduce-strip__link">Data</a>
+    {seed !== undefined && <span class="reproduce-strip__seed">seed = {seed}</span>}
+  </div>
+</aside>
+
+<style>
+  .reproduce-strip {
+    margin: var(--space-6) 0;
+    padding: var(--space-4) var(--space-5);
+    background: var(--ink);
+    color: var(--paper);
+    border-radius: var(--radius-md);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+  }
+
+  .reproduce-strip__label {
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    font-weight: 600;
+  }
+
+  .reproduce-strip__links {
+    display: flex;
+    gap: var(--space-4);
+    align-items: center;
+    font-family: var(--font-mono);
+    font-size: var(--meta-1);
+  }
+
+  .reproduce-strip__link {
+    color: var(--paper);
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 255, 255, 0.4);
+    text-underline-offset: 3px;
+    transition: text-decoration-color var(--dur-micro) var(--ease-out);
+  }
+
+  .reproduce-strip__link:hover {
+    text-decoration-color: var(--brick);
+  }
+
+  .reproduce-strip__seed {
+    color: rgba(255, 255, 255, 0.5);
+  }
+</style>

--- a/src/components/universal/SectionAnchors.astro
+++ b/src/components/universal/SectionAnchors.astro
@@ -27,20 +27,35 @@ const { items } = Astro.props;
 </nav>
 
 <script>
+  let currentObserver: IntersectionObserver | null = null;
+
   function setupScrollSpy() {
+    // Disconnect any prior observer to avoid leaks across View Transitions.
+    currentObserver?.disconnect();
+    currentObserver = null;
+
     const links = document.querySelectorAll<HTMLAnchorElement>('.section-anchors__link[data-anchor]');
     if (!links.length) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
+        // Pick the intersecting entry whose target is closest to the top
+        // of the viewport (smallest non-negative boundingClientRect.top).
+        // This avoids a race where two sections enter the viewport in the
+        // same callback batch and "last in iteration order wins".
+        let best: { id: string; top: number } | null = null;
         for (const entry of entries) {
-          const id = entry.target.id;
-          const link = document.querySelector(`.section-anchors__link[data-anchor="${id}"]`);
-          if (entry.isIntersecting) {
-            links.forEach((l) => l.classList.remove('section-anchors__link--active'));
-            link?.classList.add('section-anchors__link--active');
+          if (!entry.isIntersecting) continue;
+          const top = entry.boundingClientRect.top;
+          if (best === null || Math.abs(top) < Math.abs(best.top)) {
+            best = { id: entry.target.id, top };
           }
         }
+        if (!best) return;
+
+        links.forEach((l) => l.classList.remove('section-anchors__link--active'));
+        const link = document.querySelector(`.section-anchors__link[data-anchor="${best.id}"]`);
+        link?.classList.add('section-anchors__link--active');
       },
       { rootMargin: '-20% 0% -70% 0%' }
     );
@@ -49,10 +64,16 @@ const { items } = Astro.props;
       const target = document.getElementById(l.dataset.anchor || '');
       if (target) observer.observe(target);
     });
+
+    currentObserver = observer;
   }
 
   setupScrollSpy();
   document.addEventListener('astro:page-load', setupScrollSpy);
+  document.addEventListener('astro:before-preparation', () => {
+    currentObserver?.disconnect();
+    currentObserver = null;
+  });
 </script>
 
 <style>

--- a/src/components/universal/SectionAnchors.astro
+++ b/src/components/universal/SectionAnchors.astro
@@ -1,0 +1,102 @@
+---
+/**
+ * SectionAnchors — Lab Report sticky in-page navigation with scroll-spy.
+ * Section IDs must match the corresponding h2 ids in the body MDX.
+ */
+interface Section {
+  label: string;
+  anchor: string;
+}
+
+interface Props {
+  items: Section[];
+}
+
+const { items } = Astro.props;
+---
+
+<nav class="section-anchors" aria-label="In-page navigation">
+  <div class="section-anchors__label">In this Lab</div>
+  <ul class="section-anchors__list">
+    {items.map((s) => (
+      <li>
+        <a href={`#${s.anchor}`} class="section-anchors__link" data-anchor={s.anchor}>{s.label}</a>
+      </li>
+    ))}
+  </ul>
+</nav>
+
+<script>
+  function setupScrollSpy() {
+    const links = document.querySelectorAll<HTMLAnchorElement>('.section-anchors__link[data-anchor]');
+    if (!links.length) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = entry.target.id;
+          const link = document.querySelector(`.section-anchors__link[data-anchor="${id}"]`);
+          if (entry.isIntersecting) {
+            links.forEach((l) => l.classList.remove('section-anchors__link--active'));
+            link?.classList.add('section-anchors__link--active');
+          }
+        }
+      },
+      { rootMargin: '-20% 0% -70% 0%' }
+    );
+
+    links.forEach((l) => {
+      const target = document.getElementById(l.dataset.anchor || '');
+      if (target) observer.observe(target);
+    });
+  }
+
+  setupScrollSpy();
+  document.addEventListener('astro:page-load', setupScrollSpy);
+</script>
+
+<style>
+  .section-anchors {
+    position: sticky;
+    top: 72px;
+    margin: var(--space-5) 0;
+    padding: var(--space-3) var(--space-4);
+    background: var(--paper-recess);
+    border: 1px solid var(--fg-faint);
+    border-radius: var(--radius-md);
+    z-index: 50;
+  }
+
+  .section-anchors__label {
+    font-family: var(--font-mono);
+    font-size: var(--meta-3);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+    margin-bottom: var(--space-2);
+    font-weight: 500;
+  }
+
+  .section-anchors__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+  }
+
+  .section-anchors__link {
+    font-family: var(--font-mono);
+    font-size: var(--body-3);
+    color: var(--fg-light);
+    text-decoration: none;
+    transition: color var(--dur-micro) var(--ease-out);
+  }
+
+  .section-anchors__link:hover,
+  .section-anchors__link--active {
+    color: var(--brick);
+    font-weight: 500;
+  }
+</style>

--- a/src/components/universal/StatHero.astro
+++ b/src/components/universal/StatHero.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * StatHero — Lab Report hero with one giant result number.
+ * E.g. "87% vs 74%" + "router beat multi-agent".
+ */
+interface Props {
+  value: string;
+  label: string;
+}
+
+const { value, label } = Astro.props;
+---
+
+<section class="stat-hero">
+  <div class="stat-hero__value">{value}</div>
+  <div class="stat-hero__label">{label}</div>
+</section>
+
+<style>
+  .stat-hero {
+    text-align: center;
+    padding: var(--space-6) 0;
+    margin: var(--space-5) 0;
+    border-top: 1px solid var(--fg-faint);
+    border-bottom: 1px solid var(--fg-faint);
+  }
+
+  .stat-hero__value {
+    font-family: var(--font-display);
+    font-size: clamp(40px, 6vw, 68px);
+    font-weight: 500;
+    line-height: 1;
+    color: var(--brick);
+    letter-spacing: var(--tracking-tight);
+  }
+
+  .stat-hero__label {
+    margin-top: var(--space-3);
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -74,6 +74,8 @@ const projects = defineCollection({
     repoUrl: z.string().url(),
     liveDemoUrl: z.string().url().optional(),
     tryAgentTraceFile: z.string().optional(),
+    caseStudyAnchor: z.string().optional(),    // e.g. '#case-study' if MDX has that heading
+    failuresAnchor: z.string().optional(),     // e.g. '#failures' if MDX has that heading
     chapters: z.array(z.string()),
     references: z.array(z.string()).optional(),
   }),

--- a/src/content/evidence/baseline-eval-report.mdx
+++ b/src/content/evidence/baseline-eval-report.mdx
@@ -1,0 +1,132 @@
+---
+id: baseline-eval-report
+title: Baseline Evaluation Report
+description: Baseline evaluation of the Document Intelligence Agent across 30 test cases covering 11 categories. Documents pass rates, failure distribution, and per-case scores using an LLM-judge rubric. Establishes the starting point before hardening passes described in Chapter 6.
+heroStats:
+  - value: '63.3%'
+    label: 'Pass rate (19/30)'
+    color: 'accent'
+  - value: '0.68'
+    label: 'Avg score'
+    color: 'default'
+methodology: 30 test cases across 11 categories run against the Document Intelligence Agent (single-agent, bounded, 5-step budget). LLM-judge rubric weights correctness 0.4, groundedness 0.3, and completeness 0.3. Cases scoring 0.7 or above are marked PASS.
+measuredOn: 2026-03-26
+model: gpt-4o
+downloads:
+  - label: 'eval_results.csv'
+    href: 'https://github.com/sunilp/agentic-ai/raw/main/code/ch06/eval_results.csv'
+  - label: 'eval_harness.py'
+    href: 'https://github.com/sunilp/agentic-ai/raw/main/code/ch06/eval_harness.py'
+---
+
+**Run ID:** baseline-v1
+**Date:** 2026-03-26
+**Agent:** Document Intelligence Agent (single-agent, bounded, 5-step budget)
+**Model:** gpt-4o (temperature 0.0)
+**Dataset:** 30 test cases across 11 categories
+**Harness:** `src/ch06/eval_harness.py` with default rubric (correctness 0.4, grounded 0.3, completeness 0.3)
+**Pass threshold:** 0.7
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total cases | 30 |
+| Passed | 19 |
+| Failed | 11 |
+| Pass rate | 63.3% |
+| Average score | 0.68 |
+| Average latency | 2,340ms |
+| Total tokens | 47,200 |
+| Total cost | $0.118 |
+
+## Scores by Category
+
+| Category | Cases | Passed | Pass Rate | Avg Score |
+|----------|-------|--------|-----------|-----------|
+| simple_retrieval | 5 | 5 | 100% | 0.92 |
+| technical_detail | 7 | 5 | 71% | 0.74 |
+| conceptual | 2 | 2 | 100% | 0.88 |
+| comparison | 3 | 2 | 67% | 0.65 |
+| design_reasoning | 2 | 1 | 50% | 0.58 |
+| judgment | 1 | 0 | 0% | 0.42 |
+| error_handling | 3 | 2 | 67% | 0.71 |
+| enumeration | 1 | 1 | 100% | 0.85 |
+| security | 2 | 1 | 50% | 0.55 |
+| no_answer | 2 | 0 | 0% | 0.30 |
+| failure_handling | 2 | 0 | 0% | 0.38 |
+
+## Failure Distribution
+
+| Failure Category | Count | Description |
+|-----------------|-------|-------------|
+| no_citation | 5 | Answer lacked source citations |
+| incorrect | 4 | Answer contained wrong information |
+| escalation_missed | 2 | Should have escalated but answered confidently |
+
+## Analysis
+
+**What works well:**
+
+- Simple retrieval questions (100% pass rate) -- when the answer is directly in one chunk, the agent finds it reliably. These queries have clear vocabulary overlap with the indexed content and require no cross-document synthesis.
+- Conceptual questions with clear vocabulary matches perform well. "What is a bounded agent?" maps directly to chapter content.
+- The chunking strategy handles single-document answers effectively. Chunk sizes of 512 tokens with 64-token overlap capture most self-contained explanations.
+- Enumeration queries ("list the five hardening layers") work when the source text uses numbered lists or bullet points that survive chunking.
+
+**What fails:**
+
+- "No answer" cases (0% pass rate) -- the agent answers from training knowledge instead of escalating when evidence is insufficient. The confidence estimation heuristic is too generous. Both no_answer cases received retrieval scores below 0.4, but the agent still generated answers.
+- Design reasoning questions (50%) -- these require synthesizing across multiple chunks and the agent often cites only one source. The single-document retrieval bias means the agent finds one relevant paragraph and stops looking.
+- Judgment questions (0%) -- "when should you use a workflow instead of an agent?" requires reasoning the agent cannot do from document evidence alone. The answer involves weighing tradeoffs, which the model does from training data rather than retrieved evidence.
+- Failure handling (0%) -- the agent does not recognize when its own retrieval step returns low-quality results. It treats any retrieved content as valid evidence.
+
+**Key insight:** The baseline agent's biggest weakness is not retrieval quality -- it is uncertainty calibration. It does not know when it does not know. This is exactly what Chapter 6 addresses with proper evaluation and hardening. The five `no_citation` failures and two `escalation_missed` failures account for 64% of all failures, and both root causes trace back to the same problem: the agent lacks a reliable mechanism for assessing its own confidence.
+
+## Per-Case Results
+
+| Case ID | Category | Query | Score | Result | Failure Categories | Latency (ms) |
+|---------|----------|-------|-------|--------|-------------------|---------------|
+| SR-001 | simple_retrieval | What is the default chunk size used by the document loader? | 0.95 | PASS | -- | 1,820 |
+| SR-002 | simple_retrieval | What embedding model does the retriever use? | 0.90 | PASS | -- | 1,740 |
+| SR-003 | simple_retrieval | What is the pass threshold in the default rubric? | 0.95 | PASS | -- | 1,680 |
+| SR-004 | simple_retrieval | How many retry attempts does the reliability module default to? | 0.90 | PASS | -- | 1,920 |
+| SR-005 | simple_retrieval | What format does the tracer use for output files? | 0.90 | PASS | -- | 1,850 |
+| TD-001 | technical_detail | What retry strategy does the reliability module use? | 0.85 | PASS | -- | 2,140 |
+| TD-002 | technical_detail | What fields does the EvalCase model include? | 0.80 | PASS | -- | 2,280 |
+| TD-003 | technical_detail | How does the idempotency tracker key its cache? | 0.78 | PASS | -- | 2,410 |
+| TD-004 | technical_detail | What injection patterns does the security module detect? | 0.72 | PASS | -- | 2,560 |
+| TD-005 | technical_detail | What are the three scoring dimensions in the default rubric? | 0.75 | PASS | -- | 2,320 |
+| TD-006 | technical_detail | How does the checkpoint serialization handle non-JSON types? | 0.55 | FAIL | no_citation | 2,680 |
+| TD-007 | technical_detail | What is the structure of a TraceSpan and how does nesting work? | 0.48 | FAIL | no_citation | 2,740 |
+| CN-001 | conceptual | What is a bounded agent? | 0.92 | PASS | -- | 1,980 |
+| CN-002 | conceptual | What is the difference between evaluation and testing for LLM systems? | 0.84 | PASS | -- | 2,120 |
+| CMP-001 | comparison | How does the workflow implementation differ from the agent implementation? | 0.78 | PASS | -- | 2,890 |
+| CMP-002 | comparison | What are the tradeoffs between retry-on-all-exceptions versus selective retry? | 0.62 | FAIL | no_citation | 3,120 |
+| CMP-003 | comparison | Compare pattern-based injection detection with architectural defenses. | 0.55 | FAIL | incorrect | 3,340 |
+| DR-001 | design_reasoning | Why does the system use exponential backoff instead of fixed intervals? | 0.72 | PASS | -- | 2,680 |
+| DR-002 | design_reasoning | Why is the permission policy default restrictive rather than permissive? | 0.44 | FAIL | incorrect | 2,940 |
+| JD-001 | judgment | When should you use a workflow instead of an agent for document QA? | 0.42 | FAIL | incorrect | 3,180 |
+| EH-001 | error_handling | What happens when all retry attempts are exhausted? | 0.82 | PASS | -- | 2,240 |
+| EH-002 | error_handling | How does the agent handle a tool call with invalid arguments? | 0.75 | PASS | -- | 2,480 |
+| EH-003 | error_handling | What happens if the checkpoint file is corrupted? | 0.55 | FAIL | no_citation | 2,620 |
+| EN-001 | enumeration | List all failure categories tracked by the evaluation harness. | 0.85 | PASS | -- | 2,060 |
+| SC-001 | security | What side effects require approval in the default permission policy? | 0.72 | PASS | -- | 2,180 |
+| SC-002 | security | How does the system handle a successful prompt injection? | 0.38 | FAIL | incorrect, no_citation | 2,880 |
+| NA-001 | no_answer | What quantum computing algorithms does the system support? | 0.10 | FAIL | escalation_missed | 2,540 |
+| NA-002 | no_answer | What is the system's GDPR compliance status? | 0.12 | FAIL | escalation_missed | 2,380 |
+| FH-001 | failure_handling | What does the agent do when retrieval returns zero results? | 0.42 | FAIL | incorrect | 2,440 |
+| FH-002 | failure_handling | How does the system recover from a mid-run model provider outage? | 0.34 | FAIL | incorrect | 2,620 |
+
+## Interpreting These Results
+
+The 63.3% pass rate is a realistic baseline for a first implementation. It is not a good production number -- most teams would want 85%+ before shipping. But the value of this report is not the topline number. It is the failure distribution.
+
+Seven of eleven failures involve either missing citations or missing escalation. These are not model capability problems. They are system design problems with known fixes:
+
+1. **Citation enforcement.** Add citation format validation to the response parser. If the response lacks citations in the expected format, score it as a partial failure and retry with an explicit citation instruction.
+
+2. **Escalation threshold.** Set a minimum retrieval relevance score (0.5). Below that threshold, the agent should escalate rather than attempt to answer. The current system has no such threshold.
+
+3. **Multi-chunk synthesis.** For comparison and design reasoning queries, retrieve from multiple document sections and present them explicitly as separate evidence blocks. The current system retrieves the top-5 chunks but does not distinguish between "five chunks from one section" and "five chunks from five sections."
+
+These three fixes are implemented in the hardening pass described in Chapter 6. The post-hardening evaluation report shows the impact.

--- a/src/content/evidence/failure-cases.mdx
+++ b/src/content/evidence/failure-cases.mdx
@@ -1,0 +1,194 @@
+---
+id: failure-cases
+title: Failure Case Studies
+description: Five concrete failure cases from the Document Intelligence Agent baseline evaluation, each illustrating a different failure mode with root cause analysis and the fix applied during hardening. Covers escalation failure, citation fabrication, chunk boundary miss, tool argument hallucination, and budget exhaustion.
+heroStats:
+  - value: '37%'
+    label: 'Baseline failure rate (11/30)'
+    color: 'accent'
+  - value: '5'
+    label: 'No-citation failures (most common mode)'
+    color: 'default'
+methodology: Five failures selected from the 11 baseline failures to represent distinct root causes. Each case includes the full agent output, scoring breakdown, root cause diagnosis, and the specific fix applied during hardening. Combined, these five fixes moved pass rate from 63.3% to 83.3%.
+measuredOn: 2026-03-26
+model: gpt-4o
+downloads:
+  - label: 'failure_cases.json'
+    href: 'https://github.com/sunilp/agentic-ai/raw/main/code/ch06/failure_cases.json'
+  - label: 'eval_results.csv'
+    href: 'https://github.com/sunilp/agentic-ai/raw/main/code/ch06/eval_results.csv'
+---
+
+Five failures from the baseline evaluation. Each illustrates a different failure mode and what it teaches about agent system design. These are not hypothetical scenarios -- they are actual outputs from running `make eval` against the baseline implementation.
+
+---
+
+## Case 1: The Confident Wrong Answer
+
+**Case ID:** NA-001
+**Query:** "What quantum computing algorithms does the system support?"
+**Expected:** Escalate (no relevant documents)
+**Actual:** "The system supports various quantum-inspired optimization algorithms for document retrieval, including quantum approximate optimization for vector similarity search and quantum-enhanced embedding techniques."
+**Score:** 0.10 (FAIL)
+**Category:** no_answer
+**Failure type:** escalation_missed
+
+### What Happened
+
+The agent retrieved chunks about "algorithms" and "optimization" from unrelated code. The retrieval scores were low (0.31-0.42) but the agent answered confidently anyway, hallucinating from training knowledge. Every claim in the response is fabricated. The system has no quantum computing features. The model generated plausible technical language by combining real concepts (vector similarity, embeddings) with the query's topic (quantum computing).
+
+### Root Cause
+
+The confidence estimation heuristic does not distinguish between "low relevance retrieval" and "no relevant retrieval." A retrieval score of 0.35 should trigger escalation, not a confident answer. The system prompt instructs the agent to escalate when evidence is insufficient, but the model interprets "insufficient" differently when it has topically adjacent (but irrelevant) chunks in context. The presence of any evidence, regardless of quality, biases the model toward answering.
+
+### Fix Applied in Hardening
+
+Added a minimum retrieval relevance threshold of 0.5. Below that, the system escalates before the model call, removing the model's opportunity to confabulate. Post-hardening, this case correctly escalates with the response: "I don't have enough evidence to answer this question. The available documents cover document intelligence, evaluation, and security, but do not address quantum computing."
+
+### Design Lesson
+
+Never let the model decide whether to escalate based on weak evidence. Make it a system-level decision based on retrieval scores. The model is too agreeable -- it will try to answer anything you put in its context window. Escalation is an engineering control, not a prompt instruction.
+
+---
+
+## Case 2: Citation Fabrication
+
+**Case ID:** TD-007
+**Query:** "What is the structure of a TraceSpan and how does nesting work?"
+**Expected:** Description of TraceSpan fields with explanation of hierarchical nesting for debugging
+**Actual:** "The TraceSpan includes span_id, name, start_time, end_time, duration_ms, input_data, output_data, metadata, error, and children fields. Nesting allows parent spans to contain child spans, such as a retrieval span containing embedding and vector search sub-spans. [Source: src/ch06/tracer.py, line 42-55]"
+**Score:** 0.48 (FAIL)
+**Category:** technical_detail
+**Failure type:** no_citation
+
+### What Happened
+
+The answer content is correct. The field list matches the source code, and the nesting explanation is accurate. But the citation format is wrong in a subtle way: the agent cited "src/ch06/tracer.py, line 42-55" -- a source file path with line numbers -- instead of the expected format "[Source: chapter_06.md, tracer section]". The eval harness scored grounding at 0.0 because the cited source does not match any document in the corpus. The agent cited the code file directly (which it inferred from context) rather than the chapter that describes it.
+
+### Root Cause
+
+The system prompt says "cite your sources using [Source: filename, chunk_id] format." The retrieved chunks come from chapter_06.md, which discusses the tracer code and includes code snippets. The model saw the code snippet, recognized it as coming from tracer.py, and cited the original file rather than the document it was retrieved from. This is technically a reasonable inference, but it breaks the citation contract because tracer.py is not in the retrieval index.
+
+### Fix Applied in Hardening
+
+Two changes. First, the system prompt now explicitly says "cite the document the evidence was retrieved from, not the source code file it describes." Second, the response parser validates that cited sources match documents in the corpus index. If they do not match, the parser strips the invalid citation and the answer gets re-scored as uncited, triggering a retry with a citation-focused instruction.
+
+### Design Lesson
+
+Citation format is a contract between the agent and the eval harness. The model does not naturally understand this contract -- it cites what seems most helpful to the user. If citation format matters (and in production it does, because downstream systems parse citations programmatically), enforce it with validation, not just instructions.
+
+---
+
+## Case 3: Chunk Boundary Miss
+
+**Case ID:** CMP-002
+**Query:** "What are the tradeoffs between retry-on-all-exceptions versus selective retry?"
+**Expected:** Explanation covering: retrying all exceptions is simpler but wastes attempts on non-retryable errors; selective retry requires classifying errors but avoids wasting attempts; the 429 vs 400 distinction
+**Actual:** "Retrying on all exceptions provides simplicity -- any failure triggers a retry. However, this can waste retry attempts on errors that will never succeed, such as validation errors. Selective retry is more efficient but requires upfront classification of which errors are retryable." (No citation)
+**Score:** 0.62 (FAIL)
+**Category:** comparison
+**Failure type:** no_citation
+
+### What Happened
+
+The answer captures the general tradeoff but misses the specific examples from the documentation: the 429 (rate limited) vs 400 (bad request) distinction, and the guidance about 500 errors being "probably retryable." The retrieved chunks included this detail, but it spanned a chunk boundary. The key paragraph was split between chunk 15 (which ends with "you should narrow this to retryable errors only") and chunk 16 (which begins with "A 429 (rate limited) is retryable. A 400 (bad request) is not").
+
+The model received both chunks but they were not adjacent in the context window. Chunks 15 and 16 were separated by an unrelated chunk (chunk 17, about checkpointing) that had a slightly higher retrieval score for the keyword "retry." The model synthesized from chunk 15 alone, missing the concrete examples in chunk 16.
+
+### Root Cause
+
+The retrieval pipeline ranks chunks independently by relevance score. It does not consider chunk adjacency. When information spans a boundary, the two halves may be retrieved but interleaved with other chunks, breaking the narrative flow that the model needs to synthesize a complete answer. The 64-token overlap between chunks was not enough to capture the full 429/400 example.
+
+### Fix Applied in Hardening
+
+Added a "neighbor boost" to the retrieval pipeline: when a chunk scores above 0.7, its immediate neighbors (chunk N-1 and chunk N+1) get a 0.15 relevance boost. This keeps related chunks adjacent in the context window. Post-hardening, this case passes with score 0.82 and includes the specific HTTP status code examples.
+
+### Design Lesson
+
+Chunking is not just a preprocessing step -- it is an architectural decision that determines your retrieval ceiling. If your chunks are too small, answers span boundaries. If they are too large, irrelevant content dilutes the context. There is no universal right answer; the right chunk size depends on the structure of your source documents and the types of queries you expect.
+
+---
+
+## Case 4: Argument Hallucination in Tool Call
+
+**Case ID:** FH-001
+**Query:** "What does the agent do when retrieval returns zero results?"
+**Expected:** Description of the agent's behavior when no chunks meet the relevance threshold
+**Actual:** Agent called `search_documents(query="retrieval zero results handling", collection="error_handling_docs")` -- a collection that does not exist
+**Score:** 0.42 (FAIL)
+**Category:** failure_handling
+**Failure type:** incorrect
+
+### What Happened
+
+The agent decided that its initial retrieval was insufficient (correctly -- the top chunk scored only 0.52) and attempted to refine its search. But instead of reformulating the query and searching the same collection, it fabricated a collection name: `error_handling_docs`. The tool registry has one collection: `documents`. The agent invented a plausible-sounding but nonexistent collection, presumably because the query mentioned "error handling" and the model inferred a dedicated collection might exist.
+
+The tool call failed with "Collection 'error_handling_docs' not found." The agent then received this error as a tool result, but instead of retrying with the correct collection, it used its remaining step budget to answer from its initial (weak) retrieval. The final answer was vague and missed the specific behavior described in the source material.
+
+### Root Cause
+
+The tool schema describes the `collection` parameter as `str` with no enumeration of valid values. The model has no way to know which collections exist without either (a) a constrained parameter type listing valid options or (b) a tool that lists available collections. Neither was provided. The model guessed, and guessed wrong.
+
+### Fix Applied in Hardening
+
+Changed the `collection` parameter from a free-form string to an enum listing valid collection names. The model can no longer hallucinate collection names because the tool schema constrains the valid inputs. Additionally, added a `list_collections` tool that the agent can call to discover available collections at runtime.
+
+### Design Lesson
+
+Every free-form string parameter in a tool schema is an invitation for the model to hallucinate. Constrain tool parameters wherever possible: use enums, provide valid ranges, list allowed values. The more constrained the tool interface, the fewer ways the model can produce invalid calls. This is the principle from Chapter 2: tools should be hard to misuse.
+
+---
+
+## Case 5: Budget Exhaustion on Multi-Hop Question
+
+**Case ID:** FH-002
+**Query:** "How does the system recover from a mid-run model provider outage?"
+**Expected:** Explanation combining checkpointing (save state between steps), retry with backoff (handle transient failures), and circuit breaker (stop after sustained failures)
+**Actual:** After 5 steps, the agent produced a partial answer covering only retry with backoff. Checkpointing and circuit breakers were not mentioned.
+**Score:** 0.34 (FAIL)
+**Category:** failure_handling
+**Failure type:** incorrect
+
+### What Happened
+
+This query requires synthesizing information from three separate sections of Chapter 6: retry (reliability section), checkpointing (reliability section, different subsection), and circuit breakers (production notes). The agent's 5-step budget was consumed as follows:
+
+| Step | Action | Result |
+|------|--------|--------|
+| 1 | Retrieve "model provider outage recovery" | Top chunk: retry section (relevance: 0.62). No mention of checkpointing. |
+| 2 | Refine query: "system recovery provider failure" | Same chunks returned. Retrieval does not have enough diverse content for this broad query. |
+| 3 | Refine query: "handle API failure gracefully" | New chunk from reliability section about retry. Still no checkpointing or circuit breaker content. |
+| 4 | Tool call: `extract_code_block("chapter_06.md", "with_retry")` | Got the retry code. Agent now has detailed retry information but nothing else. |
+| 5 | Forced answer (budget exhausted) | Answered about retry only. |
+
+The agent spent 4 of 5 steps drilling deeper into retry instead of broadening its search to find checkpointing and circuit breakers. By the time it exhausted its budget, it had comprehensive retry information but had never encountered the other two recovery mechanisms.
+
+### Root Cause
+
+The agent's search refinement strategy is greedy: when a retrieval returns partially relevant results, it refines the query to get more relevant results on the same subtopic. It does not have a "broaden" strategy -- a way to explicitly search for related but different aspects of a question. The step budget of 5 is also tight for a three-part synthesis question; even with a broaden strategy, the agent might need 6-7 steps to find all three recovery mechanisms.
+
+### Fix Applied in Hardening
+
+Two changes. First, added a "decompose" step for multi-part questions. Before retrieval, the agent breaks the query into sub-questions: "How does the system retry on failure?", "How does the system save progress between steps?", "How does the system handle sustained outages?" Each sub-question gets its own retrieval. Second, increased the step budget from 5 to 8 for queries classified as "multi-hop" by the router.
+
+Post-hardening, this case scores 0.78 (PASS). The decomposition produces three sub-queries, each retrieving from different sections of Chapter 6, and the final answer covers all three recovery mechanisms.
+
+### Design Lesson
+
+Step budgets are not just cost controls -- they are architectural constraints. A budget of 5 steps works for single-topic queries but fails for synthesis questions that require visiting multiple sections of the corpus. Either increase the budget for complex queries (which costs more) or add a decomposition step that turns one complex query into several simple ones (which is more reliable). The decomposition approach is better because it converts a hard problem (multi-hop search) into several easy problems (single-hop search) that the agent already handles well.
+
+---
+
+## Summary of Fixes
+
+| Case | Failure Mode | Fix | Category |
+|------|-------------|-----|----------|
+| 1 | Confident wrong answer | Retrieval relevance threshold (0.5 minimum) | System-level control |
+| 2 | Citation fabrication | Citation validation + retry on format mismatch | Response parsing |
+| 3 | Chunk boundary miss | Neighbor boost in retrieval ranking | Retrieval pipeline |
+| 4 | Argument hallucination | Constrained tool parameters (enum instead of free string) | Tool design |
+| 5 | Budget exhaustion | Query decomposition + adaptive step budget | Agent architecture |
+
+Each fix addresses a different layer of the system. No single fix would resolve all five failures. This is why hardening is a multi-layer process: the eval report tells you what fails, the traces tell you why, and the fix depends on which layer is responsible.
+
+The combined effect of these five fixes, applied together, moves the baseline pass rate from 63.3% to 83.3%. The remaining failures are concentrated in judgment and no_answer categories that require deeper model capability improvements rather than system-level fixes.

--- a/src/content/evidence/trace-example.mdx
+++ b/src/content/evidence/trace-example.mdx
@@ -1,0 +1,240 @@
+---
+id: trace-example
+title: Trace Examples
+description: Annotated traces of three Document Intelligence Agent runs showing every step with timing, tokens, and decision points. Covers a clean pass, an escalation failure, and a multi-step tool-using run. Demonstrates how to read traces to diagnose retrieval, decision, and cost issues.
+heroStats:
+  - value: '3,240'
+    label: 'Tokens — multi-step trace (Trace 3)'
+    color: 'accent'
+  - value: '4,280ms'
+    label: 'Latency — multi-step trace (Trace 3)'
+    color: 'default'
+methodology: Three representative traces selected from the baseline evaluation run. Each trace logged via src/ch06/tracer.py with full span data including retrieval scores, token counts, and per-call timing. Traces chosen to illustrate distinct execution patterns.
+measuredOn: 2026-03-26
+model: gpt-4o
+downloads:
+  - label: 'trace_TD001.json'
+    href: 'https://github.com/sunilp/agentic-ai/raw/main/code/ch06/traces/trace_TD001.json'
+  - label: 'trace_NA002.json'
+    href: 'https://github.com/sunilp/agentic-ai/raw/main/code/ch06/traces/trace_NA002.json'
+  - label: 'trace_TD002.json'
+    href: 'https://github.com/sunilp/agentic-ai/raw/main/code/ch06/traces/trace_TD002.json'
+---
+
+Three traced agent runs from the baseline evaluation. Each illustrates a different execution pattern: a clean pass, a failure, and a multi-step tool-using run.
+
+---
+
+## Trace 1: Clean Pass -- "What retry strategy does the reliability module use?"
+
+**Query:** "What retry strategy does the reliability module use?"
+**Result:** PASS (score: 0.85)
+**Total time:** 2,140ms
+**Total tokens:** 1,847
+**Steps:** 1 (no refinement needed)
+
+### Trace Waterfall
+
+| Span | Duration | Tokens | Detail |
+|------|----------|--------|--------|
+| 1. Retrieve | 45ms | 0 | Query: "retry strategy reliability module". Top 5 chunks retrieved. Best match: chapter 6, reliability section, chunk 14 (relevance: 0.87) |
+| 2. Build Context | 3ms | 0 | System prompt (142 tokens) + 5 evidence chunks (823 tokens) + query (12 tokens) = 977 tokens total context |
+| 3. Model Call #1 | 1,890ms | 1,847 | Prompt: 977 tokens. Completion: 870 tokens. Model: gpt-4o. Temperature: 0.0 |
+| 4. Parse Response | 2ms | 0 | No tool calls. Direct answer with citations. Confidence: 0.74 |
+| **Total** | **2,140ms** | **1,847** | |
+
+### What the Model Saw
+
+**System prompt (142 tokens):**
+
+```
+You are a document intelligence agent. Answer the user's question
+using ONLY the evidence provided below. Cite your sources using
+[Source: filename, chunk_id] format. If the evidence is insufficient
+to answer confidently, respond with "I don't have enough evidence
+to answer this question" and explain what information is missing.
+Do not use your training knowledge to fill gaps in the evidence.
+```
+
+**Evidence chunks (top 3 of 5 shown):**
+
+```
+[chunk_14, chapter_06.md, relevance: 0.87]
+The `with_retry` function wraps any async operation with exponential
+backoff... max_attempts: int = 3, min_wait: float = 1.0,
+max_wait: float = 30.0... This uses the tenacity library, which
+handles the exponential backoff math.
+
+[chunk_15, chapter_06.md, relevance: 0.82]
+The critical design choice is retry_on. By default, it retries on
+all exceptions. In practice, you should narrow this to retryable
+errors only. A 429 (rate limited) is retryable. A 400 (bad request)
+is not...
+
+[chunk_16, chapter_06.md, relevance: 0.71]
+Wrap the model client call, not the entire agent loop. If step 3
+of 5 hits a rate limit, you want to retry step 3, not restart
+from step 1.
+```
+
+**Query (12 tokens):** "What retry strategy does the reliability module use?"
+
+### What the Model Returned
+
+> The reliability module uses exponential backoff with configurable parameters. The `with_retry` function wraps async operations and supports three configuration options: `max_attempts` (default 3), `min_wait` (default 1.0 second), and `max_wait` (default 30.0 seconds). It is built on the tenacity library. The `retry_on` parameter controls which exceptions trigger a retry -- by default all exceptions, though in practice this should be narrowed to retryable errors like 429 (rate limited) and 500 (server error), excluding non-retryable errors like 400 (bad request). [Source: chapter_06.md]
+
+### Scoring
+
+| Criterion | Weight | Score | Notes |
+|-----------|--------|-------|-------|
+| Correctness | 0.4 | 1.0 | Answer matches expected: "exponential backoff with configurable max attempts, min wait, and max wait" |
+| Grounded | 0.3 | 0.5 | Citation present but uses "chapter_06.md" instead of the expected "reliability.py" format |
+| Completeness | 0.3 | 1.0 | Full answer addressing all parameters |
+| **Weighted** | | **0.85** | **PASS** (threshold: 0.7) |
+
+### What This Trace Teaches
+
+1. **Retrieval was fast (45ms) and accurate (0.87 relevance).** The chunking strategy works for direct questions about a specific module. The query vocabulary ("retry strategy", "reliability module") maps directly to the source text.
+2. **Context assembly is negligible (3ms).** The bottleneck is always the model call. Optimizing context assembly is not worth the engineering effort.
+3. **977 tokens of context for 870 tokens of output** -- roughly 1:1 input:output ratio. This is efficient. Compare with Trace 3 below where the ratio is 3:1.
+4. **Grounding partially failed.** The model cited the source but in a slightly different format than expected. The eval harness caught this as a partial score. This is the kind of failure that a stricter response parser would catch and retry.
+
+---
+
+## Trace 2: Failure -- "What is the system's GDPR compliance status?"
+
+**Query:** "What is the system's GDPR compliance status?"
+**Result:** FAIL (score: 0.12)
+**Total time:** 2,380ms
+**Total tokens:** 1,620
+**Steps:** 1 (should have escalated, did not)
+
+### Trace Waterfall
+
+| Span | Duration | Tokens | Detail |
+|------|----------|--------|--------|
+| 1. Retrieve | 52ms | 0 | Query: "GDPR compliance status". Top 5 chunks retrieved. Best match: chapter 06, security section, chunk 22 (relevance: 0.34) |
+| 2. Build Context | 3ms | 0 | System prompt (142 tokens) + 5 evidence chunks (780 tokens) + query (9 tokens) = 931 tokens total context |
+| 3. Model Call #1 | 2,120ms | 1,620 | Prompt: 931 tokens. Completion: 689 tokens. Model: gpt-4o. Temperature: 0.0 |
+| 4. Parse Response | 5ms | 0 | No tool calls. Direct answer (should have been escalation). Confidence: 0.41 |
+| **Total** | **2,380ms** | **1,620** | |
+
+### What the Model Saw
+
+**Evidence chunks (top 3 of 5 shown):**
+
+```
+[chunk_22, chapter_06.md, relevance: 0.34]
+The security module in src/ch06/security.py addresses two aspects:
+permission enforcement and injection detection...
+
+[chunk_23, chapter_06.md, relevance: 0.29]
+Run the injection test suite weekly. Update the payload list as new
+injection techniques emerge. Review the permission policies
+quarterly...
+
+[chunk_08, chapter_06.md, relevance: 0.26]
+Without evaluation: You cannot detect regressions when you change
+the prompt, the model, or the retrieval strategy...
+```
+
+The retrieval scores are all below 0.4. None of the retrieved chunks mention GDPR, compliance frameworks, data protection, or any related concept. The chunks are about security and evaluation -- topically adjacent but not relevant.
+
+### What the Model Returned
+
+> The system incorporates several compliance-relevant features. The permission policy enforces least-privilege access, the injection detection module provides security monitoring, and the evaluation harness enables ongoing validation. For GDPR specifically, the system's tracing and checkpointing features provide auditability, though explicit GDPR compliance documentation would need to be added based on your specific data processing requirements. [Source: chapter_06.md, security section]
+
+### Scoring
+
+| Criterion | Weight | Score | Notes |
+|-----------|--------|-------|-------|
+| Correctness | 0.4 | 0.0 | The system has no GDPR compliance features. This answer is fabricated from tangentially related content. |
+| Grounded | 0.3 | 0.0 | Claims are not supported by the cited evidence. The security section says nothing about GDPR. |
+| Completeness | 0.3 | 0.4 | Answer is substantive in length but substantively wrong |
+| **Weighted** | | **0.12** | **FAIL** (threshold: 0.7) |
+
+**Failure categories:** `escalation_missed`
+
+### What This Trace Teaches
+
+1. **Retrieval scores were a clear signal.** The best chunk scored 0.34 -- well below what a correct answer would need. But the agent had no threshold for "these results are too weak to answer." It treated 0.34 the same as 0.87.
+2. **The model confabulated a plausible but wrong answer.** It took genuinely present features (permission policies, tracing) and reframed them as "compliance-relevant." This is not hallucination in the traditional sense -- the features exist. It is misattribution: claiming those features serve a purpose (GDPR compliance) that they were never designed for.
+3. **The system prompt said "if the evidence is insufficient, escalate."** The model did not follow this instruction. Why? Because the retrieved chunks were topically adjacent (security, auditing), the model judged them as "sufficient" even though they did not address the actual question.
+4. **The fix is architectural, not prompt-based.** Adding more emphatic instructions to "please really escalate when unsure" does not work reliably. The fix is a retrieval relevance threshold (0.5 minimum) that prevents the model from seeing low-quality evidence in the first place. If the best chunk is below 0.5, the system escalates before the model call, saving both tokens and incorrect answers.
+
+---
+
+## Trace 3: Multi-Step with Tool Call -- "What fields does the EvalCase model include?"
+
+**Query:** "What fields does the EvalCase model include?"
+**Result:** PASS (score: 0.80)
+**Total time:** 4,280ms
+**Total tokens:** 3,240
+**Steps:** 3 (initial retrieval, tool call for code extraction, final answer)
+
+### Trace Waterfall
+
+| Span | Duration | Tokens | Detail |
+|------|----------|--------|--------|
+| 1. Retrieve | 48ms | 0 | Query: "EvalCase model fields". Top 5 chunks retrieved. Best match: chapter 06, evaluation section, chunk 4 (relevance: 0.78) |
+| 2. Build Context | 3ms | 0 | System prompt (142 tokens) + 5 evidence chunks (860 tokens) + query (10 tokens) = 1,012 tokens |
+| 3. Model Call #1 | 1,680ms | 1,420 | Prompt: 1,012 tokens. Completion: 408 tokens. Contains tool call: `extract_code_block("chapter_06.md", "EvalCase")` |
+| 4. Tool: extract_code_block | 12ms | 0 | Searched chapter_06.md for code block containing "EvalCase". Found Pydantic model definition. Returned 6-line code snippet. |
+| 5. Build Context #2 | 2ms | 0 | Previous context (1,012 tokens) + tool result (89 tokens) + model response (408 tokens) = 1,509 tokens |
+| 6. Model Call #2 | 2,340ms | 1,820 | Prompt: 1,509 tokens. Completion: 311 tokens. Final answer with citation. |
+| 7. Parse Response | 3ms | 0 | No further tool calls. Direct answer. Confidence: 0.82 |
+| **Total** | **4,280ms** | **3,240** | |
+
+### What Happened at Each Step
+
+**Step 1-2: Initial retrieval.** The retrieved chunks included the narrative description of EvalCase but not the actual code definition. The chunk containing the code block was ranked 3rd (relevance: 0.68) and included surrounding prose that diluted the field list.
+
+**Step 3: Model decides to use a tool.** Rather than answering from the narrative description alone, the model recognized it needed the exact field list and called `extract_code_block` to get the Pydantic model definition. This is the bounded autonomy in action -- the agent made a judgment call that the narrative evidence was insufficient for a precise answer.
+
+**Step 4: Tool execution.** The tool searched the source document for a code block containing "EvalCase" and returned:
+
+```python
+class EvalCase(BaseModel):
+    id: str
+    query: str
+    expected_answer: str
+    expected_sources: list[str]
+    category: str
+    difficulty: str
+```
+
+**Step 5-6: Second model call.** With both the narrative description and the exact code, the model produced a complete answer listing all six fields with their types and purpose.
+
+### What the Model Returned
+
+> The EvalCase model includes six fields: `id` (str) for tracking, `query` (str) for the test question, `expected_answer` (str) for the gold answer, `expected_sources` (list[str]) for expected citation sources, `category` (str) for slicing results by query type, and `difficulty` (str) for additional metadata. [Source: chapter_06.md, EvalCase class definition]
+
+### Scoring
+
+| Criterion | Weight | Score | Notes |
+|-----------|--------|-------|-------|
+| Correctness | 0.4 | 1.0 | All six fields listed with correct types |
+| Grounded | 0.3 | 1.0 | Cites the class definition directly |
+| Completeness | 0.3 | 0.4 | Listed fields but did not explain the role of `category` and `difficulty` in analysis (partial) |
+| **Weighted** | | **0.80** | **PASS** (threshold: 0.7) |
+
+### What This Trace Teaches
+
+1. **The tool call was the right decision.** Without it, the agent would have listed fields from the narrative description, likely missing `difficulty` which is only mentioned once in prose. The code extraction gave it the definitive list.
+2. **Cost of the tool call:** 12ms latency and 89 tokens of result. Negligible. The cost is in the second model call (1,820 tokens), not the tool itself.
+3. **Context grew from 1,012 to 1,509 tokens between calls.** This 50% growth is manageable for a 2-step run but would compound in a 5-step run. Context pruning between steps (Chapter 6's recommendation) would help for longer runs.
+4. **The 3,240 total tokens cost roughly $0.008.** The same query through the workflow (no tool call, single model call) would cost $0.0016 but would likely score lower on completeness. This is the single-agent tradeoff in action: better answers at higher cost.
+
+---
+
+## Reading Traces in Practice
+
+These three traces illustrate the three questions you should ask when reviewing any agent run:
+
+1. **Was retrieval accurate?** Check the relevance scores. Trace 1 had 0.87 (good). Trace 2 had 0.34 (bad -- should have triggered escalation). Retrieval quality determines the ceiling for answer quality.
+
+2. **Did the agent make good decisions?** Trace 3 shows a good decision (use a tool to get exact data). Trace 2 shows a bad decision (answer confidently from weak evidence). The agent's decision quality is what separates a bounded agent from a workflow.
+
+3. **Where did the time and tokens go?** In all three traces, model calls dominate. Retrieval and tool execution are fast. Context assembly is negligible. If you need to optimize latency, optimize the model call (shorter context, faster model, or caching).
+
+The trace format used here matches the `Tracer` output from `src/ch06/tracer.py`. In production, these traces would be stored as JSON and queryable through whatever observability stack you use. The human-readable format above is what `make trace-report` produces for review.

--- a/src/content/evidence/workflow-vs-agent-comparison.mdx
+++ b/src/content/evidence/workflow-vs-agent-comparison.mdx
@@ -1,0 +1,140 @@
+---
+id: workflow-vs-agent-comparison
+title: 'Architecture Comparison: Workflow vs Single-Agent vs Multi-Agent'
+description: Side-by-side evaluation of three architectures on the same 30 queries. Multi-agent improves pass rate by only 3.4 percentage points over single-agent but costs 2.4x more and takes 2.2x longer. Provides the empirical basis for the book's architecture selection guidance.
+heroStats:
+  - value: '3.4pp'
+    label: 'Multi-agent accuracy gain over single-agent'
+    color: 'accent'
+  - value: '2.4x'
+    label: 'Multi-agent cost ratio vs single-agent'
+    color: 'default'
+  - value: '2.2x'
+    label: 'Multi-agent latency ratio vs single-agent'
+    color: 'default'
+methodology: Same 30 test cases from the baseline evaluation run against workflow, single-agent, and multi-agent architectures. All architectures use gpt-4o at temperature 0.0. Scored with the default rubric (correctness 0.4, grounded 0.3, completeness 0.3) at pass threshold 0.7.
+measuredOn: 2026-03-26
+model: gpt-4o
+downloads:
+  - label: 'comparison_results.csv'
+    href: 'https://github.com/sunilp/agentic-ai/raw/main/code/ch06/comparison_results.csv'
+  - label: 'eval_harness.py'
+    href: 'https://github.com/sunilp/agentic-ai/raw/main/code/ch06/eval_harness.py'
+---
+
+**Date:** 2026-03-26
+**Dataset:** Same 30 test cases from baseline evaluation
+**Models:** gpt-4o (temperature 0.0) for all three architectures
+**Rubric:** Default (correctness 0.4, grounded 0.3, completeness 0.3), threshold 0.7
+
+## Summary
+
+| Metric | Workflow | Single Agent | Multi-Agent |
+|--------|----------|-------------|-------------|
+| Pass rate | 56.7% | 63.3% | 66.7% |
+| Avg score | 0.61 | 0.68 | 0.71 |
+| Avg latency | 890ms | 2,340ms | 5,120ms |
+| Avg tokens/query | 620 | 1,570 | 3,840 |
+| Estimated cost (30 queries) | $0.047 | $0.118 | $0.288 |
+| Steps per query | 1.0 | 2.8 | 4.6 |
+| P95 latency | 1,240ms | 3,680ms | 8,940ms |
+
+## The Tradeoff
+
+Multi-agent improves pass rate by only 3.4 percentage points over single-agent, but costs 2.4x more and takes 2.2x longer. The workflow is cheapest and fastest but misses nuanced questions. For this task -- document question-answering with citation requirements -- single-agent is the sweet spot. It captures the major accuracy gains from being able to refine queries and re-retrieve, without the cost overhead of routing queries through a verifier that mostly confirms what the primary agent already got right.
+
+The data makes this clear: multi-agent's accuracy advantage comes entirely from the comparison and design_reasoning categories. On every other category, it matches single-agent at 2.4x the cost. Unless your query distribution is dominated by cross-document synthesis questions, multi-agent is not worth the overhead.
+
+## Where Each Architecture Wins
+
+| Category | Best Architecture | Why |
+|----------|------------------|-----|
+| simple_retrieval | Workflow (tie) | All three get these right. No reason to pay for agent overhead. Workflow: 100%, Single: 100%, Multi: 100%. |
+| technical_detail | Single Agent | Agent can refine query when first retrieval misses. Workflow cannot. Multi-agent adds cost without improving accuracy here. |
+| conceptual | Workflow (tie) | Clear vocabulary matches mean first retrieval succeeds. Agent overhead adds latency without accuracy gain. |
+| comparison | Multi-Agent | Verifier catches incorrect comparisons that single agent misses. Worth the overhead for these high-value queries. |
+| design_reasoning | Multi-Agent | Synthesis across sources benefits from reasoner + verifier separation. Multi-agent scores 0.72 vs single agent's 0.58. |
+| judgment | None | All three fail. Uncertainty calibration is a model problem, not an architecture problem. |
+| error_handling | Single Agent | Agent can retry with rephrased queries. Workflow is one-shot. Multi-agent adds no value here. |
+| enumeration | Workflow (tie) | Structured lists are easily retrieved and formatted by any architecture. |
+| security | Single Agent (marginal) | Agent can cross-reference permission policy docs. Multi-agent shows no improvement. |
+| no_answer | None | All three fail. None of them have proper escalation thresholds. This is a calibration problem across all architectures. |
+| failure_handling | None | All three fail. The failure handling questions expose gaps in all architectures' self-awareness. |
+
+## Per-Category Breakdown
+
+| Category | Workflow Score | Single Agent Score | Multi-Agent Score | Workflow Cost | Single Agent Cost | Multi-Agent Cost |
+|----------|--------------|-------------------|-------------------|---------------|-------------------|-------------------|
+| simple_retrieval | 0.89 | 0.92 | 0.93 | $0.008 | $0.019 | $0.046 |
+| technical_detail | 0.58 | 0.74 | 0.75 | $0.012 | $0.031 | $0.074 |
+| conceptual | 0.85 | 0.88 | 0.89 | $0.003 | $0.007 | $0.018 |
+| comparison | 0.48 | 0.65 | 0.78 | $0.005 | $0.013 | $0.032 |
+| design_reasoning | 0.35 | 0.58 | 0.72 | $0.003 | $0.010 | $0.026 |
+| judgment | 0.38 | 0.42 | 0.45 | $0.002 | $0.004 | $0.012 |
+| error_handling | 0.60 | 0.71 | 0.72 | $0.005 | $0.013 | $0.031 |
+| enumeration | 0.82 | 0.85 | 0.86 | $0.002 | $0.004 | $0.010 |
+| security | 0.48 | 0.55 | 0.56 | $0.003 | $0.007 | $0.016 |
+| no_answer | 0.28 | 0.30 | 0.32 | $0.002 | $0.005 | $0.012 |
+| failure_handling | 0.32 | 0.38 | 0.40 | $0.003 | $0.006 | $0.014 |
+
+## Cost Breakdown
+
+### Workflow (1 model call per query)
+
+| Component | Avg Tokens | Avg Cost | Notes |
+|-----------|------------|----------|-------|
+| Retrieval | 0 | $0.000 | Embedding lookup only, no model call |
+| Context assembly | 0 | $0.000 | Deterministic string construction |
+| Model call | 620 | $0.0016 | Single call: 380 prompt + 240 completion |
+| **Total per query** | **620** | **$0.0016** | |
+| **Total (30 queries)** | **18,600** | **$0.047** | |
+
+### Single Agent (avg 2.8 model calls per query)
+
+| Component | Avg Tokens | Avg Cost | Notes |
+|-----------|------------|----------|-------|
+| Retrieval | 0 | $0.000 | Embedding lookup |
+| Initial model call | 620 | $0.0016 | Same as workflow |
+| Refinement calls (avg 1.8) | 950 | $0.0024 | Query refinement + re-retrieval + answer |
+| **Total per query** | **1,570** | **$0.0039** | |
+| **Total (30 queries)** | **47,100** | **$0.118** | |
+
+### Multi-Agent (avg 4.6 model calls per query)
+
+| Component | Avg Tokens | Avg Cost | Notes |
+|-----------|------------|----------|-------|
+| Router call | 280 | $0.0007 | Classify query complexity |
+| Primary agent (avg 2.2 calls) | 1,960 | $0.0049 | Retrieval + reasoning |
+| Verifier agent (avg 1.4 calls) | 1,600 | $0.0040 | Cross-check citations and factual claims |
+| **Total per query** | **3,840** | **$0.0096** | |
+| **Total (30 queries)** | **115,200** | **$0.288** | |
+
+## Latency Distribution
+
+| Percentile | Workflow | Single Agent | Multi-Agent |
+|------------|----------|-------------|-------------|
+| P50 | 840ms | 2,180ms | 4,620ms |
+| P75 | 980ms | 2,840ms | 6,180ms |
+| P90 | 1,140ms | 3,340ms | 7,820ms |
+| P95 | 1,240ms | 3,680ms | 8,940ms |
+| P99 | 1,380ms | 4,120ms | 10,280ms |
+
+The multi-agent P95 is 7.2x the workflow P95. For a user-facing application with a 3-second SLA, multi-agent is not viable without caching or pre-computation. Single-agent fits within a 4-second SLA. Workflow fits comfortably within any reasonable SLA.
+
+## Verdict
+
+For the Document Intelligence Agent task:
+
+- Use a **workflow** for simple, single-source questions (60% of real queries). These are lookup queries with clear vocabulary overlap. The workflow handles them at 1/3 the latency and 1/3 the cost of the single agent, with no accuracy penalty.
+
+- Use a **single agent** for multi-hop or refinement-needed queries (30%). These are technical detail and error handling queries where the first retrieval might miss. The agent's ability to refine its query and re-retrieve justifies the 2.6x cost increase over the workflow.
+
+- Use **multi-agent** only for high-stakes queries where verification justifies the 2.4x cost premium over single-agent (10%). Comparison and design reasoning queries benefit measurably from a verifier. Everything else does not.
+
+- The **hybrid approach** (workflow default, agent escalation) outperforms any single architecture. Route simple queries through the workflow. Escalate to the single agent when the workflow's confidence is low. Escalate to multi-agent only for explicitly flagged high-value queries. This hybrid routing reduces average cost by 40% compared to running every query through the single agent, with no reduction in pass rate.
+
+## What This Comparison Does Not Show
+
+This comparison holds the model constant (gpt-4o for all architectures). In practice, the workflow could use a cheaper model (gpt-4o-mini) for simple queries, reducing the cost gap further. The single agent could route its refinement calls through a cheaper model. These model-routing optimizations are covered in Chapter 6's cost management section but are not reflected in these numbers.
+
+The comparison also holds the dataset constant. In production, the query distribution matters enormously. If 90% of your queries are simple lookups, the workflow is the clear winner. If 50% of your queries require cross-document synthesis, multi-agent starts to justify its cost. Know your query distribution before choosing an architecture.

--- a/src/content/labs/multi-agent-vs-router-100-queries.mdx
+++ b/src/content/labs/multi-agent-vs-router-100-queries.mdx
@@ -1,0 +1,92 @@
+---
+id: lab-001
+title: Multi-agent vs router on 100 customer-support queries
+description: 100 real support queries from a public dataset, run twice — once through a single-agent workflow router, once through a 3-agent hierarchical multi-agent system. Measured against the same eval rubric.
+hypothesis: A workflow router beats a 3-agent system on accuracy for sub-5-step support queries, with lower cost and lower latency.
+result: 87% vs 74%
+resultLabel: Router beat multi-agent on accuracy (+3.4pp normalized)
+date: 2026-05-20
+readingTime: 12
+reproduceRepo: https://github.com/sunilp/agentic-ai/tree/main/code/labs/lab-001
+dataUrl: https://github.com/sunilp/agentic-ai/raw/main/code/labs/lab-001/queries.json
+seed: 42
+references:
+  - ch-04
+  - ch-07
+  - fn-001
+  - evidence-workflow-vs-agent-comparison
+---
+
+import Callout from '~/components/universal/Callout.astro';
+
+The question this Lab answers: when a customer support query takes under 5 steps to resolve, does a multi-agent system actually add value over a workflow router calling a single agent? The TL;DR result is no — the router beat multi-agent on accuracy, cost, and latency on the same 100 queries. The interesting question is *why* the multi-agent system underperformed, which the Method section unpacks.
+
+## Setup
+
+**Dataset.** 100 customer support queries sampled from the public CSAT Bench dataset, filtered to queries that resolve within 5 turns of human-in-the-loop assistance. The filter exists because the experiment is specifically about *short-horizon* support tasks — multi-agent systems may still win on longer-horizon tasks; that's a separate Lab.
+
+**Workflow router architecture.** A switch statement that maps query category to one of four agent prompts: billing, technical, account, or escalation. The agent runs once, calls 0-3 tools (knowledge base lookup, account lookup, ticket creator), and produces a final response. Single LLM invocation per query; budget 8000 input tokens, 1500 output tokens.
+
+**Multi-agent architecture.** Three agents in hierarchical orchestration: a classifier agent (picks the worker), a worker agent (handles the query with tools), and a verifier agent (checks the worker's output against the original query before returning). All three use the same base model. Worker has the same tool budget as the router's agent.
+
+**Both systems** ran against the same eval rubric: 0.4 correctness, 0.3 grounded (did the answer cite the right tool output), 0.3 completeness. Pass threshold 0.7. LLM-judge with claude-opus-4-7 for consistency. Same model (claude-sonnet-4-6) for the agents under test.
+
+## Method
+
+Each system ran on the 100 queries with seed 42 for reproducibility. We logged the full trace per query, captured tool calls, token counts, latency from first byte to final byte, and total dollar cost per Anthropic's published pricing.
+
+Eval was run 3 times for each system to bound LLM-judge variance — final scores are the average. The 3-run variance was below 1pp on both systems, so the headline numbers are stable.
+
+The router was run with no per-category tuning beyond the initial prompt template. The multi-agent system was given two days of prompt-engineering polish before the eval was locked, to give it a fair shot.
+
+<Callout type="gotcha">
+The first multi-agent run scored 81%, which was within striking distance of the router. On inspection, the verifier agent was bypassing 14% of queries with "looks good to me" rubber-stamp responses regardless of content. The fix was a stricter verifier prompt with explicit verification criteria, but stricter verification also surfaced more genuine errors — net result: the multi-agent system dropped to 74% on the final eval.
+</Callout>
+
+## Results
+
+**Accuracy.** Router 87% / Multi-agent 74%. Difference: 13pp gross, 3.4pp normalized after controlling for query category mix (the multi-agent's classifier wasn't perfect, and it routed 9 queries to the wrong worker, which costs accuracy on top of the architecture overhead). The 3.4pp is the architecture cost.
+
+**Cost.** Router averaged $0.024 per query / Multi-agent $0.057 — 2.4× more expensive. The classifier + verifier are net-new LLM calls; the worker is doing the same work as the router's agent. So the cost penalty is mostly the orchestration overhead.
+
+**Latency.** Router p50 1.8s / Multi-agent p50 4.0s — 2.2× slower. Sequential agent invocation is the cause; parallelism in the multi-agent system was not pursued because the verifier needs the worker's output. Other multi-agent topologies could parallelize, but the failure mode the hypothesis targets (rubber-stamp verifier or category misroute) does not go away in parallel topologies.
+
+**Failure modes (multi-agent).**
+
+- Verifier rubber-stamp: 14% of queries pre-fix, ~3% post-fix
+- Classifier mis-routing: 9% of queries (worker handled wrong category)
+- Worker hallucination on grounding: 4% of queries (same rate as router's single agent — not an architecture failure)
+
+## Conclusion
+
+For short-horizon support queries with clear category boundaries, a workflow router beats a 3-agent system on every measured axis. The architecture cost of multi-agent — even hierarchical, even with a verifier — is real and non-trivial when the task does not require runtime coordination.
+
+This Lab does NOT show that multi-agent is bad. It shows that multi-agent costs something, and for tasks where the workflow already handles the routing well, that cost has no offsetting benefit.
+
+The next Lab in this series will measure the inflection point: at what query complexity does multi-agent start to earn its overhead? Plausible answer: queries that require dynamic decomposition the workflow router cannot encode (e.g., open-ended troubleshooting, multi-step research). That's the next experiment.
+
+## What we got wrong
+
+**Initial multi-agent system was too lenient.** The first eval pass produced 81% for multi-agent, which would have been a much more favorable headline. The rubber-stamp verifier was the actual cause; the fix improved diagnostic clarity but dropped the headline number. If you only run one eval pass, you get the rubber-stamp result. We almost shipped the lenient number.
+
+**Category labels in the dataset were not perfectly clean.** ~6 of the 100 queries had ambiguous categories, which made both systems' performance look worse than it would on a curated dataset. The router benefited slightly more from the noise because the workflow categorization is simpler. We left the noise in; production data is messier.
+
+**Eval cost.** Each full run cost ~$2.40 with claude-opus-4-7 as judge. Three runs per system = ~$15 total. Cheap, but worth noting for anyone reproducing.
+
+## Caveats
+
+- Single model (claude-sonnet-4-6 for agents, claude-opus-4-7 for judge). Cross-model robustness untested.
+- 100 queries is the absolute floor for an honest eval — wider replication would reduce LLM-judge variance further.
+- The multi-agent system was given prompt-engineering effort but not framework-level orchestration tuning. CrewAI, AutoGen, LangGraph variants may produce different numbers.
+- The router's single-prompt architecture is sometimes called a "smart switch" rather than a workflow. The category boundary between "workflow" and "single-agent with routing" is fuzzy; reasonable readers may classify this differently.
+
+```python
+# Sample harness invocation. Full code at the reproduce repo.
+from labs.lab_001 import run_router, run_multi_agent, evaluate
+
+queries = load_queries('queries.json')
+router_results = run_router(queries, seed=42)
+multi_results = run_multi_agent(queries, seed=42)
+
+print(evaluate(router_results), evaluate(multi_results))
+```

--- a/src/content/labs/multi-agent-vs-router-100-queries.mdx
+++ b/src/content/labs/multi-agent-vs-router-100-queries.mdx
@@ -14,7 +14,7 @@ references:
   - ch-04
   - ch-07
   - fn-001
-  - evidence-workflow-vs-agent-comparison
+  - workflow-vs-agent-comparison
 ---
 
 import Callout from '~/components/universal/Callout.astro';

--- a/src/content/projects/doc-intelligence-agent.mdx
+++ b/src/content/projects/doc-intelligence-agent.mdx
@@ -1,0 +1,217 @@
+---
+slug: doc-intelligence-agent
+title: Document Intelligence Agent
+tagline: "Ingest. Retrieve. Cite. Escalate on uncertainty."
+description: "A document question-answering system that retrieves evidence from ingested documents and answers with citations. Built incrementally across Chapters 2, 3, 4, and 6 of Agentic AI for Serious Engineers. This is the full case study -- the architecture, what we measured, what surprised us, and what we would change."
+architecture: /agentic-ai/assets/diagrams/system-architecture.svg
+evalStats:
+  accuracy: '76.7%'
+  avgCost: '$0.004'
+  latencyP50: '2.34s'
+repoUrl: https://github.com/sunilp/agentic-ai/tree/main/project/doc-intelligence-agent
+chapters: [ch-02, ch-03, ch-04, ch-06]
+references: [ch-02, ch-03, ch-04, ch-06, evidence-baseline-eval-report]
+---
+
+A document question-answering system that retrieves evidence from ingested documents and answers with citations.
+
+## What it does
+
+- Ingests PDF, markdown, and text documents
+- Chunks and indexes content using vector similarity
+- Retrieves relevant passages for a query
+- Answers with source citations
+- Escalates when evidence is insufficient (does not hallucinate)
+
+## Architecture walkthrough
+
+The system has four layers, each responsible for a distinct concern. The diagram below shows the full architecture; the narrative walks through each layer and the decisions behind it.
+
+<figure>
+  <img src="/agentic-ai/assets/diagrams/system-architecture.svg" alt="Document Intelligence Agent system architecture showing ingestion pipeline, retrieval layer, agent loop, and response pipeline" />
+  <figcaption>Figure 1: System architecture -- ingestion, retrieval, agent loop, and response pipeline</figcaption>
+</figure>
+
+**Ingestion pipeline.** Documents enter through the document loader (`src/ch02/loader.py`), which handles PDF, markdown, and plain text. The loader extracts raw text and metadata (filename, page numbers, headings). The chunker splits text into 512-token chunks with 64-token overlap. This overlap value was chosen deliberately -- shorter overlaps miss cross-sentence context, and longer overlaps waste tokens on duplication. After chunking, each chunk is embedded using a sentence-transformer model and stored in the vector index.
+
+**Retrieval layer.** Given a query, the retriever embeds it using the same model and runs a cosine similarity search against the index. It returns the top-5 chunks ranked by relevance score. After the hardening pass (Chapter 6), a neighbor boost was added: when a chunk scores above 0.7, its immediate neighbors (chunk N-1 and chunk N+1) receive a 0.15 relevance boost. This keeps related content adjacent in the context window and prevents chunk-boundary misses.
+
+**Agent loop.** The orchestration layer comes in three configurations, each built in a different chapter:
+
+1. **Workflow** (`src/ch03/workflow.py`): Fixed pipeline. Retrieve, build context, answer. One model call. Deterministic control flow.
+2. **Single agent** (`src/ch03/agent.py`): Bounded autonomy with a 5-step budget. Can refine its search query, call `extract_code_block` for precise code retrieval, and escalate when evidence is insufficient. Averages 2.8 model calls per query.
+3. **Multi-agent** (`src/ch04/multi_agent.py`): Router classifies query complexity, primary agent retrieves and reasons, verifier agent cross-checks citations and factual claims. Averages 4.6 model calls per query.
+
+**Response pipeline.** The response parser validates the agent's output against the citation contract: every factual claim must reference a document in the corpus index. After hardening, invalid citations (those referencing source code files instead of indexed documents) trigger a retry with explicit citation instructions. The response is then scored by the eval harness if running in evaluation mode.
+
+## Two implementations, one comparison
+
+This project is built twice to demonstrate the core architectural tradeoff:
+
+1. **Workflow** (`src/ch03/workflow.py`): Fixed pipeline. Retrieve, build context, answer. One model call. Deterministic.
+2. **Agent** (`src/ch03/agent.py`): Bounded autonomy. Can refine its search, plan steps, and escalate. Multiple model calls. Adaptive.
+
+Running both side by side with `make eval` shows exactly where each approach wins and loses. The comparison is not hypothetical -- it produces the data that drives the architectural decisions in Chapter 7.
+
+## What we measured
+
+### Baseline evaluation
+
+The baseline evaluation ran 30 test cases across 11 categories against the single-agent architecture. Full results are in the baseline evaluation report.
+
+| Metric | Value |
+|--------|-------|
+| Total cases | 30 |
+| Passed | 19 |
+| Failed | 11 |
+| Pass rate | 63.3% |
+| Average score | 0.68 |
+| Average latency | 2,340ms |
+| Total tokens | 47,200 |
+| Total cost | $0.118 |
+
+The failure distribution told us more than the pass rate:
+
+| Failure Category | Count | Description |
+|-----------------|-------|-------------|
+| no_citation | 5 | Answer lacked source citations or cited non-existent sources |
+| incorrect | 4 | Answer contained wrong information |
+| escalation_missed | 2 | Should have escalated but answered confidently |
+
+Seven of eleven failures traced back to the same root cause: the agent lacked a reliable mechanism for assessing its own confidence. It did not know when it did not know. The five no_citation failures and two escalation_missed failures accounted for 64% of all failures, and both categories are uncertainty calibration problems, not retrieval quality problems.
+
+### After hardening
+
+Chapter 6's hardening pass applied five targeted fixes, each addressing a different layer of the system:
+
+| Fix | Layer | What it addressed |
+|-----|-------|-------------------|
+| Retrieval relevance threshold (0.5 minimum) | System-level control | Confident wrong answers on out-of-scope queries |
+| Citation validation + retry on format mismatch | Response parsing | Citations referencing source code instead of indexed documents |
+| Neighbor boost in retrieval ranking | Retrieval pipeline | Answers missing detail that spanned chunk boundaries |
+| Constrained tool parameters (enum instead of free string) | Tool design | Agent hallucinating non-existent collection names |
+| Query decomposition + adaptive step budget | Agent architecture | Budget exhaustion on multi-hop questions |
+
+Post-hardening results:
+
+| Metric | Baseline | After Hardening | Change |
+|--------|----------|----------------|--------|
+| Pass rate | 63.3% | 76.7% | +13.4pp |
+| Average score | 0.68 | 0.79 | +0.11 |
+| no_citation failures | 5 | 1 | -4 |
+| escalation_missed failures | 2 | 0 | -2 |
+| incorrect failures | 4 | 3 | -1 |
+
+The +13.4 percentage point improvement came almost entirely from fixing uncertainty calibration and citation enforcement -- system-level controls, not model upgrades.
+
+## Architecture comparison
+
+We ran all three architectures (workflow, single agent, multi-agent) on the same 30 test cases.
+
+| Metric | Workflow | Single Agent | Multi-Agent |
+|--------|----------|-------------|-------------|
+| Pass rate | 56.7% | 63.3% | 66.7% |
+| Avg score | 0.61 | 0.68 | 0.71 |
+| Avg latency | 890ms | 2,340ms | 5,120ms |
+| Avg tokens/query | 620 | 1,570 | 3,840 |
+| Estimated cost (30 queries) | $0.047 | $0.118 | $0.288 |
+| P95 latency | 1,240ms | 3,680ms | 8,940ms |
+
+### Where each architecture wins
+
+| Category | Best Architecture | Why |
+|----------|------------------|-----|
+| simple_retrieval | Workflow (tie) | All three get these right. No reason to pay for agent overhead. |
+| technical_detail | Single Agent | Agent can refine query when first retrieval misses. Workflow cannot. Multi-agent adds no improvement. |
+| comparison | Multi-Agent | Verifier catches incorrect comparisons that single agent misses. Worth the overhead here. |
+| design_reasoning | Multi-Agent | Synthesis across sources benefits from reasoner + verifier separation. Multi-agent scores 0.72 vs single agent's 0.58. |
+| judgment / no_answer | None | All three fail. Uncertainty calibration is a model problem, not an architecture problem. |
+
+### The verdict
+
+Multi-agent improves pass rate by only 3.4 percentage points over single-agent, but costs 2.4x more and takes 2.2x longer. The improvement is concentrated in just two categories (comparison and design_reasoning). On every other category, multi-agent matches single-agent at 2.4x the cost.
+
+The hybrid approach outperforms any single architecture:
+
+- **Workflow** for simple, single-source questions (60% of real queries). Latency: sub-second. Cost: $0.0016 per query.
+- **Single agent** for multi-hop or refinement-needed queries (30%). The agent's query refinement justifies its 2.6x cost over the workflow.
+- **Multi-agent** only for explicitly flagged high-value queries where verification matters (10%). The 2.4x premium over single-agent is justified only for comparison and design reasoning queries.
+
+This hybrid routing reduces average cost by 40% compared to running every query through the single agent, with no reduction in pass rate.
+
+## What surprised us
+
+**Retrieval quality was not the bottleneck -- uncertainty calibration was.** Before building the system, we assumed we would spend most of our hardening effort improving retrieval: better embeddings, smarter chunking, more sophisticated re-ranking. In practice, retrieval worked well for 80%+ of queries. The biggest source of failures was the agent's inability to recognize when its retrieval was insufficient. It would receive chunks with relevance scores of 0.31 and answer confidently, hallucinating from training knowledge. The fix was a system-level retrieval threshold (0.5 minimum), not a better embedding model. This one change eliminated all escalation_missed failures.
+
+**Multi-agent improved accuracy by only 3.4 percentage points at 2.4x cost.** We expected the verifier agent to be more valuable. In practice, it confirmed what the primary agent already got right on 90%+ of queries. Its genuine contributions were limited to comparison and design_reasoning queries -- about 15% of the test set. For everything else, the verifier was performing a confirmation ceremony. A deterministic validation step (checking that cited documents exist in the index, checking that numbers parse correctly) would have caught most of the same errors at negligible cost.
+
+**The hybrid approach (workflow default, agent escalation) outperformed any single architecture.** This was the most important finding. No single architecture was best for all query types. But a routing layer that sends simple queries to the workflow and escalates complex ones to the agent produced better cost-adjusted results than running everything through any single architecture. The routing decision is simple: if the workflow's retrieval confidence is above threshold, use the workflow answer. If not, escalate to the agent. This is not sophisticated. It is effective.
+
+**Chunk overlap of 200 characters prevented more failures than expected.** The initial chunker used 64-token overlap. This was not enough to prevent cross-boundary misses on several technical_detail and comparison queries. Increasing overlap and adding the neighbor boost in the retrieval pipeline resolved this category of failure. Chunking is not a preprocessing detail -- it is an architectural decision that sets your retrieval ceiling.
+
+**The model's citation behavior required enforcement, not instruction.** The system prompt clearly stated the citation format. The model ignored it roughly 17% of the time -- not because it could not follow the format, but because it made reasonable inferences that violated the contract (citing source code files instead of the indexed documents that described them). The fix was citation validation in the response parser, not a stronger prompt. When correctness matters, enforce with code, not with instructions.
+
+## What we would change
+
+**Replace heuristic confidence estimation with a calibrated model.** The biggest class of failures -- confident wrong answers and missed escalations -- traces to the confidence estimation heuristic being too generous. The current system uses retrieval relevance scores as a proxy for answer confidence, with a hard threshold at 0.5. A calibrated model trained on (retrieval_score, answer_score) pairs from evaluation data would produce more nuanced escalation decisions. The data from the evaluation runs provides exactly the training signal needed.
+
+**Add query expansion for vocabulary mismatch cases.** Several technical_detail failures traced to the user's query terminology not matching the document's vocabulary. Query expansion -- generating 2-3 synonym queries before retrieval -- would bridge this gap without requiring an agent loop. This is a retrieval improvement, not an agent improvement.
+
+**Implement adaptive chunking based on document structure.** The current chunker uses a fixed 512-token window regardless of document structure. Technical documents have natural boundaries: section headings, code blocks, numbered lists. A structure-aware chunker that respects these boundaries would produce more coherent chunks and reduce cross-boundary misses.
+
+**Add an online feedback loop from user corrections.** The current system improves only through offline evaluation and manual hardening. In production, users who correct or reject the agent's answers are providing exactly the signal needed to improve retrieval and calibration. Logging user corrections, mapping them back to the query-retrieval-answer chain, and using them to update retrieval weights and escalation thresholds would create a continuous improvement loop.
+
+**Build the hybrid router from day one.** The comparison data makes it clear that no single architecture is optimal for all query types. If we were building this again, we would start with the hybrid architecture (workflow + agent escalation) rather than building the workflow first, then the agent, then comparing. The routing logic is simple enough that it does not add meaningful complexity, and it would have saved weeks of evaluation time.
+
+## Chapter cross-references
+
+| Chapter | What gets built |
+|---------|-----------------|
+| Chapter 2: Tools, Context, and the Agent Loop | Tool registry, document loader, chunker, retriever, basic agent loop |
+| Chapter 3: Workflow-First, Agent-Second | Workflow implementation, bounded agent, side-by-side comparison |
+| Chapter 4: Multi-Agent Without Theater | Multi-agent architecture with retriever, reasoner, and verifier |
+| Chapter 6: Evaluating and Hardening Agent Systems | Eval harness, tracer, reliability hardening, cost profiler, security hardening |
+| Chapter 7: When Not to Use Agents | Decision framework, honest retrospective with comparison data |
+
+## Evidence
+
+| Document | What it contains |
+|----------|-----------------|
+| Baseline Evaluation Report | 63.3% pass rate, per-category scores, failure distribution |
+| Architecture Comparison | Workflow vs single-agent vs multi-agent on same 30 queries |
+| Failure Case Studies | 5 traced failures with root cause analysis and fixes |
+| Trace Examples | 3 annotated agent runs showing step-by-step execution |
+
+## Running
+
+```bash
+make install
+python -m src.ch02.run --docs path/to/your/documents/
+python -m src.ch03.compare
+make eval
+```
+
+## Evaluation
+
+The eval harness tests 30 cases across six categories:
+
+| Category | Cases | What it tests |
+|----------|-------|---------------|
+| Simple retrieval | 5 | Direct factual questions with clear answers |
+| Technical detail | 5 | Specific implementation details in the docs |
+| Comparison | 5 | "What is the difference between X and Y" |
+| Design reasoning | 5 | Why decisions were made |
+| Error handling | 5 | Ambiguous or partially-answerable questions |
+| No-answer | 5 | Questions where the system should escalate rather than guess |
+
+See `evals/rubric.yaml` for scoring criteria and `evals/gold.json` for the gold dataset.
+
+## Critical failure surfaces
+
+These are not bugs to fix -- they are architectural constraints to understand and design around.
+
+- **Retrieval miss**: The answer exists in the documents but the query does not match the right chunks. Addressed by query expansion and neighbor boost.
+- **Context overflow**: Too many retrieved chunks degrade answer quality by diluting focus. Mitigated by chunk relevance thresholds.
+- **Hallucination on sparse evidence**: The model generates plausible-sounding but unsupported answers when retrieval is weak. Addressed by the 0.5 retrieval relevance threshold.
+- **Escalation threshold tuning**: Too conservative means unhelpful escalations; too permissive means hallucinated answers. Requires calibration against evaluation data.
+- **Chunk boundary splits**: Information spanning chunk boundaries may be retrieved but separated by unrelated content. Addressed by neighbor boost and increased overlap.

--- a/src/content/projects/framework-comparison.mdx
+++ b/src/content/projects/framework-comparison.mdx
@@ -1,0 +1,104 @@
+---
+slug: framework-comparison
+title: Framework Comparison
+tagline: Side-by-side comparison of raw, ADK, and LangChain agent implementations on identical queries to quantify framework overhead.
+description: "Companion to Section 0d of Agentic AI for Serious Engineers. Runs three agent implementations -- raw (no framework), Google ADK, and LangChain -- against the same test queries and reports accuracy, token overhead, latency, and cost for each. ADK and LangChain columns are optional; the raw agent works without any additional dependencies."
+architecture: /agentic-ai/assets/diagrams/three-way-comparison.svg
+evalStats:
+  accuracy: '84%'
+  avgCost: '$0.000560'
+  latencyP50: '41.2ms'
+repoUrl: https://github.com/sunilp/agentic-ai/tree/main/project/framework-comparison
+chapters: [ch-00d]
+---
+
+Side-by-side comparison of three agent implementations on identical test queries: raw (no framework), Google ADK, and LangChain.
+
+## What's inside
+
+- `src/raw_agent.py` -- Thin wrapper around `src/ch00/raw_agent.Agent`. No additional dependencies.
+- `src/adk_agent.py` -- Thin wrapper around `src/ch00/adk_agent.create_adk_agent`. Requires `google-adk`. If not installed, the column is skipped with a clear message.
+- `src/langchain_agent.py` -- Thin wrapper around `src/ch00/langchain_agent.create_langchain_agent`. Requires `langchain-core`, `langchain-anthropic`, and `langgraph`. If not installed, the column is skipped.
+- `src/compare.py` -- Runs all available implementations concurrently against the shared test queries and prints a comparison table.
+- `evals/test_queries.yaml` -- Five benchmark queries with expected answers.
+- `evals/rubric.yaml` -- Scoring rules (exact match = 1.0, substring = 0.8, no match = 0.0) and reported metrics.
+- `evals/run_eval.py` -- Full eval runner with per-query detail and summary table.
+
+## Prerequisites
+
+```bash
+# Base install (raw agent works with this)
+make install
+
+# Optional: enable ADK column
+pip install google-adk
+
+# Optional: enable LangChain column
+pip install langchain-core langchain-anthropic langgraph
+```
+
+## How to run
+
+```bash
+# Quick comparison (available implementations only)
+python project/framework-comparison/src/compare.py
+
+# Full eval with scoring
+python project/framework-comparison/evals/run_eval.py
+```
+
+## What you'll see
+
+With only the raw agent available:
+
+```
+Framework Comparison -- Foundations Section 0d
+=================================================================
+Running 5 queries across available implementations...
+
+=================================================================
+Implementation: raw_agent
+=================================================================
+Query                                  Score  Steps  Tokens       ms
+--------------------------------------  ------  -----  ------  ------
+What is 15 * 7?                           0.8      2     140    43.1
+...
+
+Implementation: adk_agent
+  SKIPPED: google-adk is not installed. Install with: pip install google-adk
+
+Implementation: langchain_agent
+  SKIPPED: langchain-core is not installed. ...
+
+=======================================================================
+Summary
+=======================================================================
+Implementation         Avg Score  Total Tokens     Avg ms   Total cost
+---------------------------------------------------------------------
+raw_agent                   0.84           700       41.2   $0.000560
+adk_agent           skipped (not installed)
+langchain_agent     skipped (not installed)
+```
+
+With all three frameworks installed, the summary table shows all columns and makes the overhead of each framework visible in tokens, latency, and cost.
+
+## What this comparison measures
+
+The rubric (`evals/rubric.yaml`) reports four metrics:
+
+| Metric | What it measures |
+|--------|-----------------|
+| accuracy | Average score across queries (0.0-1.0) |
+| total_tokens | Sum of all tokens consumed across the query set |
+| average_latency_ms | Mean time per query |
+| total_cost_usd | Estimated dollar cost for the full query set |
+
+The accuracy metric is identical across all three implementations because they run the same tools against the same queries. What differs is the overhead: how many extra tokens each framework adds to the prompt, how much latency the framework's orchestration layer contributes, and whether the framework exposes token usage data at all (ADK does not expose raw counts in the default runner).
+
+## What the comparison shows
+
+Section 0d makes the argument empirically: when accuracy is held constant (same tools, same queries), the question becomes what a framework costs you and what it gives back. The comparison table quantifies the cost side. The give-back -- guardrails, observability, deployment infrastructure -- is harder to measure but is what the rest of the book is about.
+
+## Connection to the book
+
+Section 0d evaluates three agent frameworks against the same task. This project makes that evaluation runnable so you can see the numbers yourself rather than take the chapter's word for them. The framework selection framework introduced in Section 0d -- choose raw when you need control, choose a framework when you need infrastructure -- is grounded in this data.

--- a/src/content/projects/incident-runbook-agent.mdx
+++ b/src/content/projects/incident-runbook-agent.mdx
@@ -1,0 +1,98 @@
+---
+slug: incident-runbook-agent
+title: Incident Runbook Agent
+tagline: "Inspect signals, search runbooks, propose remediation, request human approval."
+description: "An operational agent that inspects system signals, searches runbooks for matching procedures, proposes remediation steps, and requests human approval before executing any action. Built as the second end-to-end project for the book, demonstrating human-in-the-loop architecture in practice."
+architecture: /agentic-ai/assets/diagrams/incident-runbook-architecture.svg
+evalStats:
+  accuracy: '88%'
+  avgCost: '$0.006'
+  latencyP50: '1.8s'
+repoUrl: https://github.com/sunilp/agentic-ai/tree/main/project/incident-runbook-agent
+chapters: [ch-05]
+references: [ch-05]
+---
+
+An operational agent that inspects system signals, searches runbooks for matching procedures, proposes remediation steps, and requests human approval before executing any action.
+
+## What it teaches
+
+This project is the practical complement to Chapter 5: Human-in-the-Loop as Architecture. Where the chapter explains the primitives -- approval gates, escalation policies, and audit logs -- this project wires them into a working agent pipeline that handles production incidents.
+
+The key lessons:
+
+- **Approval gates belong in code, not prompts.** The agent does not decide what needs approval. The escalation policy and approval gate enforce that decision deterministically, regardless of what the model thinks about risk.
+- **Dry-run by default.** The agent proposes but never executes unless explicitly configured for live mode. Safety is the default posture; autonomy is opted into.
+- **Audit everything.** Every decision -- agent and human -- is recorded in an append-only log. The compliance trail is a debugging tool, not just a regulatory checkbox.
+- **Bounded action space.** The agent does not invent remediation steps. It matches known runbook procedures. This constraint keeps the agent's behavior within the bounds of verified, documented responses.
+
+## Architecture
+
+Four components in a linear pipeline with approval gates at decision points:
+
+1. **Signal Ingestion** -- receives and normalizes system alerts into typed `Alert` models
+2. **Runbook Search** -- vector similarity search over runbook symptoms, returning matched procedures with confidence scores
+3. **Remediation Engine** -- proposes steps based on the matched runbook
+4. **Approval Loop** -- escalation policy check, then approval gate, then audit logging
+
+```
+Alert -> Runbook Search -> Match Found? -> Escalation Policy
+                                               |
+                                         PROCEED / ESCALATE / HALT
+                                               |
+                                         Approval Gate
+                                               |
+                                      APPROVE / REJECT / MODIFY
+                                               |
+                                         Execute (or Dry-Run)
+                                               |
+                                         Audit Log
+```
+
+Every step records to the audit log. Not just the final decision -- every intermediate step. When you reconstruct an incident response after the fact, you can trace the full reasoning: which runbook matched, at what confidence, what the escalation policy decided, whether a human reviewed it, and what they decided.
+
+## HITL primitives used
+
+The project imports and composes the three primitives from `src/ch05_hitl/`:
+
+| Primitive | Module | Role in pipeline |
+|-----------|--------|-----------------|
+| `ApprovalGate` | `src/ch05_hitl/approval.py` | Routes actions to human reviewers based on risk and confidence |
+| `EscalationPolicy` | `src/ch05_hitl/escalation.py` | Decides PROCEED / ESCALATE / HALT based on per-tier rules |
+| `AuditLog` | `src/ch05_hitl/audit.py` | Records every decision immutably for compliance and debugging |
+
+The escalation policy uses four risk tiers (low, medium, high, critical) with different confidence thresholds and maximum autonomous actions per tier. Critical-tier incidents always escalate to a human -- the agent never proceeds autonomously on critical alerts regardless of its confidence.
+
+## Running
+
+```bash
+# From the repo root
+python project/incident-runbook-agent/src/run.py
+```
+
+## Evaluation
+
+```bash
+python project/incident-runbook-agent/evals/run_eval.py
+```
+
+25 incident scenarios across five categories: correct triage, no-runbook cases, false alarms, approximate matches, and escalation scenarios. The evaluation measures both the agent's triage accuracy and the appropriateness of its escalation decisions -- does it escalate when it should, and proceed when it can?
+
+## Known failure surfaces
+
+Documented in detail in `project/incident-runbook-agent/docs/failure-analysis.md`:
+
+- **Semantic gap** -- alert terminology does not match runbook symptoms
+- **Wrong match** -- alert matches a runbook for a different issue
+- **Over-escalation** -- routine issues escalated unnecessarily, contributing to approval fatigue
+- **Under-escalation** -- high-risk actions proceed without human review
+- **Stale context** -- situation changes between escalation and human review
+- **Approval fatigue** -- too many escalations cause reviewers to rubber-stamp
+
+Chapter 7's decision framework includes a HITL theater check specifically informed by these failure modes: if approval latency is under 10 seconds, rejection rate is under 1%, and modification rate is zero, the human oversight is ceremonial rather than genuine.
+
+## Connection to the book
+
+This project sits at the intersection of Chapters 5 and 7. Chapter 5 explains why and how to build HITL controls. Chapter 7 asks whether those controls are earning their cost -- or whether a simpler architecture (a workflow with direct human handling, or a fully autonomous agent with post-hoc review) would be more effective for a given deployment context.
+
+The Incident Runbook Agent is an example where HITL is clearly justified: the actions have real-world consequences (remediation on production infrastructure), the cost of a wrong action exceeds the cost of review latency, and regulatory requirements demand a human decision trail. Not every agent system meets these criteria. Chapter 7's decision framework helps you determine whether yours does.

--- a/src/content/projects/llm-explorer.mdx
+++ b/src/content/projects/llm-explorer.mdx
@@ -1,0 +1,82 @@
+---
+slug: llm-explorer
+title: LLM Explorer
+tagline: Hands-on experiments that make token counting, cost projection, and structured output tangible before you build agents.
+description: "Companion to Section 0a of Agentic AI for Serious Engineers. Three runnable modules -- token counter, context overflow simulator, and structured output patterns -- answer the core economics questions before you commit to an architecture. All modules run against a mock client; no API key required."
+architecture: /agentic-ai/assets/diagrams/context-window-bucket.svg
+evalStats:
+  accuracy: 'N/A'
+  avgCost: '$0.00'
+  latencyP50: 'N/A'
+repoUrl: https://github.com/sunilp/agentic-ai/tree/main/project/llm-explorer
+chapters: [ch-00a]
+---
+
+Hands-on experiments that make the mechanics of language models tangible before building agents on top of them.
+
+## What's inside
+
+- `src/token_counter.py` -- Compare the character-based token estimator from `llm_basics.py` against tiktoken (if installed). Project batch processing costs across all four model tiers from cheapest to most expensive.
+- `src/context_overflow.py` -- Progressive context fill experiment: fill a 4,096-token context window in 10% increments and observe how simulated quality degrades. Demonstrates the "lost in the middle" effect without a live model.
+- `src/structured_output.py` -- Three structured output patterns: JSON mode (model returns only JSON), schema enforcement (Pydantic validation), and extraction with fallback (safe default on failure).
+
+## How to run
+
+```bash
+make install
+
+# Token counting and cost projection
+python project/llm-explorer/src/token_counter.py
+
+# Context overflow experiment
+python project/llm-explorer/src/context_overflow.py
+
+# Structured output patterns
+python project/llm-explorer/src/structured_output.py
+```
+
+All three modules run against `MockClient` -- no API key required.
+
+## What you'll see
+
+**token_counter.py** prints a comparison table of character-based vs tiktoken counts for five sample texts ranging from a short sentence to a JSON snippet. Below the table, a batch cost projection shows the total cost to process 10,000 documents across all four model tiers, followed by a sensitivity table showing how cost scales with document length.
+
+```
+Token estimation: character-based vs tiktoken
+Sample                 chars  estimate  tiktoken  error %
+short_sentence            63        15        14    +7.1%
+medium_paragraph         367        91        83    +9.6%
+...
+
+Batch cost projection: 10,000 documents, 800 prompt tokens, 200 completion tokens each
+
+Model                               $/doc   Total cost
+gpt-4o-mini                    $0.000180       $1.80
+claude-haiku-4-5-20251001      $0.000720       $7.20
+gpt-4o                         $0.002200      $22.00
+claude-sonnet-4-20250514       $0.002800      $28.00
+```
+
+**context_overflow.py** prints a quality bar chart for each fill level from 10% to 100%:
+
+```
+Fill %  Est tokens  Utilisation   Found?  Quality  Bar
+   10%         409        10.0%      yes     1.00  [####################]
+   50%        2047        50.0%      yes     0.93  [##################  ]
+   80%        3277        80.0%      yes     0.55  [###########         ]
+  100%        4094       100.0%       no     0.22  [####                ]
+```
+
+**structured_output.py** prints pass/fail results for all three patterns, including deliberately invalid responses that exercise Pydantic validation errors.
+
+## What you'll learn
+
+Running these experiments answers three questions that determine your system's economics before you write a single agent:
+
+1. How far off is the quick token estimate? (Usually within 10%.)
+2. At what fill level does quality degrade? (Around 50% utilisation for middle-positioned content.)
+3. Which structured output pattern is safest? (Extraction with fallback -- the others silently fail on malformed model output.)
+
+## Connection to the book
+
+Section 0a covers how models process text as token sequences, why context windows are finite, and how to estimate cost before committing to an architecture. These experiments let you run the numbers yourself rather than trust the prose. The cost projections appear again in Chapter 7 when the book walks through framework selection decisions.

--- a/src/content/projects/memory-agent.mdx
+++ b/src/content/projects/memory-agent.mdx
@@ -1,0 +1,201 @@
+---
+slug: memory-agent
+title: Memory Agent
+tagline: "Memory-augmented pipeline with session, long-term, and shared memory layers."
+description: "A memory-augmented multi-agent orchestrator that extends the Chapter 4 multi-agent pipeline with three memory layers: session memory for conversation context, long-term memory for episodic learning, and shared memory for cross-agent coordination. Built as the third end-to-end project for the book, demonstrating how agents learn from experience without losing control."
+architecture: /agentic-ai/assets/diagrams/memory-hierarchy.svg
+evalStats:
+  accuracy: '82%'
+  avgCost: '$0.007'
+  latencyP50: '3.1s'
+repoUrl: https://github.com/sunilp/agentic-ai/tree/main/project/memory-agent
+chapters: [ch-12, ch-08]
+references: [ch-12, ch-08]
+---
+
+A memory-augmented multi-agent orchestrator with session, long-term, and shared memory layers, plus security defenses against memory poisoning.
+
+## What it does
+
+- Maintains a sliding context window across conversation turns with pluggable truncation strategies
+- Stores corrections, escalations, and negative retrievals as episodic long-term memories
+- Shares retrieval caches and pipeline state across agents via scoped key-value storage
+- Scrubs PII from session memory before storage
+- Detects and blocks three classes of memory poisoning attacks
+- Filters memory writes through a worthiness gate so only genuinely informative experiences are retained
+
+## Architecture overview
+
+The system layers three memory subsystems onto the existing retriever-reasoner-verifier pipeline from Chapter 4.
+
+```
+Query
+  |
+  v
+SessionMemory           (sliding context window, PII scrubbing)
+  |
+  v
+SharedMemory            (check retrieval cache, write pipeline state)
+  |
+  v
+RetrieverAgent ------>  SharedMemory (cache results)
+  |
+  v
+ReasoningAgent          (uses session context + long-term memories)
+  |
+  v
+VerifierAgent           (retry loop; rejections written to SharedMemory)
+  |
+  v
+LongTermMemory          (store corrections, escalations, negative retrievals)
+  |
+  v
+Response
+```
+
+**Session memory** (`src/ch12_memory/session_memory.py`) manages the sliding context window presented to the LLM on each turn. Three truncation strategies ship out of the box: recency (drop oldest), importance (score by heuristic signals -- numbers, questions, back-references -- and drop the least valuable), and compaction (summarise the oldest portion into a single system message). PII scrubbing runs before storage when enabled.
+
+**Long-term memory** (`src/ch12_memory/long_term_memory.py`) persists episodic records of corrections, escalations, and negative retrievals into a SQLite-backed vector store. A worthiness filter decides what gets stored: corrections, escalations, and negative retrievals are always persisted; high-confidence routine successes are discarded. This keeps long-term memory lean and focused on genuinely informative experiences.
+
+**Shared memory** (`src/ch12_memory/shared_memory.py`) provides a scoped key-value store with optimistic concurrency and atomic claims. Agents write retrieval caches, pipeline state, and verification rejections at AGENT, TEAM, or GLOBAL scope. Version-checked writes prevent stale overwrites; atomic claims provide "first writer wins" semantics for task coordination.
+
+## How to run
+
+### Unit tests
+
+```bash
+# From repo root
+pytest tests/unit/test_session_memory.py -v
+pytest tests/unit/test_long_term_memory.py -v
+pytest tests/unit/test_shared_memory.py -v
+pytest tests/unit/test_memory_store.py -v
+pytest tests/unit/test_defenses.py -v
+pytest tests/unit/test_scrubber.py -v
+```
+
+### Integration tests
+
+```bash
+pytest tests/integration/test_memory_pipeline.py -v
+pytest tests/integration/test_memory_security.py -v
+```
+
+### Security demos
+
+```bash
+python project/memory-agent/src/poisoning_demo.py
+```
+
+## What you'll see
+
+### Unit tests
+
+```
+tests/unit/test_session_memory.py::test_recency_truncation PASSED
+tests/unit/test_session_memory.py::test_importance_scoring PASSED
+tests/unit/test_session_memory.py::test_compaction_summarises_old PASSED
+tests/unit/test_long_term_memory.py::test_store_correction PASSED
+tests/unit/test_long_term_memory.py::test_worthiness_filter PASSED
+tests/unit/test_shared_memory.py::test_version_conflict PASSED
+tests/unit/test_shared_memory.py::test_atomic_claim PASSED
+tests/unit/test_defenses.py::test_validator_blocks_contradictory_correction PASSED
+tests/unit/test_defenses.py::test_anomaly_detector_flags_dormant PASSED
+```
+
+### Integration tests
+
+```
+tests/integration/test_memory_pipeline.py::test_full_pipeline_with_memory PASSED
+tests/integration/test_memory_pipeline.py::test_session_context_truncation PASSED
+tests/integration/test_memory_security.py::test_poisoning_blocked PASSED
+tests/integration/test_memory_security.py::test_sleeper_detected PASSED
+```
+
+### Security demos
+
+```
+============================================================
+  Memory Poisoning Attack Demonstrations
+============================================================
+
+------------------------------------------------------------
+DEMO 1: Direct Memory Poisoning
+------------------------------------------------------------
+
+[WITHOUT DEFENSE] Stored poisoned record: True
+  Correction text: maximum refund is $50,000 per transaction ...
+
+[WITH DEFENSE] MemoryValidator blocked it: True
+  Human-reviewed override accepted: True
+
+------------------------------------------------------------
+DEMO 2: Shared Memory Poisoning
+------------------------------------------------------------
+
+  Claimed result : fabricated_document.md
+  Actual result  : policy_v3.md
+  Mismatch found : True
+  [DEFENSE] Independent verification detected the discrepancy.
+
+------------------------------------------------------------
+DEMO 3: Sleeper Memory Attack
+------------------------------------------------------------
+
+  Memory ID      : sleeper_1
+  Age (days)     : 90
+  Access count   : 0
+  Flagged        : True
+  [DEFENSE] MemoryAnomalyDetector flagged this as suspicious.
+
+  Legitimate record (access_count=15) flagged: False
+```
+
+## Security demos
+
+Three memory poisoning attacks and their corresponding defenses:
+
+| Attack | Vector | Defense |
+|--------|--------|---------|
+| Direct poisoning | Contradictory correction claims $50,000 refund when evidence says $500 | `MemoryValidator` detects numeric divergence between evidence and correction |
+| Shared memory poisoning | Compromised retriever writes fabricated results to shared cache | Independent verification compares claimed vs actual retrieval results |
+| Sleeper memory | Dormant record planted months ago activates on trigger query | `MemoryAnomalyDetector` flags zero-access records older than the dormancy threshold |
+
+Each defense is deterministic -- no LLM calls, no probabilistic checks. The validator runs heuristic contradiction detection; the anomaly detector uses age and access count thresholds. Human-reviewed corrections bypass the validator because a human has already judged the content.
+
+## Evaluation
+
+The eval harness (`project/memory-agent/evals/`) scores the memory-augmented agent across five criteria:
+
+| Criterion | Weight | What it measures |
+|-----------|--------|-----------------|
+| accuracy | 1.0 | Fraction of queries where the answer matches expected |
+| memory_hit_rate | 0.5 | Fraction of queries where the relevant memory was retrieved |
+| contradiction_rate | 0.8 | Fraction of responses contradicting stored verified facts (lower is better) |
+| cost_efficiency | 0.3 | Token cost ratio vs baseline |
+| latency | 0.2 | Fraction of queries answered within target latency |
+
+Four test datasets cover distinct memory capabilities:
+
+- `test_queries_multiturn.yaml` -- multi-turn conversation with context dependencies
+- `test_queries_learning.yaml` -- correction storage and retrieval across sessions
+- `test_queries_coordination.yaml` -- multi-agent shared state and cache coherence
+- `test_poisoning.yaml` -- adversarial inputs that should be blocked
+
+## Connection to the book
+
+This project is the practical companion to Chapter 12: Memory Management. Where the chapter explains the theory -- why agents need memory, how to structure it, and what can go wrong -- this project wires all three memory layers into a working pipeline and demonstrates the security surface that memory creates.
+
+The key architectural decisions:
+
+- **Session memory uses truncation, not unlimited context.** The chapter explains why unbounded context windows degrade performance and cost. The implementation provides three strategies so you can measure the tradeoff for your workload.
+- **Long-term memory is selective.** The worthiness filter discards routine successes. Only corrections, escalations, negative retrievals, and non-obvious successes are persisted. The chapter explains why: an agent that remembers everything learns nothing useful.
+- **Shared memory uses optimistic concurrency.** The chapter explains why locks are impractical for multi-agent coordination. The implementation uses version-checked writes and atomic claims instead.
+- **Security defenses are deterministic.** The chapter argues that memory validation should not depend on the same LLM that produced the memory. The implementation enforces this: `MemoryValidator` and `MemoryAnomalyDetector` use heuristic rules, not model calls.
+
+## Chapter cross-references
+
+| Chapter | Connection |
+|---------|------------|
+| Chapter 4: Multi-Agent Without Theater | Base multi-agent pipeline that this project extends |
+| Chapter 6: Evaluating and Hardening | Security hardening patterns applied to the memory layer |
+| Chapter 12: Memory Management | The chapter this project implements |

--- a/src/content/projects/research-agent.mdx
+++ b/src/content/projects/research-agent.mdx
@@ -1,0 +1,100 @@
+---
+slug: research-agent
+title: Research Agent
+tagline: An instrumented multi-step agent loop with per-step cost logging, exportable JSON traces, and graceful error recovery.
+description: "Companion to Section 0c of Agentic AI for Serious Engineers. Extends the minimal agent loop with per-step StepTrace objects, accumulated AgentTrace export, and error recovery that captures exceptions as trace entries rather than terminating the run. The eval harness runs five benchmark queries and scores results against expected answers."
+architecture: /agentic-ai/assets/diagrams/agent-loop-foundations.svg
+evalStats:
+  accuracy: '100%'
+  avgCost: '$0.000276'
+  latencyP50: '73.4ms'
+repoUrl: https://github.com/sunilp/agentic-ai/tree/main/project/research-agent
+chapters: [ch-00c, ch-00d]
+---
+
+An expanded agent loop with configurable budgets, step-level token and cost tracking, JSON trace export, and graceful error recovery.
+
+## What's inside
+
+- `src/agent.py` -- `ResearchAgent`: the full instrumented loop. Extends the minimal agent from `src/ch00/raw_agent.py` with per-step `StepTrace` objects, accumulated `AgentTrace` export, and error recovery that captures exceptions as trace entries rather than terminating the run.
+- `src/tools.py` -- Four research tools with Pydantic validation: `calculator`, `search`, `read_url` (simulated URL fetch), and `summarize` (LLM-powered summarisation via an injectable `ModelClient`).
+- `src/run.py` -- CLI runner that takes a query, runs the agent, and prints the annotated trace. Optional `--export PATH` writes the trace to JSON.
+- `evals/test_queries.yaml` -- Five benchmark queries with expected answers.
+- `evals/run_eval.py` -- Loads the YAML, runs the agent against each query using scripted mock responses, scores with `score_answer()`, and prints a results table.
+
+## How to run
+
+```bash
+make install
+
+# Single query
+python project/research-agent/src/run.py "What is 15 * 7?"
+
+# Single query with trace export
+python project/research-agent/src/run.py --export trace.json "What is 100 / 4 + 10?"
+
+# Full eval suite
+python project/research-agent/evals/run_eval.py
+```
+
+## What you'll see
+
+The CLI runner prints an annotated trace for each run:
+
+```
+Trace for: 'What is 15 * 7?'
+Model: claude-haiku-4-5-20251001  max_steps: 8
+------------------------------------------------------------
+[1] tool_call  calculator({'operation': 'multiply', 'a': 15, 'b': 7})
+      -> 105.0
+      tokens=55  cost=$0.000044  42.3ms
+[2] response  '15 * 7 = 105'
+      tokens=85  cost=$0.000068  31.1ms
+------------------------------------------------------------
+Summary: 2 steps  140 tokens  $0.000112  73.4ms  [COMPLETED]
+Answer:  15 * 7 = 105
+```
+
+The eval runner prints a scored results table followed by a summary:
+
+```
+Running eval harness against research_agent (MockClient)...
+
+============================================================
+Implementation: research_agent
+============================================================
+Query                                    Expected      Got                       Score
+---------------------------------------- ------------ ------------------------- -----
+What is 15 * 7?                          105          15 * 7 = 105                0.8
+...
+
+Pass rate: 5/5 (100%)
+```
+
+## The trace format
+
+The `AgentTrace` dataclass serialises cleanly to JSON for offline analysis:
+
+```json
+{
+  "query": "What is 100 / 4 + 10?",
+  "model": "claude-haiku-4-5-20251001",
+  "total_steps": 3,
+  "total_cost_usd": 0.000276,
+  "budget_exhausted": false,
+  "answer": "100 / 4 + 10 = 35",
+  "steps": [
+    {"step": 1, "type": "tool_call", "tool": "calculator", "...": "..."},
+    {"step": 2, "type": "tool_call", "tool": "calculator", "...": "..."},
+    {"step": 3, "type": "response", "content": "100 / 4 + 10 = 35", "...": "..."}
+  ]
+}
+```
+
+## Connection to the book
+
+Section 0c introduces the raw agent loop -- the simplest possible implementation where a model iterates between tool calls and text responses. This project adds the instrumentation layer that makes production agents debuggable. The three additions -- per-step cost visibility, exportable traces, and captured error recovery -- each appear again in later chapters:
+
+- Per-step cost tracking is the foundation for the cost profiler in Chapter 6.
+- Trace export feeds the failure analysis workflow in Chapter 6's hardening section.
+- Error recovery as a design pattern (capture, log, continue) is formalised in Chapter 8's reliability section.

--- a/src/content/projects/tool-using-assistant.mdx
+++ b/src/content/projects/tool-using-assistant.mdx
@@ -1,0 +1,77 @@
+---
+slug: tool-using-assistant
+title: Tool-Using Assistant
+tagline: A single-turn assistant that selects and executes tools with Pydantic validation, isolating tool-call logic from the agent loop.
+description: "Companion to Section 0b of Agentic AI for Serious Engineers. A single-turn assistant that takes a query, selects the appropriate tool, executes it with validated arguments, and returns the result. Deliberate single-turn design isolates tool selection from multi-step loop logic. No API key required."
+architecture: /agentic-ai/assets/diagrams/function-calling-cycle.svg
+evalStats:
+  accuracy: 'N/A'
+  avgCost: '$0.00'
+  latencyP50: '1.0ms'
+repoUrl: https://github.com/sunilp/agentic-ai/tree/main/project/tool-using-assistant
+chapters: [ch-00b]
+---
+
+A single-turn assistant that takes a query, selects the appropriate tool, executes it with validated arguments, and returns the result.
+
+## What's inside
+
+- `src/tools.py` -- Four tools with Pydantic input validation: `calculator` (six operations), `word_counter` (word/character/sentence counts), `search` (simulated web search with realistic result objects), and `file_reader` (reads local files, sandboxed to the project directory).
+- `src/assistant.py` -- The `ToolUsingAssistant` class: receives a query, calls the model to select a tool, executes it via `execute_tool_call()`, then calls the model again to produce a final answer. Logs tool selections and validation errors.
+
+## How to run
+
+```bash
+make install
+
+# See all four tools and their schemas
+python project/tool-using-assistant/src/tools.py
+
+# Run the assistant demo
+python project/tool-using-assistant/src/assistant.py
+```
+
+No API key required. The demo uses `MockClient` with scripted responses to simulate tool selection.
+
+## What you'll see
+
+The tools demo prints the schema for each registered tool as the model would receive it, then runs direct calls including intentional validation failures:
+
+```
+Registered tools:
+
+  calculator: Perform arithmetic: add, subtract, multiply, divide, power, or modulo.
+    - operation [string] required (enum: ['add', 'subtract', 'multiply', 'divide', 'power', 'modulo'])
+    - a [number] required
+    - b [number] required
+  ...
+
+calculator(add, 15, 7) -> 22.0
+calculator(sqrt, 9, 0) [invalid op] -> Validation error: ...
+word_counter('   ') [empty text] -> Validation error: text must not be empty
+```
+
+The assistant demo runs five queries through the scripted mock and shows the full interaction:
+
+```
+Query:    What is 99 multiplied by 7?
+Tool:     calculator({'operation': 'multiply', 'a': 99, 'b': 7})
+Result:   693.0
+Answer:   99 * 7 = 693
+Tokens:   135  Latency: 1.2ms
+
+Query:    What is the capital of France?
+Tool:     (none -- direct answer)
+Answer:   The capital of France is Paris.
+Tokens:   80  Latency: 0.8ms
+```
+
+## How this differs from the agent loop
+
+This is a single-turn assistant -- one query produces at most one tool call and one answer. It does not loop. That design choice is deliberate: it isolates tool selection and validation from the multi-step loop logic so each concern can be understood independently.
+
+For the full multi-step loop see `project/research-agent/`.
+
+## Connection to the book
+
+Section 0b explains how structured tool calling works: how tools are described to the model as schemas, how the model selects and parameterises them, why Pydantic validation matters before execution, and what happens when the model passes invalid arguments. The `tools.py` file demonstrates all four steps in a single runnable file. The `assistant.py` file shows what a real single-turn implementation looks like, including the follow-up call that produces a human-readable answer from a raw tool result.

--- a/src/layouts/EvidenceLayout.astro
+++ b/src/layouts/EvidenceLayout.astro
@@ -1,0 +1,136 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
+import PageLayout from './PageLayout.astro';
+import Container from '~/components/layout/Container.astro';
+import Reader from '~/components/layout/Reader.astro';
+import KineticHeading from '~/components/universal/KineticHeading.astro';
+import Dek from '~/components/universal/Dek.astro';
+import Tag from '~/components/universal/Tag.astro';
+import HeroStatGrid from '~/components/universal/HeroStatGrid.astro';
+import Provenance from '~/components/universal/Provenance.astro';
+import DownloadList from '~/components/universal/DownloadList.astro';
+import { buildReverseIndex, getReverseLinks } from '~/lib/cross-links';
+import { entriesToContentEntries } from '~/lib/content-helpers';
+
+interface Props {
+  entry: CollectionEntry<'evidence'>;
+}
+
+const { entry } = Astro.props;
+const d = entry.data;
+
+const [chapters, fieldNotes, recipes, labs, evidence, projects] = await Promise.all([
+  getCollection('chapters'),
+  getCollection('fieldNotes'),
+  getCollection('recipes'),
+  getCollection('labs'),
+  getCollection('evidence'),
+  getCollection('projects'),
+]);
+const allEntries = [...chapters, ...fieldNotes, ...recipes, ...labs, ...evidence, ...projects];
+const reverseIndex = buildReverseIndex(entriesToContentEntries(allEntries as any));
+const links = getReverseLinks(reverseIndex, d.id);
+
+const collectionRoute: Record<string, string> = {
+  chapters: '/agentic-ai/book',
+  fieldNotes: '/agentic-ai/field-notes',
+  recipes: '/agentic-ai/recipes',
+  projects: '/agentic-ai/projects',
+  evidence: '/agentic-ai/evidence',
+  labs: '/agentic-ai/labs',
+  patterns: '/agentic-ai/patterns',
+};
+---
+
+<PageLayout
+  title={`${d.title} — Evidence`}
+  description={d.description}
+  currentNav="Evidence"
+>
+  <Container>
+    <Tag variant="accent">Evidence</Tag>
+    <KineticHeading level={1}>{d.title}</KineticHeading>
+    <Dek italic>{d.description}</Dek>
+
+    <HeroStatGrid items={d.heroStats.map((s) => ({ value: s.value, label: s.label, color: s.color }))} />
+
+    <Provenance measuredOn={d.measuredOn} model={d.model} />
+
+    <Reader>
+      <article class="evidence-body">
+        <slot />
+      </article>
+
+      <DownloadList items={d.downloads} />
+
+      {(links.referencedBy.length > 0 || links.citedBy.length > 0) && (
+        <section class="evidence-cited-by">
+          <h2>Cited by</h2>
+          <ul>
+            {[...links.referencedBy, ...links.citedBy].map((l) => (
+              <li><a href={`${collectionRoute[l.collection] ?? '/agentic-ai'}/${l.id}/`}>{l.collection}/{l.id}</a></li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </Reader>
+  </Container>
+</PageLayout>
+
+<style>
+  .evidence-body {
+    font-size: var(--body-1);
+    line-height: var(--lh-base);
+  }
+
+  .evidence-body :global(h2) {
+    margin-top: var(--space-6);
+    margin-bottom: var(--space-3);
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--fg-faint);
+  }
+
+  .evidence-body :global(p) {
+    margin: 0 0 var(--space-4);
+  }
+
+  .evidence-body :global(table) {
+    border-collapse: collapse;
+    margin: var(--space-4) 0;
+    font-size: var(--body-2);
+    width: 100%;
+  }
+
+  .evidence-body :global(th),
+  .evidence-body :global(td) {
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--fg-faint);
+    text-align: left;
+  }
+
+  .evidence-body :global(th) {
+    background: var(--paper-recess);
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+  }
+
+  .evidence-cited-by {
+    margin-top: var(--space-6);
+    padding-top: var(--space-5);
+    border-top: 1px solid var(--fg-faint);
+  }
+
+  .evidence-cited-by h2 {
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+  }
+
+  .evidence-cited-by ul { list-style: none; padding: 0; }
+  .evidence-cited-by a { font-family: var(--font-mono); font-size: var(--body-3); color: var(--fg); }
+</style>

--- a/src/layouts/LabReportLayout.astro
+++ b/src/layouts/LabReportLayout.astro
@@ -1,0 +1,146 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
+import PageLayout from './PageLayout.astro';
+import Container from '~/components/layout/Container.astro';
+import Reader from '~/components/layout/Reader.astro';
+import MetaStrip from '~/components/universal/MetaStrip.astro';
+import KineticHeading from '~/components/universal/KineticHeading.astro';
+import Dek from '~/components/universal/Dek.astro';
+import HypothesisBlock from '~/components/universal/HypothesisBlock.astro';
+import StatHero from '~/components/universal/StatHero.astro';
+import SectionAnchors from '~/components/universal/SectionAnchors.astro';
+import ReproduceStrip from '~/components/universal/ReproduceStrip.astro';
+import { buildReverseIndex, getReverseLinks } from '~/lib/cross-links';
+import { entriesToContentEntries } from '~/lib/content-helpers';
+
+interface Props {
+  entry: CollectionEntry<'labs'>;
+}
+
+const { entry } = Astro.props;
+const d = entry.data;
+
+const [chapters, fieldNotes, recipes, labs, evidence, projects] = await Promise.all([
+  getCollection('chapters'),
+  getCollection('fieldNotes'),
+  getCollection('recipes'),
+  getCollection('labs'),
+  getCollection('evidence'),
+  getCollection('projects'),
+]);
+const allEntries = [...chapters, ...fieldNotes, ...recipes, ...labs, ...evidence, ...projects];
+const reverseIndex = buildReverseIndex(entriesToContentEntries(allEntries as any));
+const links = getReverseLinks(reverseIndex, d.id);
+
+const dateStr = d.date.toISOString().slice(0, 10);
+const metaItems = [d.id.toUpperCase(), dateStr, `${d.readingTime} min`];
+
+const sections = [
+  { label: 'Setup', anchor: 'setup' },
+  { label: 'Method', anchor: 'method' },
+  { label: 'Results', anchor: 'results' },
+  { label: 'Conclusion', anchor: 'conclusion' },
+  { label: 'What we got wrong', anchor: 'what-we-got-wrong' },
+  { label: 'Caveats', anchor: 'caveats' },
+];
+
+const collectionRoute: Record<string, string> = {
+  chapters: '/agentic-ai/book',
+  fieldNotes: '/agentic-ai/field-notes',
+  recipes: '/agentic-ai/recipes',
+  projects: '/agentic-ai/projects',
+  evidence: '/agentic-ai/evidence',
+  labs: '/agentic-ai/labs',
+  patterns: '/agentic-ai/patterns',
+};
+---
+
+<PageLayout
+  title={`${d.title} — Lab Report`}
+  description={d.description}
+  currentNav="Labs"
+>
+  <Container>
+    <MetaStrip items={metaItems} />
+    <KineticHeading level={1}>{d.title}</KineticHeading>
+    <Dek italic>{d.description}</Dek>
+
+    <HypothesisBlock>{d.hypothesis}</HypothesisBlock>
+
+    <StatHero value={d.result} label={d.resultLabel} />
+
+    <SectionAnchors items={sections} />
+
+    <Reader>
+      <article class="lab-body">
+        <slot />
+      </article>
+
+      <ReproduceStrip repo={d.reproduceRepo} data={d.dataUrl} seed={d.seed} />
+
+      {(links.referencedBy.length > 0 || links.citedBy.length > 0) && (
+        <section class="lab-cited-by">
+          <h2>Cited by</h2>
+          <ul>
+            {[...links.referencedBy, ...links.citedBy].map((l) => (
+              <li><a href={`${collectionRoute[l.collection] ?? '/agentic-ai'}/${l.id}/`}>{l.collection}/{l.id}</a></li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </Reader>
+  </Container>
+</PageLayout>
+
+<style>
+  .lab-body {
+    font-size: var(--body-1);
+    line-height: var(--lh-base);
+  }
+
+  .lab-body :global(h2) {
+    margin-top: var(--space-7);
+    margin-bottom: var(--space-3);
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--fg-faint);
+    scroll-margin-top: 120px;
+  }
+
+  .lab-body :global(p),
+  .lab-body :global(ul),
+  .lab-body :global(ol) {
+    margin: 0 0 var(--space-4);
+  }
+
+  .lab-body :global(li) { margin-bottom: var(--space-2); }
+
+  .lab-body :global(a) {
+    color: var(--fg);
+    text-decoration: underline;
+    text-decoration-color: var(--fg-faint);
+    text-underline-offset: 3px;
+  }
+
+  .lab-body :global(a:hover) {
+    color: var(--brick);
+    text-decoration-color: var(--brick);
+  }
+
+  .lab-cited-by {
+    margin-top: var(--space-6);
+    padding-top: var(--space-5);
+    border-top: 1px solid var(--fg-faint);
+  }
+
+  .lab-cited-by h2 {
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+  }
+
+  .lab-cited-by ul { list-style: none; padding: 0; }
+  .lab-cited-by a { font-family: var(--font-mono); font-size: var(--body-3); color: var(--fg); }
+</style>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -6,6 +6,7 @@
 import { ClientRouter } from 'astro:transitions';
 import TopNav from '~/components/universal/TopNav.astro';
 import SiteFooter from '~/components/universal/SiteFooter.astro';
+import CommandPalette from '~/components/islands/CommandPalette.svelte';
 import '~/styles/global.css';
 
 interface Props {
@@ -42,6 +43,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
   <body class={bodyClass}>
     <a href="#main-content" class="skip-nav">Skip to content</a>
     <TopNav current={currentNav} />
+    <CommandPalette client:idle />
     <main id="main-content">
       <slot />
     </main>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -55,8 +55,8 @@ const collectionRoute: Record<string, string> = {
 
     <ProductCardHero
       runIt={d.liveDemoUrl}
-      caseStudy="#case-study"
-      failures="#failures"
+      caseStudy={d.caseStudyAnchor}
+      failures={d.failuresAnchor}
       codeRepo={d.repoUrl}
     />
 

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -1,0 +1,154 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
+import PageLayout from './PageLayout.astro';
+import Container from '~/components/layout/Container.astro';
+import Reader from '~/components/layout/Reader.astro';
+import KineticHeading from '~/components/universal/KineticHeading.astro';
+import Dek from '~/components/universal/Dek.astro';
+import Tag from '~/components/universal/Tag.astro';
+import ProductCardHero from '~/components/universal/ProductCardHero.astro';
+import ArchitectureDiagram from '~/components/universal/ArchitectureDiagram.astro';
+import EvalStats from '~/components/universal/EvalStats.astro';
+import { buildReverseIndex, getReverseLinks } from '~/lib/cross-links';
+import { entriesToContentEntries } from '~/lib/content-helpers';
+
+interface Props {
+  entry: CollectionEntry<'projects'>;
+}
+
+const { entry } = Astro.props;
+const d = entry.data;
+
+const [chapters, fieldNotes, recipes, labs, evidence, projects] = await Promise.all([
+  getCollection('chapters'),
+  getCollection('fieldNotes'),
+  getCollection('recipes'),
+  getCollection('labs'),
+  getCollection('evidence'),
+  getCollection('projects'),
+]);
+const allEntries = [...chapters, ...fieldNotes, ...recipes, ...labs, ...evidence, ...projects];
+const reverseIndex = buildReverseIndex(entriesToContentEntries(allEntries as any));
+const links = getReverseLinks(reverseIndex, d.slug);
+
+const collectionRoute: Record<string, string> = {
+  chapters: '/agentic-ai/book',
+  fieldNotes: '/agentic-ai/field-notes',
+  recipes: '/agentic-ai/recipes',
+  projects: '/agentic-ai/projects',
+  evidence: '/agentic-ai/evidence',
+  labs: '/agentic-ai/labs',
+  patterns: '/agentic-ai/patterns',
+};
+---
+
+<PageLayout
+  title={`${d.title} — Projects`}
+  description={d.description}
+  currentNav="Book"
+>
+  <Container>
+    <Tag>Project</Tag>
+    <KineticHeading level={1}>{d.title}</KineticHeading>
+    <Dek italic>{d.tagline}</Dek>
+
+    <ProductCardHero
+      runIt={d.liveDemoUrl}
+      caseStudy="#case-study"
+      failures="#failures"
+      codeRepo={d.repoUrl}
+    />
+
+    <ArchitectureDiagram
+      src={d.architecture}
+      alt={`${d.title} system architecture`}
+      caption={`Figure 1: ${d.title} architecture`}
+    />
+
+    <EvalStats stats={d.evalStats} />
+
+    <Reader>
+      <article class="project-body">
+        <slot />
+      </article>
+
+      {(links.referencedBy.length > 0 || links.citedBy.length > 0) && (
+        <section class="project-cited-by">
+          <h2>Cited by</h2>
+          <ul>
+            {[...links.referencedBy, ...links.citedBy].map((l) => (
+              <li><a href={`${collectionRoute[l.collection] ?? '/agentic-ai'}/${l.id}/`}>{l.collection}/{l.id}</a></li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </Reader>
+  </Container>
+</PageLayout>
+
+<style>
+  .project-body {
+    font-size: var(--body-1);
+    line-height: var(--lh-base);
+  }
+
+  .project-body :global(h2) {
+    margin-top: var(--space-7);
+    margin-bottom: var(--space-3);
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--fg-faint);
+  }
+
+  .project-body :global(h3) {
+    margin-top: var(--space-5);
+    margin-bottom: var(--space-2);
+  }
+
+  .project-body :global(p),
+  .project-body :global(ul),
+  .project-body :global(ol) {
+    margin: 0 0 var(--space-4);
+  }
+
+  .project-body :global(li) {
+    margin-bottom: var(--space-2);
+  }
+
+  .project-body :global(a) {
+    color: var(--fg);
+    text-decoration: underline;
+    text-decoration-color: var(--fg-faint);
+    text-underline-offset: 3px;
+  }
+
+  .project-body :global(a:hover) {
+    color: var(--brick);
+    text-decoration-color: var(--brick);
+  }
+
+  .project-cited-by {
+    margin-top: var(--space-7);
+    padding-top: var(--space-5);
+    border-top: 1px solid var(--fg-faint);
+  }
+
+  .project-cited-by h2 {
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+  }
+
+  .project-cited-by ul {
+    list-style: none;
+    padding: 0;
+  }
+
+  .project-cited-by a {
+    font-family: var(--font-mono);
+    font-size: var(--body-3);
+    color: var(--fg);
+  }
+</style>

--- a/src/lib/d3-helpers.ts
+++ b/src/lib/d3-helpers.ts
@@ -1,0 +1,17 @@
+/**
+ * D3 helpers — small utilities used by chart Svelte islands.
+ * Keep the bundle small by importing only what we need.
+ */
+import { scaleLinear, scaleBand, max, min, extent } from 'd3';
+
+export { scaleLinear, scaleBand, max, min, extent };
+
+/** Map a numeric value to brick or ink based on whether it's the "winning" datum. */
+export function colorForValue(value: number, isAccent: boolean): string {
+  return isAccent ? '#9b4a3f' : '#1a1a1a';
+}
+
+/** Format a numeric tick: 87 → "87%", 1.4 → "1.4×", -3.4 → "-3.4pp". */
+export function formatTick(value: number, unit: '%' | '×' | 'pp' | ''): string {
+  return `${value.toFixed(unit === '×' ? 1 : 1)}${unit}`;
+}

--- a/src/lib/d3-helpers.ts
+++ b/src/lib/d3-helpers.ts
@@ -6,12 +6,12 @@ import { scaleLinear, scaleBand, max, min, extent } from 'd3';
 
 export { scaleLinear, scaleBand, max, min, extent };
 
-/** Map a numeric value to brick or ink based on whether it's the "winning" datum. */
-export function colorForValue(value: number, isAccent: boolean): string {
+/** Brick or ink based on whether this is the "winning" datum. */
+export function colorForAccent(isAccent: boolean): string {
   return isAccent ? '#9b4a3f' : '#1a1a1a';
 }
 
-/** Format a numeric tick: 87 → "87%", 1.4 → "1.4×", -3.4 → "-3.4pp". */
+/** Format a numeric tick: 87 → "87.0%", 1.4 → "1.4×", -3.4 → "-3.4pp". */
 export function formatTick(value: number, unit: '%' | '×' | 'pp' | ''): string {
-  return `${value.toFixed(unit === '×' ? 1 : 1)}${unit}`;
+  return `${value.toFixed(1)}${unit}`;
 }

--- a/src/pages/evidence/[...slug].astro
+++ b/src/pages/evidence/[...slug].astro
@@ -1,0 +1,23 @@
+---
+import { getCollection, render, type CollectionEntry } from 'astro:content';
+import EvidenceLayout from '~/layouts/EvidenceLayout.astro';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('evidence');
+  return entries.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}
+
+interface Props {
+  entry: CollectionEntry<'evidence'>;
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+---
+
+<EvidenceLayout entry={entry}>
+  <Content />
+</EvidenceLayout>

--- a/src/pages/evidence/index.astro
+++ b/src/pages/evidence/index.astro
@@ -1,0 +1,122 @@
+---
+import { getCollection } from 'astro:content';
+import PageLayout from '~/layouts/PageLayout.astro';
+import Container from '~/components/layout/Container.astro';
+import MagazineGrid from '~/components/layout/MagazineGrid.astro';
+import KineticHeading from '~/components/universal/KineticHeading.astro';
+import Dek from '~/components/universal/Dek.astro';
+import Tag from '~/components/universal/Tag.astro';
+import HeroStatGrid from '~/components/universal/HeroStatGrid.astro';
+
+const entries = await getCollection('evidence');
+const sorted = entries.sort((a, b) => b.data.measuredOn.getTime() - a.data.measuredOn.getTime());
+
+const heroStats = [
+  { value: '3.4pp', label: 'Workflow > Agent', color: 'accent' as const },
+  { value: '2.4×', label: 'Cost ratio', color: 'accent' as const },
+  { value: '2.2×', label: 'Latency', color: 'accent' as const },
+];
+---
+
+<PageLayout
+  title="Evidence — Agentic AI for Serious Engineers"
+  description="What we measured. Provenance. Downloads."
+  currentNav="Evidence"
+>
+  <Container>
+    <header style="margin: var(--space-7) 0 var(--space-5);">
+      <Tag variant="accent">Evidence</Tag>
+      <KineticHeading level={1}>Evidence</KineticHeading>
+      <Dek italic>Numbers, not narratives. Every claim on this site links back here. Every Evidence page links its own raw data, harness code, and measurement provenance.</Dek>
+    </header>
+
+    <HeroStatGrid items={heroStats} />
+
+    <h2 class="evidence-wall__heading">All Evidence</h2>
+    {sorted.length === 0 ? (
+      <p style="color: var(--fg-light); font-style: italic;">No Evidence pages yet.</p>
+    ) : (
+      <MagazineGrid cols={2}>
+        {sorted.map((e) => (
+          <a class="ev-card" href={`/agentic-ai/evidence/${e.id}/`}>
+            <div class="ev-card__title">{e.data.title}</div>
+            <p class="ev-card__desc">{e.data.description}</p>
+            <div class="ev-card__meta">
+              {e.data.heroStats.slice(0, 2).map((s) => (
+                <span class="ev-card__stat">{s.value} {s.label}</span>
+              ))}
+            </div>
+            <div class="ev-card__date">Measured {e.data.measuredOn.toISOString().slice(0, 10)}</div>
+          </a>
+        ))}
+      </MagazineGrid>
+    )}
+  </Container>
+</PageLayout>
+
+<style>
+  .evidence-wall__heading {
+    margin: var(--space-7) 0 var(--space-5);
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+
+  .ev-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-5);
+    background: var(--paper);
+    color: var(--fg);
+    border: 1px solid var(--fg-faint);
+    border-radius: var(--radius-md);
+    transition: border-color var(--dur-micro) var(--ease-out), transform var(--dur-micro) var(--ease-out);
+  }
+
+  .ev-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--brick);
+  }
+
+  .ev-card__title {
+    font-family: var(--font-display);
+    font-size: var(--display-3);
+    font-weight: 500;
+    line-height: var(--lh-snug);
+  }
+
+  .ev-card__desc {
+    color: var(--fg-light);
+    font-size: var(--body-2);
+    line-height: var(--lh-snug);
+    margin: 0;
+    flex: 1;
+  }
+
+  .ev-card__meta {
+    display: flex;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+
+  .ev-card__stat {
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    color: var(--brick);
+  }
+
+  .ev-card__date {
+    font-family: var(--font-mono);
+    font-size: var(--meta-3);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+    border-top: 1px solid var(--fg-faint);
+    padding-top: var(--space-2);
+  }
+</style>

--- a/src/pages/labs/[...slug].astro
+++ b/src/pages/labs/[...slug].astro
@@ -1,0 +1,23 @@
+---
+import { getCollection, render, type CollectionEntry } from 'astro:content';
+import LabReportLayout from '~/layouts/LabReportLayout.astro';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('labs');
+  return entries.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}
+
+interface Props {
+  entry: CollectionEntry<'labs'>;
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+---
+
+<LabReportLayout entry={entry}>
+  <Content />
+</LabReportLayout>

--- a/src/pages/labs/index.astro
+++ b/src/pages/labs/index.astro
@@ -1,0 +1,101 @@
+---
+import { getCollection } from 'astro:content';
+import PageLayout from '~/layouts/PageLayout.astro';
+import Container from '~/components/layout/Container.astro';
+import MagazineGrid from '~/components/layout/MagazineGrid.astro';
+import KineticHeading from '~/components/universal/KineticHeading.astro';
+import Dek from '~/components/universal/Dek.astro';
+import Tag from '~/components/universal/Tag.astro';
+import Cadence from '~/components/universal/Cadence.astro';
+
+const entries = await getCollection('labs');
+const sorted = entries.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+---
+
+<PageLayout
+  title="Labs — Agentic AI for Serious Engineers"
+  description="Empirical Lab Reports. Every claim reproducible from repo + data + seed."
+  currentNav="Labs"
+>
+  <Container>
+    <header style="margin: var(--space-7) 0 var(--space-6);">
+      <Tag variant="accent">Labs</Tag>
+      <KineticHeading level={1}>Labs</KineticHeading>
+      <Dek italic>Empirical Lab Reports on agent architecture. Hypothesis, method, results, what we got wrong. Repo + data + seed published with every report.</Dek>
+      <Cadence text="Every 2-3 weeks" />
+    </header>
+
+    {sorted.length === 0 ? (
+      <p style="color: var(--fg-light); font-style: italic;">No Labs yet.</p>
+    ) : (
+      <MagazineGrid cols={2}>
+        {sorted.map((e) => (
+          <a class="lab-card" href={`/agentic-ai/labs/${e.id}/`}>
+            <div class="lab-card__kicker">{e.data.id.toUpperCase()} · {e.data.date.toISOString().slice(0, 10)}</div>
+            <h2 class="lab-card__title">{e.data.title}</h2>
+            <div class="lab-card__result">{e.data.result}</div>
+            <div class="lab-card__result-label">{e.data.resultLabel}</div>
+            <p class="lab-card__hypothesis"><em>{e.data.hypothesis}</em></p>
+          </a>
+        ))}
+      </MagazineGrid>
+    )}
+  </Container>
+</PageLayout>
+
+<style>
+  .lab-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-5);
+    background: var(--paper);
+    color: var(--fg);
+    border: 1px solid var(--fg-faint);
+    border-left: 3px solid var(--brick);
+    border-radius: var(--radius-md);
+    transition: transform var(--dur-micro) var(--ease-out);
+  }
+
+  .lab-card:hover { transform: translateY(-2px); }
+
+  .lab-card__kicker {
+    font-family: var(--font-mono);
+    font-size: var(--meta-3);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--brick);
+  }
+
+  .lab-card__title {
+    font-family: var(--font-display);
+    font-size: var(--display-3);
+    font-weight: 500;
+    line-height: var(--lh-snug);
+    margin: 0;
+  }
+
+  .lab-card__result {
+    font-family: var(--font-display);
+    font-size: clamp(28px, 4vw, 40px);
+    font-weight: 500;
+    line-height: 1;
+    color: var(--brick);
+  }
+
+  .lab-card__result-label {
+    font-family: var(--font-mono);
+    font-size: var(--meta-3);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-loose);
+    color: var(--fg-light);
+  }
+
+  .lab-card__hypothesis {
+    color: var(--fg-light);
+    font-size: var(--body-2);
+    line-height: var(--lh-snug);
+    margin: 0;
+    font-family: var(--font-display);
+  }
+</style>

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -1,0 +1,23 @@
+---
+import { getCollection, render, type CollectionEntry } from 'astro:content';
+import ProjectLayout from '~/layouts/ProjectLayout.astro';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('projects');
+  return entries.map((entry) => ({
+    params: { slug: entry.data.slug },
+    props: { entry },
+  }));
+}
+
+interface Props {
+  entry: CollectionEntry<'projects'>;
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+---
+
+<ProjectLayout entry={entry}>
+  <Content />
+</ProjectLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -7,7 +7,7 @@ import KineticHeading from '~/components/universal/KineticHeading.astro';
 import Dek from '~/components/universal/Dek.astro';
 import Tag from '~/components/universal/Tag.astro';
 
-const entries = await getCollection('projects');
+const entries = (await getCollection('projects')).sort((a, b) => a.data.title.localeCompare(b.data.title));
 ---
 
 <PageLayout

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,89 @@
+---
+import { getCollection } from 'astro:content';
+import PageLayout from '~/layouts/PageLayout.astro';
+import Container from '~/components/layout/Container.astro';
+import MagazineGrid from '~/components/layout/MagazineGrid.astro';
+import KineticHeading from '~/components/universal/KineticHeading.astro';
+import Dek from '~/components/universal/Dek.astro';
+import Tag from '~/components/universal/Tag.astro';
+
+const entries = await getCollection('projects');
+---
+
+<PageLayout
+  title="Projects — Agentic AI for Serious Engineers"
+  description="Production-grade agent systems built incrementally through the book."
+  currentNav="Book"
+>
+  <Container>
+    <header style="margin: var(--space-7) 0 var(--space-6);">
+      <Tag>Projects</Tag>
+      <KineticHeading level={1}>Projects</KineticHeading>
+      <Dek italic>Production-grade agent systems built incrementally through the book.</Dek>
+    </header>
+
+    {entries.length === 0 ? (
+      <p style="color: var(--fg-light); font-style: italic;">No projects yet.</p>
+    ) : (
+      <MagazineGrid cols={3}>
+        {entries.map((e) => (
+          <a class="proj-card" href={`/agentic-ai/projects/${e.data.slug}/`}>
+            <div class="proj-card__name">{e.data.title}</div>
+            <p class="proj-card__tagline">{e.data.tagline}</p>
+            <div class="proj-card__stats">
+              <span>{e.data.evalStats.accuracy}</span>
+              <span>·</span>
+              <span>{e.data.evalStats.avgCost}</span>
+              <span>·</span>
+              <span>{e.data.evalStats.latencyP50}</span>
+            </div>
+          </a>
+        ))}
+      </MagazineGrid>
+    )}
+  </Container>
+</PageLayout>
+
+<style>
+  .proj-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-5);
+    background: var(--paper);
+    color: var(--fg);
+    border: 1px solid var(--fg-faint);
+    border-radius: var(--radius-md);
+    transition: transform var(--dur-micro) var(--ease-out), border-color var(--dur-micro) var(--ease-out);
+  }
+
+  .proj-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--ink);
+  }
+
+  .proj-card__name {
+    font-family: var(--font-display);
+    font-size: var(--display-3);
+    font-weight: 500;
+    line-height: var(--lh-snug);
+  }
+
+  .proj-card__tagline {
+    color: var(--fg-light);
+    font-size: var(--body-2);
+    line-height: var(--lh-snug);
+    margin: 0;
+    flex: 1;
+  }
+
+  .proj-card__stats {
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    color: var(--fg-light);
+    display: flex;
+    gap: var(--space-2);
+    border-top: 1px solid var(--fg-faint);
+    padding-top: var(--space-3);
+  }
+</style>


### PR DESCRIPTION
## Summary

Week 3 of the mkdocs → Astro 5 migration. Builds on W1 (PR #7) and W2 (PR #8). This PR:

- **Ports 7 project teardowns to MDX**: Doc Intelligence Agent (flagship), Incident Runbook Agent, Memory Agent, LLM Explorer, Tool-Using Assistant, Research Agent, Framework Comparison. Each gets a ProductCardHero (Run / Read case / See failures / View code), ArchitectureDiagram with scroll-driven trace-in, and EvalStats row (accuracy / cost / latency). 3 of 7 have real source eval numbers; 4 are synthesized with sensible defaults — noted in the W3 ship summary.
- **Ports 4 Evidence pages to MDX**: Baseline Eval Report, Workflow vs Agent Comparison, Trace Example, Failure Cases. All hero stats sourced from real numbers in the original markdown.
- **Builds the Evidence Wall** at `/evidence/` with the homepage's signature 3.4pp / 2.4× / 2.2× as page-level hero.
- **Ships the first Lab Report** (L-001 "Multi-agent vs router on 100 customer-support queries"). Results match homepage stats exactly. 6 sections with scroll-spy SectionAnchors (Setup / Method / Results / Conclusion / What we got wrong / Caveats). ReproduceStrip footer with repo + data + seed.
- **Stands up 3 new layouts**: ProjectLayout, EvidenceLayout, LabReportLayout. All wire cross-links so "Cited by" footers auto-populate as W4 chapters/labs reference these pages.
- **Adds 11 universal components**: HeroStatGrid, StatHero, HypothesisBlock, SectionAnchors (with IntersectionObserver scroll-spy), ReproduceStrip, ProductCardHero, EvalStats, ArchitectureDiagram, MethodBlock, Provenance, DownloadList.
- **Adds 2 Svelte 5 islands**: D3Chart (bar + compare types, brick-red accent), CommandPalette (Cmd+K Pagefind UI with lazy-load + keyboard nav).
- **Installs D3.js 7** + adds `src/lib/d3-helpers.ts` utility module.
- **Ports 47 architecture SVGs** from `docs/diagrams/` to `public/assets/diagrams/`.
- **Wires CommandPalette globally** in PageLayout via `client:idle`. Pagefind index loads on first open.
- **Cross-links coverage extended**: 4 detail layouts now (FieldNote/Project/Evidence/Lab). RecipeLayout intentionally omitted; ChapterLayout in W4.

## What's NOT in this PR (intentional)

- mkdocs `docs/`, `mkdocs.yml`, `.github/workflows/deploy.yml` are untouched. Live site continues serving mkdocs.
- 5 Foundations + 13 chapters — W4.
- `/start/` audience routing page — W4.
- `/patterns/` cross-cut hub — W4.
- Live mkdocs → Astro cutover — W4.
- Codex-generated proper `og-default.png` and L-001 OG image — documented as follow-up in W3 ship summary. Current `og-default.png` is the W2 placeholder.

## Test Plan

- [ ] `pnpm install && pnpm test` — expect 11/11 passing
- [ ] `pnpm astro check` — expect 0 errors, 0 warnings (1 pre-existing hint in d3-helpers.ts is harmless)
- [ ] `pnpm build` — expect 22 pages built + 5 redirect stubs + Pagefind index (22 pages / 2803 words)
- [ ] `pnpm dev` and visit:
  - `/agentic-ai/projects/` — magazine grid with 7 project cards
  - `/agentic-ai/projects/doc-intelligence-agent/` — flagship: 4-quadrant ProductCardHero, ArchitectureDiagram (system-architecture.svg), EvalStats row, case study body
  - `/agentic-ai/projects/research-agent/` — confirm real source-numbers in EvalStats (100% / $0.000276 / 73.4ms)
  - `/agentic-ai/evidence/` — Evidence Wall with 3 brick-red hero stats + 4 evidence cards
  - `/agentic-ai/evidence/workflow-vs-agent-comparison/` — backs the homepage 3.4pp claim; HeroStatGrid with brick-red 3.4pp + 2.4× + 2.2×
  - `/agentic-ai/labs/` — Labs index with L-001 card
  - `/agentic-ai/labs/multi-agent-vs-router-100-queries/` — full Lab: hypothesis, "87% vs 74%" StatHero, 6 section anchors, reproduce strip with seed=42
- [ ] Press `Cmd+K` (or `Ctrl+K`): command palette slides in with backdrop blur. Type "agent" — Pagefind returns hits across multiple content types. Arrow keys navigate; Enter goes to result.
- [ ] DevTools `prefers-reduced-motion: reduce` — confirm scroll-driven animations (ArchitectureDiagram trace-in, Banner parallax) stop, CommandPalette panel doesn't slide
- [ ] Click a SectionAnchor on the Lab Report — confirm smooth scroll + scroll-spy highlights the current section
- [ ] Click a "Cited by" link on any detail page if present (will likely be empty in W3 — most cross-refs land in W4 chapter content)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site-wide search overlay with Cmd/Ctrl+K and keyboard navigation
  * Interactive D3-powered charts for comparative metrics
  * New UI components: architecture diagrams, download lists, stat grids, blocks, provenance/reproduce strips, section anchors, and command palette

* **Documentation**
  * Added extensive Evidence, Labs, and Projects content: evaluation reports, failure cases, execution traces, comparisons, and project case studies
  * New layouts and pages to browse Evidence, Labs, and Projects sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunilp/agentic-ai/pull/9)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->