### PR TITLE
docs: README — add Signal content type, tighten Field Notes line

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ pnpm astro check  # type check
 Content lives under `src/content/` as MDX with Zod-validated frontmatter:
 
 - **chapters/** — 5 Foundations + 13 chapters
-- **fieldNotes/** — twice-weekly observations (Thursdays + Sundays)
+- **fieldNotes/** — twice-weekly observations from inside the work (Thursdays + Sundays)
+- **signal/** — commentary on external discourse: papers, tools, marketplaces, vendor claims
 - **recipes/** — buildable-in-an-afternoon walkthroughs (Wednesdays)
 - **projects/** — case-study teardowns of 7 reference systems
 - **evidence/** — measured eval data backing the homepage stats


### PR DESCRIPTION
Adds Signal to the Content Types list. Tightens the Field Notes line to name its scope (lessons from inside the work) so the two sections are clearly distinct in the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Content Types section with clarified descriptions for improved documentation clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunilp/agentic-ai/pull/15)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->