### PR TITLE
Foundations refresh: fix, verify, cite, redraw

### DIFF
--- a/public/assets/diagrams/agent-loop-foundations.svg
+++ b/public/assets/diagrams/agent-loop-foundations.svg
@@ -1,69 +1,60 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="560" height="520" viewBox="0 0 560 520" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 520" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
-    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
+    <marker id="aiB" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#9b4a3f" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
   </defs>
+  <rect width="560" height="520" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="560" height="520" fill="#ffffff"/>
+  <!-- OBSERVE (top) -->
+  <rect x="180" y="48" width="200" height="64" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="280" y="74" text-anchor="middle" font-size="11" letter-spacing="2" font-weight="500" fill="#1a1a1a">OBSERVE</text>
+  <text x="280" y="94" text-anchor="middle" font-size="11" fill="#6b6b6b">query · results so far</text>
 
-  <!-- Title -->
-  <text x="280" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">The Agent Loop</text>
-  <line x1="40" y1="42" x2="520" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <!-- THINK (bottom right) -->
+  <rect x="336" y="240" width="188" height="64" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="430" y="266" text-anchor="middle" font-size="11" letter-spacing="2" font-weight="500" fill="#1a1a1a">THINK</text>
+  <text x="430" y="286" text-anchor="middle" font-size="11" fill="#6b6b6b">act, or answer</text>
 
-  <!-- Subtitle -->
-  <text x="280" y="62" text-anchor="middle" font-size="12" fill="#6B7280">Three phases. Repeated until the task is done or budget is exhausted.</text>
+  <!-- ACT (bottom left) -->
+  <rect x="36" y="240" width="188" height="64" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="130" y="266" text-anchor="middle" font-size="11" letter-spacing="2" font-weight="500" fill="#1a1a1a">ACT</text>
+  <text x="130" y="286" text-anchor="middle" font-size="11" fill="#6b6b6b">execute the tool call</text>
 
-  <!-- Center circle -->
-  <circle cx="280" cy="280" r="62" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="2"/>
-  <text x="280" y="272" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">Step 1, 2, 3...</text>
-  <text x="280" y="290" text-anchor="middle" font-size="12" fill="#6B7280">Budget: 5 steps</text>
-  <text x="280" y="308" text-anchor="middle" font-size="11" fill="#9CA3AF">remaining</text>
+  <!-- Cycle arrows -->
+  <path d="M382,110 Q480,150 448,236" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="505" y="160" text-anchor="middle" font-size="11" fill="#6b6b6b">model</text>
+  <text x="505" y="174" text-anchor="middle" font-size="11" fill="#6b6b6b">call</text>
 
-  <!-- TOP: Observe (blue) -->
-  <rect x="175" y="82" width="210" height="84" rx="10" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
-  <text x="280" y="108" text-anchor="middle" font-size="15" font-weight="bold" fill="#1D4ED8">Observe</text>
-  <text x="280" y="128" text-anchor="middle" font-size="11" fill="#374151">Assemble context</text>
-  <text x="280" y="145" text-anchor="middle" font-size="10" fill="#6B7280">query · tool results · history</text>
-  <text x="280" y="160" text-anchor="middle" font-size="10" fill="#6B7280">system prompt · state</text>
+  <path d="M334,292 Q280,338 230,292" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="282" y="336" text-anchor="middle" font-size="11" fill="#6b6b6b">tool call</text>
 
-  <!-- BOTTOM-RIGHT: Think (amber) -->
-  <rect x="378" y="330" width="160" height="84" rx="10" fill="#FEF3C7" stroke="#F59E0B" stroke-width="2"/>
-  <text x="458" y="356" text-anchor="middle" font-size="15" font-weight="bold" fill="#92400E">Think</text>
-  <text x="458" y="376" text-anchor="middle" font-size="11" fill="#374151">Call the LLM</text>
-  <text x="458" y="393" text-anchor="middle" font-size="10" fill="#6B7280">model reasons over</text>
-  <text x="458" y="408" text-anchor="middle" font-size="10" fill="#6B7280">assembled context</text>
+  <path d="M128,238 Q96,140 174,86" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="66" y="150" text-anchor="middle" font-size="11" fill="#6b6b6b">result</text>
+  <text x="66" y="164" text-anchor="middle" font-size="11" fill="#6b6b6b">feeds back</text>
 
-  <!-- BOTTOM-LEFT: Act (green) -->
-  <rect x="22" y="330" width="160" height="84" rx="10" fill="#F0FDF4" stroke="#22c55e" stroke-width="2"/>
-  <text x="102" y="356" text-anchor="middle" font-size="15" font-weight="bold" fill="#15803D">Act</text>
-  <text x="102" y="376" text-anchor="middle" font-size="11" fill="#374151">Execute or answer</text>
-  <text x="102" y="393" text-anchor="middle" font-size="10" fill="#6B7280">run tool · write file</text>
-  <text x="102" y="408" text-anchor="middle" font-size="10" fill="#6B7280">call API · return</text>
+  <!-- Center: budget -->
+  <text x="280" y="186" text-anchor="middle" font-size="12" font-weight="500" fill="#1a1a1a">STEP 1 · 2 · 3 …</text>
+  <text x="280" y="206" text-anchor="middle" font-size="11" fill="#6b6b6b">budget enforced by your code,</text>
+  <text x="280" y="222" text-anchor="middle" font-size="11" fill="#6b6b6b">not the model</text>
 
-  <!-- Arrow: Observe → Think (top to right) -->
-  <path d="M358,148 Q440,148 440,328" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
-  <text x="448" y="240" font-size="10" fill="#374151">LLM</text>
-  <text x="448" y="254" font-size="10" fill="#374151">call</text>
+  <!-- Exit: the model answers -->
+  <line x1="430" y1="304" x2="430" y2="364" stroke="#9b4a3f" stroke-width="1.5" marker-end="url(#aiB)"/>
+  <text x="422" y="332" text-anchor="end" font-size="11" fill="#9b4a3f">answer instead</text>
+  <text x="422" y="346" text-anchor="end" font-size="11" fill="#9b4a3f">of a tool call</text>
 
-  <!-- Arrow: Think → Act (right to left, bottom) -->
-  <path d="M378,373 Q280,436 182,373" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
-  <text x="280" y="452" text-anchor="middle" font-size="10" fill="#374151">tool call or final answer</text>
+  <rect x="336" y="368" width="188" height="64" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="430" y="394" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#9b4a3f">RETURN ANSWER</text>
+  <text x="430" y="414" text-anchor="middle" font-size="11" fill="#1a1a1a">'15 * 7 + 3 = 108.0'</text>
 
-  <!-- Arrow: Act → Observe (left to top) -->
-  <path d="M120,328 Q120,148 173,148" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
-  <text x="92" y="240" text-anchor="end" font-size="10" fill="#374151">result</text>
-  <text x="92" y="254" text-anchor="end" font-size="10" fill="#374151">feeds back</text>
-
-  <!-- Step counter example -->
-  <rect x="90" y="472" width="380" height="36" rx="8" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="100" y="490" font-size="11" font-weight="bold" fill="#374151">Step 1:</text>
-  <text x="148" y="490" font-size="11" fill="#6B7280">search("X")</text>
-  <text x="220" y="490" font-size="11" font-weight="bold" fill="#374151">Step 2:</text>
-  <text x="268" y="490" font-size="11" fill="#6B7280">read_result()</text>
-  <text x="348" y="490" font-size="11" font-weight="bold" fill="#374151">Step 3:</text>
-  <text x="396" y="490" font-size="11" fill="#22c55e">answer()</text>
-  <text x="280" y="508" text-anchor="middle" font-size="10" fill="#9CA3AF">Each step burns tokens. Budget enforced by your code, not the model.</text>
+  <!-- Worked example strip -->
+  <line x1="40" y1="458" x2="520" y2="458" stroke="#e8e8e8" stroke-width="1"/>
+  <text x="280" y="482" text-anchor="middle" font-size="11" fill="#6b6b6b">step 1 multiply(15, 7) &#8594; 105.0 · step 2 add(105, 3) &#8594; 108.0</text>
+  <text x="280" y="500" text-anchor="middle" font-size="11" fill="#6b6b6b">step 3 · the model answers instead of calling again</text>
 </svg>

--- a/public/assets/diagrams/agent-trace-waterfall.svg
+++ b/public/assets/diagrams/agent-trace-waterfall.svg
@@ -1,82 +1,51 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="680" height="400" viewBox="0 0 680 400" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 400" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
   </defs>
+  <rect width="680" height="400" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="680" height="400" fill="#ffffff"/>
+  <!-- Query -->
+  <text x="40" y="42" font-size="11" letter-spacing="2" font-weight="500" fill="#6b6b6b">QUERY</text>
+  <text x="110" y="42" font-size="12" fill="#1a1a1a">"What is 15 * 7 + 3?"</text>
+  <line x1="40" y1="56" x2="640" y2="56" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Title -->
-  <text x="340" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Agent Trace: Cost and Latency Waterfall</text>
-  <line x1="40" y1="42" x2="640" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <!-- Row 1 -->
+  <text x="40" y="107" font-size="12" font-weight="500" fill="#1a1a1a">[1]</text>
+  <rect x="84" y="90" width="120" height="26" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="84" y="134" font-size="11" fill="#6b6b6b">sees: system prompt + query</text>
+  <line x1="210" y1="103" x2="418" y2="103" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <rect x="424" y="84" width="216" height="56" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="532" y="106" text-anchor="middle" font-size="11" fill="#1a1a1a">calculator · multiply(15, 7)</text>
+  <text x="532" y="126" text-anchor="middle" font-size="11" fill="#6b6b6b">&#8594; '105.0'</text>
 
-  <!-- Column headers -->
-  <text x="60" y="66" font-size="11" font-weight="bold" fill="#6B7280">STEP</text>
-  <text x="180" y="66" font-size="11" font-weight="bold" fill="#6B7280">ACTION</text>
-  <text x="460" y="66" font-size="11" font-weight="bold" fill="#6B7280">TOKENS</text>
-  <text x="560" y="66" font-size="11" font-weight="bold" fill="#6B7280">TIME</text>
-  <line x1="40" y1="72" x2="640" y2="72" stroke="#E5E7EB" stroke-width="1"/>
+  <!-- Row 2 -->
+  <text x="40" y="187" font-size="12" font-weight="500" fill="#1a1a1a">[2]</text>
+  <rect x="84" y="170" width="200" height="26" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="84" y="214" font-size="11" fill="#6b6b6b">sees: + call 1 and its result</text>
+  <line x1="290" y1="183" x2="418" y2="183" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <rect x="424" y="164" width="216" height="56" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="532" y="186" text-anchor="middle" font-size="11" fill="#1a1a1a">calculator · add(105, 3)</text>
+  <text x="532" y="206" text-anchor="middle" font-size="11" fill="#6b6b6b">&#8594; '108.0'</text>
 
-  <!-- Step 1 -->
-  <rect x="40" y="80" width="595" height="68" rx="6" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
-  <!-- Step badge -->
-  <circle cx="65" cy="114" r="16" fill="#3B82F6"/>
-  <text x="65" y="119" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">1</text>
-  <!-- Action label -->
-  <text x="110" y="104" font-size="13" font-weight="bold" fill="#1D4ED8">search("agentic AI frameworks 2024")</text>
-  <text x="110" y="122" font-size="11" fill="#374151">Called web_search tool. Got 10 results back.</text>
-  <text x="110" y="138" font-size="11" fill="#6B7280">Observe: initial query assembled · Think: decide to search · Act: call tool</text>
-  <!-- Metrics -->
-  <rect x="440" y="90" width="68" height="46" rx="4" fill="#DBEAFE"/>
-  <text x="474" y="110" text-anchor="middle" font-size="12" font-weight="bold" fill="#1D4ED8">340</text>
-  <text x="474" y="128" text-anchor="middle" font-size="10" fill="#6B7280">tokens</text>
-  <rect x="524" y="90" width="88" height="46" rx="4" fill="#DBEAFE"/>
-  <text x="568" y="110" text-anchor="middle" font-size="12" font-weight="bold" fill="#1D4ED8">0.8s</text>
-  <text x="568" y="128" text-anchor="middle" font-size="10" fill="#6B7280">elapsed</text>
+  <!-- Row 3 -->
+  <text x="40" y="267" font-size="12" font-weight="500" fill="#1a1a1a">[3]</text>
+  <rect x="84" y="250" width="280" height="26" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="84" y="294" font-size="11" fill="#6b6b6b">sees: + call 2 and its result</text>
+  <line x1="370" y1="263" x2="418" y2="263" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <rect x="424" y="244" width="216" height="56" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="532" y="266" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#9b4a3f">ANSWER</text>
+  <text x="532" y="286" text-anchor="middle" font-size="11" fill="#1a1a1a">'15 * 7 + 3 = 108.0'</text>
 
-  <!-- Connector line -->
-  <line x1="65" y1="149" x2="65" y2="162" stroke="#D1D5DB" stroke-width="2" stroke-dasharray="3,2"/>
+  <!-- Column note -->
+  <text x="84" y="330" font-size="11" fill="#6b6b6b">context only grows &#8594;</text>
 
-  <!-- Step 2 -->
-  <rect x="40" y="164" width="595" height="68" rx="6" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
-  <circle cx="65" cy="198" r="16" fill="#F59E0B"/>
-  <text x="65" y="203" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">2</text>
-  <text x="110" y="188" font-size="13" font-weight="bold" fill="#92400E">read_result() → search("production agents")</text>
-  <text x="110" y="206" font-size="11" fill="#374151">Skimmed first results. Decided to refine search for production use cases.</text>
-  <text x="110" y="222" font-size="11" fill="#6B7280">Observe: prior result added to context · Think: gap identified · Act: second search</text>
-  <rect x="440" y="174" width="68" height="46" rx="4" fill="#FEF9C3"/>
-  <text x="474" y="194" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">520</text>
-  <text x="474" y="212" text-anchor="middle" font-size="10" fill="#6B7280">tokens</text>
-  <rect x="524" y="174" width="88" height="46" rx="4" fill="#FEF9C3"/>
-  <text x="568" y="194" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">1.1s</text>
-  <text x="568" y="212" text-anchor="middle" font-size="10" fill="#6B7280">elapsed</text>
-
-  <!-- Connector line -->
-  <line x1="65" y1="233" x2="65" y2="246" stroke="#D1D5DB" stroke-width="2" stroke-dasharray="3,2"/>
-
-  <!-- Step 3 -->
-  <rect x="40" y="248" width="595" height="68" rx="6" fill="#F0FDF4" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="65" cy="282" r="16" fill="#22c55e"/>
-  <text x="65" y="287" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">3</text>
-  <text x="110" y="272" font-size="13" font-weight="bold" fill="#15803D">synthesize_answer()</text>
-  <text x="110" y="290" font-size="11" fill="#374151">Combined both search results into a structured summary. Returned to user.</text>
-  <text x="110" y="306" font-size="11" fill="#6B7280">Observe: all context assembled · Think: sufficient info · Act: return final answer</text>
-  <rect x="440" y="258" width="68" height="46" rx="4" fill="#DCFCE7"/>
-  <text x="474" y="278" text-anchor="middle" font-size="12" font-weight="bold" fill="#15803D">280</text>
-  <text x="474" y="296" text-anchor="middle" font-size="10" fill="#6B7280">tokens</text>
-  <rect x="524" y="258" width="88" height="46" rx="4" fill="#DCFCE7"/>
-  <text x="568" y="278" text-anchor="middle" font-size="12" font-weight="bold" fill="#15803D">0.6s</text>
-  <text x="568" y="296" text-anchor="middle" font-size="10" fill="#6B7280">elapsed</text>
-
-  <!-- Summary bar -->
-  <rect x="40" y="334" width="595" height="44" rx="6" fill="#111827"/>
-  <text x="110" y="352" font-size="12" font-weight="bold" fill="#ffffff">TOTAL</text>
-  <text x="170" y="352" font-size="12" fill="#9CA3AF">3 steps</text>
-  <text x="280" y="352" font-size="12" font-weight="bold" fill="#60A5FA">1,140 tokens</text>
-  <text x="420" y="352" font-size="12" font-weight="bold" fill="#34D399">$0.04 est.</text>
-  <text x="530" y="352" font-size="12" font-weight="bold" fill="#FBBF24">2.5 seconds</text>
-  <text x="340" y="370" text-anchor="middle" font-size="10" fill="#6B7280">This trace lets you see exactly where budget is spent and where time is lost.</text>
-
-  <!-- Caption -->
-  <text x="340" y="393" text-anchor="middle" font-size="11" fill="#9CA3AF">Logging every step — tokens, time, tool name — is not optional in production.</text>
+  <!-- Summary -->
+  <line x1="40" y1="346" x2="640" y2="346" stroke="#e8e8e8" stroke-width="1"/>
+  <text x="340" y="370" text-anchor="middle" font-size="12" font-weight="500" fill="#1a1a1a">3 steps · 3 model calls · 195 tokens · ~ $0.001</text>
+  <text x="340" y="390" text-anchor="middle" font-size="11" fill="#6b6b6b">each model call re-reads everything above it, then decides: tool or answer</text>
 </svg>

--- a/public/assets/diagrams/api-contract.svg
+++ b/public/assets/diagrams/api-contract.svg
@@ -1,74 +1,46 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="700" height="380" viewBox="0 0 700 380" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 380" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
-    <marker id="arr-right" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
-    <marker id="arr-left" markerWidth="10" markerHeight="7" refX="1" refY="3.5" orient="auto">
-      <polygon points="10 0, 0 3.5, 10 7" fill="#6B7280"/>
-    </marker>
-    <marker id="arr-down" markerWidth="7" markerHeight="10" refX="3.5" refY="9" orient="auto">
-      <polygon points="0 0, 3.5 10, 7 0" fill="#9CA3AF"/>
-    </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.22"/>
+    </pattern>
   </defs>
+  <rect width="700" height="380" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="700" height="380" fill="#ffffff"/>
+  <!-- The contract: two parties, two arrows -->
+  <rect x="60" y="52" width="180" height="72" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="150" y="84" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">YOUR CODE</text>
+  <text x="150" y="104" text-anchor="middle" font-size="11" fill="#6b6b6b">the application</text>
 
-  <!-- Title -->
-  <text x="350" y="32" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">The API Contract: Everything Starts Here</text>
-  <line x1="40" y1="44" x2="660" y2="44" stroke="#D1D5DB" stroke-width="1"/>
+  <rect x="460" y="52" width="180" height="72" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="550" y="84" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">FRONTIER MODEL API</text>
+  <text x="550" y="104" text-anchor="middle" font-size="11" fill="#6b6b6b">a service endpoint</text>
 
-  <!-- Your Code box -->
-  <rect x="40" y="70" width="140" height="70" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
-  <text x="110" y="100" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Your Code</text>
-  <text x="110" y="118" text-anchor="middle" font-size="11" fill="#6B7280">Python / JS</text>
-  <text x="110" y="132" text-anchor="middle" font-size="11" fill="#6B7280">application</text>
+  <line x1="244" y1="74" x2="452" y2="74" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="350" y="66" text-anchor="middle" font-size="11" fill="#6b6b6b">text in · counted in tokens</text>
 
-  <!-- LLM API box -->
-  <rect x="280" y="70" width="140" height="70" rx="8" fill="#F0FDF4" stroke="#22c55e" stroke-width="2"/>
-  <text x="350" y="100" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">LLM API</text>
-  <text x="350" y="118" text-anchor="middle" font-size="11" fill="#6B7280">GPT-4 / Claude</text>
-  <text x="350" y="132" text-anchor="middle" font-size="11" fill="#6B7280">Gemini / etc.</text>
+  <line x1="456" y1="104" x2="248" y2="104" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="350" y="126" text-anchor="middle" font-size="11" fill="#6b6b6b">text out · counted in tokens</text>
 
-  <!-- Response box -->
-  <rect x="520" y="70" width="140" height="70" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="2"/>
-  <text x="590" y="100" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Response</text>
-  <text x="590" y="118" text-anchor="middle" font-size="11" fill="#6B7280">Structured</text>
-  <text x="590" y="132" text-anchor="middle" font-size="11" fill="#6B7280">JSON object</text>
-
-  <!-- Arrow: Code → API (top, going right) -->
-  <line x1="181" y1="95" x2="278" y2="95" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr-right)"/>
-  <text x="229" y="88" text-anchor="middle" font-size="10" fill="#374151">text + tokens</text>
-
-  <!-- Arrow: API → Response (top, going right) -->
-  <line x1="421" y1="95" x2="518" y2="95" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr-right)"/>
-
-  <!-- Arrow: Response → API → Code (bottom, going left) -->
-  <line x1="518" y1="125" x2="421" y2="125" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr-left)"/>
-  <line x1="278" y1="125" x2="181" y2="125" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr-left)"/>
-  <text x="350" y="145" text-anchor="middle" font-size="10" fill="#374151">text + tokens used + cost</text>
+  <text x="350" y="150" text-anchor="middle" font-size="11" fill="#6b6b6b">you pay for both strings, per token</text>
 
   <!-- Divider -->
-  <line x1="40" y1="175" x2="660" y2="175" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="4,4"/>
-  <text x="350" y="168" text-anchor="middle" font-size="10" fill="#9CA3AF">BUILT ON TOP OF THIS BASE</text>
+  <line x1="60" y1="172" x2="640" y2="172" stroke="#e8e8e8" stroke-width="1"/>
+  <rect x="240" y="164" width="220" height="16" fill="#fafaf8"/>
+  <text x="350" y="176" text-anchor="middle" font-size="11" letter-spacing="2" font-weight="500" fill="#6b6b6b">WHAT GETS BUILT ON IT</text>
 
-  <!-- Stack layers -->
-  <!-- Layer 3: Top -->
-  <rect x="180" y="190" width="340" height="46" rx="6" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-  <text x="350" y="208" text-anchor="middle" font-size="13" font-weight="bold" fill="#5B21B6">Agents</text>
-  <text x="350" y="228" text-anchor="middle" font-size="11" fill="#6B7280">Multi-step autonomous loops with tool use and iteration</text>
+  <!-- The stack, widest at the base -->
+  <rect x="210" y="194" width="280" height="46" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="350" y="213" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">AGENTS</text>
+  <text x="350" y="231" text-anchor="middle" font-size="11" fill="#6b6b6b">multi-step loops · tool use</text>
 
-  <!-- Layer 2: Middle -->
-  <rect x="150" y="244" width="400" height="46" rx="6" fill="#ECFDF5" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="350" y="262" text-anchor="middle" font-size="13" font-weight="bold" fill="#15803D">RAG / Chains</text>
-  <text x="350" y="282" text-anchor="middle" font-size="11" fill="#6B7280">Retrieval-augmented pipelines and prompt chaining</text>
+  <rect x="160" y="248" width="380" height="46" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="350" y="267" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">RAG · CHAINS</text>
+  <text x="350" y="285" text-anchor="middle" font-size="11" fill="#6b6b6b">retrieval pipelines · prompt chaining</text>
 
-  <!-- Layer 1: Bottom (base) -->
-  <rect x="120" y="298" width="460" height="46" rx="6" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
-  <text x="350" y="316" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">LLM API Call</text>
-  <text x="350" y="336" text-anchor="middle" font-size="11" fill="#6B7280">text in → text out  ·  everything else is code around this</text>
-
-  <!-- Caption -->
-  <text x="350" y="368" text-anchor="middle" font-size="11" fill="#9CA3AF">Core insight: no matter how complex your system, it all reduces to text-in, text-out.</text>
+  <rect x="110" y="302" width="480" height="56" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="350" y="325" text-anchor="middle" font-size="12" letter-spacing="1" font-weight="500" fill="#9b4a3f">THE API CALL · TEXT IN, TEXT OUT</text>
+  <text x="350" y="345" text-anchor="middle" font-size="11" fill="#1a1a1a">everything above is code around this one call</text>
 </svg>

--- a/public/assets/diagrams/before-after-guardrails.svg
+++ b/public/assets/diagrams/before-after-guardrails.svg
@@ -1,81 +1,49 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="720" height="380" viewBox="0 0 720 380" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 380" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="aiB" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#9b4a3f" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
   </defs>
+  <rect width="720" height="380" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="720" height="380" fill="#ffffff"/>
+  <!-- LEFT: raw loop -->
+  <rect x="30" y="44" width="290" height="292" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="175" y="72" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">RAW LOOP · NO GUARDRAILS</text>
+  <line x1="50" y1="84" x2="300" y2="84" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Title -->
-  <text x="360" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Guardrails: Before and After</text>
-  <line x1="40" y1="42" x2="680" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="54" y="118" font-size="12" font-weight="500" fill="#1a1a1a">unbounded loop</text>
+  <text x="54" y="136" font-size="11" fill="#6b6b6b">a confused model calls tools</text>
+  <text x="54" y="152" font-size="11" fill="#6b6b6b">forever · tokens burn</text>
 
-  <!-- LEFT PANEL: Without Guardrails -->
-  <rect x="30" y="56" width="295" height="296" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
-  <text x="178" y="82" text-anchor="middle" font-size="15" font-weight="bold" fill="#B91C1C">Without Guardrails</text>
-  <line x1="50" y1="92" x2="305" y2="92" stroke="#FCA5A5" stroke-width="1"/>
+  <text x="54" y="192" font-size="12" font-weight="500" fill="#1a1a1a">unchecked input</text>
+  <text x="54" y="210" font-size="11" fill="#6b6b6b">any query enters the loop,</text>
+  <text x="54" y="226" font-size="11" fill="#6b6b6b">however malformed or huge</text>
 
-  <!-- Bullet items -->
-  <!-- Item 1 -->
-  <circle cx="64" cy="122" r="6" fill="#EF4444"/>
-  <text x="80" y="126" font-size="13" font-weight="bold" fill="#374151">Infinite loops</text>
-  <text x="80" y="143" font-size="11" fill="#6B7280">Agent runs forever burning tokens,</text>
-  <text x="80" y="158" font-size="11" fill="#6B7280">no termination condition enforced.</text>
+  <text x="54" y="266" font-size="12" font-weight="500" fill="#1a1a1a">no visibility</text>
+  <text x="54" y="284" font-size="11" fill="#6b6b6b">when it misbehaves, nothing</text>
+  <text x="54" y="300" font-size="11" fill="#6b6b6b">tells you what happened</text>
 
-  <!-- Item 2 -->
-  <circle cx="64" cy="185" r="6" fill="#EF4444"/>
-  <text x="80" y="189" font-size="13" font-weight="bold" fill="#374151">Crashes on bad input</text>
-  <text x="80" y="206" font-size="11" fill="#6B7280">Tool receives unexpected data types.</text>
-  <text x="80" y="221" font-size="11" fill="#6B7280">Unhandled exception. Silent failure.</text>
+  <!-- CENTER: ten lines -->
+  <text x="360" y="172" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#9b4a3f">+10 LINES</text>
+  <line x1="330" y1="188" x2="384" y2="188" stroke="#9b4a3f" stroke-width="2" marker-end="url(#aiB)"/>
 
-  <!-- Item 3 -->
-  <circle cx="64" cy="248" r="6" fill="#EF4444"/>
-  <text x="80" y="252" font-size="13" font-weight="bold" fill="#374151">No visibility into steps</text>
-  <text x="80" y="269" font-size="11" fill="#6B7280">Can't diagnose what went wrong.</text>
-  <text x="80" y="284" font-size="11" fill="#6B7280">No token/cost/step data logged.</text>
+  <!-- RIGHT: three guardrails -->
+  <rect x="400" y="44" width="290" height="292" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="545" y="72" text-anchor="middle" font-size="11" letter-spacing="2" font-weight="500" fill="#1a1a1a">THREE GUARDRAILS</text>
+  <line x1="420" y1="84" x2="670" y2="84" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Item 4 -->
-  <circle cx="64" cy="311" r="6" fill="#EF4444"/>
-  <text x="80" y="315" font-size="13" font-weight="bold" fill="#374151">Wrong answer ships</text>
-  <text x="80" y="332" font-size="11" fill="#6B7280">No output validation. Confident but</text>
-  <text x="80" y="347" font-size="11" fill="#6B7280">incorrect result reaches the user.</text>
+  <text x="424" y="118" font-size="12" font-weight="500" fill="#1a1a1a">1 · budget</text>
+  <text x="424" y="136" font-size="11" fill="#6b6b6b">max_steps=5 caps the loop,</text>
+  <text x="424" y="152" font-size="11" fill="#6b6b6b">exits with a clean result</text>
 
-  <!-- CENTER: +10 lines label -->
-  <rect x="328" y="170" width="64" height="52" rx="8" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1.5"/>
-  <text x="360" y="190" text-anchor="middle" font-size="10" font-weight="bold" fill="#374151">+10 lines</text>
-  <text x="360" y="206" text-anchor="middle" font-size="10" fill="#6B7280">of code</text>
-  <text x="360" y="218" text-anchor="middle" font-size="18" fill="#374151">&#8594;</text>
+  <text x="424" y="192" font-size="12" font-weight="500" fill="#1a1a1a">2 · input validation</text>
+  <text x="424" y="210" font-size="11" fill="#6b6b6b">pydantic rejects bad queries</text>
+  <text x="424" y="226" font-size="11" fill="#6b6b6b">before a token is spent</text>
 
-  <!-- RIGHT PANEL: With Guardrails -->
-  <rect x="395" y="56" width="295" height="296" rx="10" fill="#F0FDF4" stroke="#22c55e" stroke-width="2"/>
-  <text x="543" y="82" text-anchor="middle" font-size="15" font-weight="bold" fill="#15803D">With Guardrails</text>
-  <line x1="415" y1="92" x2="670" y2="92" stroke="#86EFAC" stroke-width="1"/>
+  <text x="424" y="266" font-size="12" font-weight="500" fill="#1a1a1a">3 · step logging</text>
+  <text x="424" y="284" font-size="11" fill="#6b6b6b">every step: tool, tokens,</text>
+  <text x="424" y="300" font-size="11" fill="#6b6b6b">totals · a 2am diagnosis</text>
 
-  <!-- Bullet items -->
-  <!-- Item 1 -->
-  <circle cx="429" cy="122" r="6" fill="#22c55e"/>
-  <text x="445" y="126" font-size="13" font-weight="bold" fill="#374151">Budget stops at 5 steps</text>
-  <text x="445" y="143" font-size="11" fill="#6B7280">Configurable max_steps=5. Loop exits</text>
-  <text x="445" y="158" font-size="11" fill="#6B7280">cleanly with a "budget exceeded" result.</text>
-
-  <!-- Item 2 -->
-  <circle cx="429" cy="185" r="6" fill="#22c55e"/>
-  <text x="445" y="189" font-size="13" font-weight="bold" fill="#374151">Pydantic catches bad args</text>
-  <text x="445" y="206" font-size="11" fill="#6B7280">Tool schemas validated before dispatch.</text>
-  <text x="445" y="221" font-size="11" fill="#6B7280">Type errors caught with clear messages.</text>
-
-  <!-- Item 3 -->
-  <circle cx="429" cy="248" r="6" fill="#22c55e"/>
-  <text x="445" y="252" font-size="13" font-weight="bold" fill="#374151">Each step logged</text>
-  <text x="445" y="269" font-size="11" fill="#6B7280">Step number, tool name, tokens used,</text>
-  <text x="445" y="284" font-size="11" fill="#6B7280">cost, latency captured per step.</text>
-
-  <!-- Item 4 -->
-  <circle cx="429" cy="311" r="6" fill="#22c55e"/>
-  <text x="445" y="315" font-size="13" font-weight="bold" fill="#374151">Output schema enforced</text>
-  <text x="445" y="332" font-size="11" fill="#6B7280">Structured output validated. Malformed</text>
-  <text x="445" y="347" font-size="11" fill="#6B7280">responses rejected before delivery.</text>
-
-  <!-- Caption -->
-  <text x="360" y="368" text-anchor="middle" font-size="11" fill="#374151">Guardrails are not optional safety features. They are the engineering interface between your code and the model.</text>
+  <!-- Footnote -->
+  <text x="360" y="366" text-anchor="middle" font-size="11" fill="#6b6b6b">budget caps the loop · validation rejects bad input · logging shows what happened</text>
 </svg>

--- a/public/assets/diagrams/context-window-bucket.svg
+++ b/public/assets/diagrams/context-window-bucket.svg
@@ -1,63 +1,65 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="500" height="480" viewBox="0 0 500 480" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 480" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.28"/>
+    </pattern>
   </defs>
+  <rect width="500" height="480" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="500" height="480" fill="#ffffff"/>
+  <!-- Section header -->
+  <text x="100" y="34" font-size="11" letter-spacing="2" font-weight="500" fill="#6b6b6b">ONE FIXED-SIZE WINDOW</text>
 
-  <!-- Title -->
-  <text x="250" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">The Context Window Bucket</text>
-  <line x1="40" y1="42" x2="460" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <!-- Bucket walls, open at the top -->
+  <path d="M100,56 L100,424 L320,424 L320,56" fill="none" stroke="#1a1a1a" stroke-width="2"/>
 
-  <!-- Capacity label -->
-  <text x="250" y="62" text-anchor="middle" font-size="13" fill="#374151">Fixed capacity: <tspan font-weight="bold" fill="#111827">128,000 tokens</tspan> — once full, oldest content is dropped</text>
+  <!-- Capacity limit (the old failure mode, secondary) -->
+  <line x1="96" y1="56" x2="324" y2="56" stroke="#6b6b6b" stroke-width="1" stroke-dasharray="4,4"/>
+  <text x="336" y="60" font-size="11" fill="#6b6b6b">capacity limit</text>
+  <text x="336" y="78" font-size="11" fill="#6b6b6b">overflow: content beyond</text>
+  <text x="336" y="94" font-size="11" fill="#6b6b6b">the limit is dropped --</text>
+  <text x="336" y="110" font-size="11" fill="#6b6b6b">the old failure mode,</text>
+  <text x="336" y="126" font-size="11" fill="#6b6b6b">rarely hit today</text>
 
-  <!-- Bucket outline -->
-  <rect x="130" y="78" width="240" height="320" rx="4" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="2"/>
+  <!-- Headroom -->
+  <text x="210" y="120" text-anchor="middle" font-size="11" fill="#6b6b6b">headroom</text>
+  <text x="210" y="138" text-anchor="middle" font-size="11" fill="#6b6b6b">(windows are big now)</text>
 
-  <!-- Overflow zone (red, top) -->
-  <rect x="130" y="78" width="240" height="38" rx="4" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
-  <text x="250" y="96" text-anchor="middle" font-size="11" font-weight="bold" fill="#B91C1C">OVERFLOW — CONTENT LOST</text>
-  <text x="250" y="110" text-anchor="middle" font-size="10" fill="#EF4444">tokens above limit are truncated</text>
+  <!-- Content segments, oldest at the base -->
+  <rect x="102" y="190" width="216" height="26" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="210" y="207" text-anchor="middle" font-size="11" fill="#1a1a1a">user message</text>
 
-  <!-- Segment 5: Tool Results (purple) — from top of content area -->
-  <rect x="130" y="116" width="240" height="56" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1"/>
-  <text x="250" y="138" text-anchor="middle" font-size="12" font-weight="bold" fill="#5B21B6">Tool Results</text>
-  <text x="250" y="155" text-anchor="middle" font-size="10" fill="#6B7280">Function outputs, API responses</text>
-  <text x="388" y="147" text-anchor="middle" font-size="10" fill="#8B5CF6">~25K tokens</text>
+  <rect x="102" y="216" width="216" height="36" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="210" y="238" text-anchor="middle" font-size="11" fill="#1a1a1a">tool results</text>
 
-  <!-- Segment 4: Conversation History (amber) -->
-  <rect x="130" y="172" width="240" height="68" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1"/>
-  <text x="250" y="196" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">Conversation History</text>
-  <text x="250" y="213" text-anchor="middle" font-size="10" fill="#6B7280">Prior turns, user messages</text>
-  <text x="388" y="207" text-anchor="middle" font-size="10" fill="#F59E0B">~30K tokens</text>
+  <rect x="102" y="252" width="216" height="66" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="210" y="289" text-anchor="middle" font-size="11" fill="#1a1a1a">retrieved documents</text>
 
-  <!-- Segment 3: Retrieved Documents (green) — large -->
-  <rect x="130" y="240" width="240" height="88" fill="#F0FDF4" stroke="#22c55e" stroke-width="1"/>
-  <text x="250" y="268" text-anchor="middle" font-size="12" font-weight="bold" fill="#15803D">Retrieved Documents</text>
-  <text x="250" y="286" text-anchor="middle" font-size="10" fill="#6B7280">RAG chunks, search results</text>
-  <text x="250" y="303" text-anchor="middle" font-size="10" fill="#6B7280">knowledge base content</text>
-  <text x="388" y="285" text-anchor="middle" font-size="10" fill="#22c55e">~50K tokens</text>
+  <rect x="102" y="318" width="216" height="42" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="210" y="352" text-anchor="middle" font-size="11" fill="#1a1a1a">conversation history</text>
 
-  <!-- Segment 2: Few-shot Examples (light blue) -->
-  <rect x="130" y="328" width="240" height="42" fill="#DBEAFE" stroke="#93C5FD" stroke-width="1"/>
-  <text x="250" y="346" text-anchor="middle" font-size="12" font-weight="bold" fill="#1E40AF">Few-shot Examples</text>
-  <text x="250" y="362" text-anchor="middle" font-size="10" fill="#6B7280">Input/output demonstrations</text>
-  <text x="388" y="352" text-anchor="middle" font-size="10" fill="#3B82F6">~15K tokens</text>
+  <rect x="102" y="360" width="216" height="30" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="210" y="379" text-anchor="middle" font-size="11" fill="#1a1a1a">tool definitions</text>
 
-  <!-- Segment 1: System Prompt (blue, bottom) -->
-  <rect x="130" y="370" width="240" height="28" rx="0" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1"/>
-  <rect x="130" y="384" width="240" height="14" rx="0" fill="#EFF6FF"/>
-  <rect x="130" y="370" width="240" height="28" rx="0" fill="none" stroke="#3B82F6" stroke-width="1"/>
-  <text x="250" y="382" text-anchor="middle" font-size="12" font-weight="bold" fill="#1D4ED8">System Prompt</text>
-  <text x="388" y="385" text-anchor="middle" font-size="10" fill="#3B82F6">~8K tokens</text>
+  <rect x="102" y="390" width="216" height="32" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="210" y="410" text-anchor="middle" font-size="11" fill="#1a1a1a">system prompt</text>
 
-  <!-- Bottom of bucket (floor) -->
-  <rect x="128" y="396" width="244" height="4" rx="2" fill="#D1D5DB"/>
+  <!-- The modern failure: attention decays in the middle -->
+  <rect x="102" y="252" width="216" height="84" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="1.5"/>
+  <line x1="318" y1="300" x2="334" y2="300" stroke="#9b4a3f" stroke-width="1.5"/>
+  <text x="340" y="296" font-size="11" letter-spacing="1.5" font-weight="500" fill="#9b4a3f">WEAK ATTENTION</text>
+  <text x="340" y="314" font-size="11" fill="#6b6b6b">the middle of a long</text>
+  <text x="340" y="330" font-size="11" fill="#6b6b6b">context is read less</text>
+  <text x="340" y="346" font-size="11" fill="#6b6b6b">reliably: "lost in</text>
+  <text x="340" y="362" font-size="11" fill="#6b6b6b">the middle"</text>
 
-  <!-- Legend / caption -->
-  <text x="250" y="428" text-anchor="middle" font-size="11" fill="#374151">Fill order: system prompt first, examples, documents, history, tool results</text>
-  <text x="250" y="448" text-anchor="middle" font-size="11" fill="#9CA3AF">Engineer's job: decide what fills the bucket and in what order.</text>
-  <text x="250" y="466" text-anchor="middle" font-size="11" fill="#EF4444">What overflows gets forgotten.</text>
+  <!-- The reliable ends -->
+  <line x1="70" y1="203" x2="98" y2="203" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="64" y="196" text-anchor="end" font-size="11" fill="#6b6b6b">read</text>
+  <text x="64" y="210" text-anchor="end" font-size="11" fill="#6b6b6b">well</text>
+  <line x1="70" y1="406" x2="98" y2="406" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="64" y="399" text-anchor="end" font-size="11" fill="#6b6b6b">read</text>
+  <text x="64" y="413" text-anchor="end" font-size="11" fill="#6b6b6b">well</text>
+
+  <!-- Fill order -->
+  <text x="250" y="454" text-anchor="middle" font-size="11" fill="#6b6b6b">fills bottom-up: start of context at the base, newest on top</text>
 </svg>

--- a/public/assets/diagrams/framework-decision-tree.svg
+++ b/public/assets/diagrams/framework-decision-tree.svg
@@ -1,71 +1,66 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="700" height="400" viewBox="0 0 700 400" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
-    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
   </defs>
+  <rect width="700" height="400" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="700" height="400" fill="#ffffff"/>
+  <!-- Root -->
+  <rect x="230" y="36" width="240" height="56" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="350" y="60" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">WHAT ARE YOU BUILDING?</text>
+  <text x="350" y="80" text-anchor="middle" font-size="11" fill="#6b6b6b">before choosing a framework</text>
 
-  <!-- Title -->
-  <text x="350" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Framework Decision Tree</text>
-  <line x1="40" y1="42" x2="660" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <!-- Branch: learning -->
+  <line x1="282" y1="92" x2="168" y2="140" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="176" y="110" text-anchor="middle" font-size="11" fill="#6b6b6b">learning ·</text>
+  <text x="176" y="124" text-anchor="middle" font-size="11" fill="#6b6b6b">exploring</text>
 
-  <!-- ROOT: What are you building? -->
-  <rect x="220" y="60" width="260" height="56" rx="10" fill="#F3F4F6" stroke="#6B7280" stroke-width="2"/>
-  <text x="350" y="84" text-anchor="middle" font-size="14" font-weight="bold" fill="#111827">What are you building?</text>
-  <text x="350" y="102" text-anchor="middle" font-size="11" fill="#6B7280">Start here before choosing a framework</text>
+  <!-- Branch: production -->
+  <line x1="418" y1="92" x2="532" y2="140" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="522" y="110" text-anchor="middle" font-size="11" fill="#6b6b6b">production</text>
+  <text x="522" y="124" text-anchor="middle" font-size="11" fill="#6b6b6b">system</text>
 
-  <!-- Arrow left: Learning/exploring -->
-  <line x1="280" y1="116" x2="155" y2="168" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="185" y="147" text-anchor="middle" font-size="11" fill="#374151">Learning /</text>
-  <text x="185" y="160" text-anchor="middle" font-size="11" fill="#374151">exploring</text>
+  <!-- Leaf: build raw first (accent) -->
+  <rect x="50" y="144" width="220" height="64" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="160" y="166" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#9b4a3f">BUILD RAW FIRST</text>
+  <text x="160" y="184" text-anchor="middle" font-size="11" fill="#1a1a1a">pure python, direct API calls</text>
+  <text x="160" y="200" text-anchor="middle" font-size="11" fill="#6b6b6b">learn the mechanics first</text>
 
-  <!-- Arrow right: Production system -->
-  <line x1="420" y1="116" x2="545" y2="168" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="510" y="147" text-anchor="middle" font-size="11" fill="#374151">Production</text>
-  <text x="510" y="160" text-anchor="middle" font-size="11" fill="#374151">system</text>
+  <!-- Node: tracing question -->
+  <rect x="440" y="144" width="230" height="56" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="555" y="168" text-anchor="middle" font-size="11" font-weight="500" fill="#1a1a1a">need built-in tracing</text>
+  <text x="555" y="186" text-anchor="middle" font-size="11" font-weight="500" fill="#1a1a1a">and eval?</text>
 
-  <!-- LEFT LEAF: Build raw first -->
-  <rect x="50" y="170" width="210" height="60" rx="10" fill="#F0FDF4" stroke="#22c55e" stroke-width="2.5"/>
-  <text x="155" y="195" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">Build raw first</text>
-  <text x="155" y="213" text-anchor="middle" font-size="11" fill="#374151">Pure Python, direct API calls</text>
-  <text x="155" y="228" text-anchor="middle" font-size="10" fill="#6B7280">Learn the mechanics, not the abstraction</text>
+  <!-- Branch: not critical -->
+  <line x1="480" y1="200" x2="368" y2="264" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="372" y="224" text-anchor="middle" font-size="11" fill="#6b6b6b">not critical</text>
+  <text x="372" y="238" text-anchor="middle" font-size="11" fill="#6b6b6b">right now</text>
 
-  <!-- RIGHT BRANCH: Production sub-question -->
-  <rect x="420" y="170" width="250" height="56" rx="10" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="2"/>
-  <text x="545" y="194" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">Need built-in tracing</text>
-  <text x="545" y="210" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">and eval pipeline?</text>
+  <!-- Branch: yes -->
+  <line x1="625" y1="200" x2="625" y2="264" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="640" y="228" font-size="11" fill="#6b6b6b">yes,</text>
+  <text x="640" y="242" font-size="11" fill="#6b6b6b">critical</text>
 
-  <!-- Arrow left from production branch: Not critical -->
-  <line x1="460" y1="226" x2="345" y2="286" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="368" y="257" text-anchor="middle" font-size="11" fill="#374151">Not critical</text>
-  <text x="368" y="270" text-anchor="middle" font-size="11" fill="#374151">right now</text>
+  <!-- Leaf: langchain -->
+  <rect x="250" y="268" width="220" height="64" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="360" y="290" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">LANGCHAIN</text>
+  <text x="360" y="308" text-anchor="middle" font-size="11" fill="#1a1a1a">ecosystem · integrations</text>
+  <text x="360" y="324" text-anchor="middle" font-size="11" fill="#6b6b6b">watch: churn, opaque layers</text>
 
-  <!-- Arrow right from production branch: Yes -->
-  <line x1="630" y1="226" x2="630" y2="286" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="650" y="262" font-size="11" fill="#374151">Yes,</text>
-  <text x="648" y="275" font-size="11" fill="#374151">critical</text>
+  <!-- Leaf: google adk -->
+  <rect x="500" y="268" width="180" height="64" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="590" y="290" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">GOOGLE ADK</text>
+  <text x="590" y="308" text-anchor="middle" font-size="11" fill="#1a1a1a">tracing + eval built in</text>
+  <text x="590" y="324" text-anchor="middle" font-size="11" fill="#6b6b6b">google ecosystem</text>
 
-  <!-- Left leaf: LangChain -->
-  <rect x="230" y="288" width="230" height="60" rx="10" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="2.5"/>
-  <text x="345" y="312" text-anchor="middle" font-size="14" font-weight="bold" fill="#5B21B6">LangChain</text>
-  <text x="345" y="330" text-anchor="middle" font-size="11" fill="#374151">Rich ecosystem, many integrations</text>
-  <text x="345" y="345" text-anchor="middle" font-size="10" fill="#F59E0B">Watch out: version churn, opaque chains</text>
+  <!-- Upgrade path -->
+  <path d="M270,176 Q355,178 436,172" fill="none" stroke="#6b6b6b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="353" y="162" text-anchor="middle" font-size="10" fill="#6b6b6b">start raw, upgrade later</text>
 
-  <!-- Right leaf: Google ADK -->
-  <rect x="495" y="288" width="175" height="60" rx="10" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2.5"/>
-  <text x="582" y="312" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">Google ADK</text>
-  <text x="582" y="330" text-anchor="middle" font-size="11" fill="#374151">Tracing, evals, structured</text>
-  <text x="582" y="345" text-anchor="middle" font-size="10" fill="#F59E0B">Google Cloud ecosystem</text>
-
-  <!-- Dotted line from raw to right side (upgrade path) -->
-  <path d="M260,200 Q340,200 420,185" fill="none" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <text x="340" y="194" text-anchor="middle" font-size="9" fill="#22c55e">start here, upgrade later</text>
-
-  <!-- Caption -->
-  <text x="350" y="374" text-anchor="middle" font-size="11" fill="#374151">No framework is a permanent commitment. Start raw, add structure when you feel the pain of not having it.</text>
-  <text x="350" y="390" text-anchor="middle" font-size="11" fill="#9CA3AF">The right time to add a framework is when you keep re-solving the same problem.</text>
+  <!-- Footnote -->
+  <text x="350" y="376" text-anchor="middle" font-size="11" fill="#6b6b6b">no framework is permanent · add structure when you keep re-solving the same problem</text>
 </svg>

--- a/public/assets/diagrams/framework-layers.svg
+++ b/public/assets/diagrams/framework-layers.svg
@@ -1,75 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="720" height="400" viewBox="0 0 720 400" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 400" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
-    <marker id="arr-up" markerWidth="7" markerHeight="10" refX="3.5" refY="1" orient="auto">
-      <polygon points="0 10, 3.5 0, 7 10" fill="#6B7280"/>
-    </marker>
-    <marker id="arr-down" markerWidth="7" markerHeight="10" refX="3.5" refY="9" orient="auto">
-      <polygon points="0 0, 3.5 10, 7 0" fill="#6B7280"/>
-    </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
   </defs>
+  <rect width="720" height="400" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="720" height="400" fill="#ffffff"/>
+  <!-- TOP: eval (accent, yours) -->
+  <rect x="70" y="48" width="580" height="76" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="360" y="78" text-anchor="middle" font-size="12" letter-spacing="2" font-weight="500" fill="#9b4a3f">EVAL HARNESS · YOURS</text>
+  <text x="360" y="102" text-anchor="middle" font-size="11" fill="#1a1a1a">five queries · one scorer · measures every implementation the same way</text>
 
-  <!-- Title -->
-  <text x="360" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Framework Abstraction Layers</text>
-  <line x1="40" y1="42" x2="680" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <!-- MIDDLE: the replaceable framework layer -->
+  <rect x="70" y="148" width="580" height="104" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <text x="360" y="170" text-anchor="middle" font-size="10" letter-spacing="1.5" fill="#6b6b6b">FRAMEWORK · THE REPLACEABLE MIDDLE</text>
 
-  <!-- Left axis labels -->
-  <text x="28" y="116" text-anchor="middle" font-size="10" font-weight="bold" fill="#8B5CF6" transform="rotate(-90,28,116)">More abstraction</text>
-  <line x1="18" y1="80" x2="18" y2="160" stroke="#8B5CF6" stroke-width="2" marker-end="url(#arr-up)"/>
+  <rect x="92" y="182" width="170" height="52" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="177" y="204" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">RAW PYTHON</text>
+  <text x="177" y="222" text-anchor="middle" font-size="11" fill="#6b6b6b">~100 lines</text>
 
-  <text x="28" y="300" text-anchor="middle" font-size="10" font-weight="bold" fill="#374151" transform="rotate(-90,28,300)">More control</text>
-  <line x1="18" y1="340" x2="18" y2="250" stroke="#374151" stroke-width="2" marker-end="url(#arr-down)"/>
+  <rect x="275" y="182" width="170" height="52" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="360" y="204" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">GOOGLE ADK</text>
+  <text x="360" y="222" text-anchor="middle" font-size="11" fill="#6b6b6b">~40 lines</text>
 
-  <!-- LAYER 3 (top): LangChain -->
-  <rect x="50" y="68" width="638" height="84" rx="10" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="2"/>
-  <text x="180" y="96" text-anchor="middle" font-size="16" font-weight="bold" fill="#5B21B6">LangChain</text>
-  <text x="180" y="116" text-anchor="middle" font-size="11" fill="#374151">Chains, agents, memory, retrievers</text>
-  <text x="180" y="133" text-anchor="middle" font-size="11" fill="#374151">Large ecosystem, many integrations</text>
+  <rect x="458" y="182" width="170" height="52" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="543" y="204" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">LANGCHAIN</text>
+  <text x="543" y="222" text-anchor="middle" font-size="11" fill="#6b6b6b">~35 lines</text>
 
-  <!-- Tags for LangChain -->
-  <rect x="420" y="80" width="92" height="22" rx="4" fill="#DCFCE7"/>
-  <text x="466" y="96" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Ecosystem</text>
-  <rect x="520" y="80" width="100" height="22" rx="4" fill="#DCFCE7"/>
-  <text x="570" y="96" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Integrations</text>
-  <rect x="420" y="110" width="108" height="22" rx="4" fill="#FEF3C7"/>
-  <text x="474" y="126" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Chains opaque</text>
-  <rect x="536" y="110" width="104" height="22" rx="4" fill="#FEF3C7"/>
-  <text x="588" y="126" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Version churn</text>
+  <!-- BOTTOM: tool logic (yours) -->
+  <rect x="70" y="276" width="580" height="76" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="360" y="306" text-anchor="middle" font-size="12" letter-spacing="2" font-weight="500" fill="#1a1a1a">TOOL LOGIC + SYSTEM PROMPT · YOURS</text>
+  <text x="360" y="330" text-anchor="middle" font-size="11" fill="#6b6b6b">calculator · search · word_count · identical in all three</text>
 
-  <!-- LAYER 2 (middle): Google ADK -->
-  <rect x="50" y="176" width="638" height="84" rx="10" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
-  <text x="180" y="204" text-anchor="middle" font-size="16" font-weight="bold" fill="#1D4ED8">Google ADK</text>
-  <text x="180" y="224" text-anchor="middle" font-size="11" fill="#374151">Agent development kit, structured evals</text>
-  <text x="180" y="241" text-anchor="middle" font-size="11" fill="#374151">Built-in tracing, Google Cloud native</text>
-
-  <!-- Tags for ADK -->
-  <rect x="420" y="188" width="72" height="22" rx="4" fill="#DCFCE7"/>
-  <text x="456" y="204" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Tracing</text>
-  <rect x="500" y="188" width="54" height="22" rx="4" fill="#DCFCE7"/>
-  <text x="527" y="204" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Eval</text>
-  <rect x="420" y="218" width="96" height="22" rx="4" fill="#FEF3C7"/>
-  <text x="468" y="234" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Loop hidden</text>
-  <rect x="524" y="218" width="140" height="22" rx="4" fill="#FEF3C7"/>
-  <text x="594" y="234" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Context managed</text>
-
-  <!-- LAYER 1 (bottom): Raw Python -->
-  <rect x="50" y="284" width="638" height="84" rx="10" fill="#F3F4F6" stroke="#6B7280" stroke-width="2"/>
-  <text x="180" y="312" text-anchor="middle" font-size="16" font-weight="bold" fill="#374151">Raw Python</text>
-  <text x="180" y="332" text-anchor="middle" font-size="11" fill="#374151">Direct API calls, manual loop, explicit state</text>
-  <text x="180" y="349" text-anchor="middle" font-size="11" fill="#374151">You write everything, you control everything</text>
-
-  <!-- Tags for Raw Python -->
-  <rect x="420" y="296" width="88" height="22" rx="4" fill="#DCFCE7"/>
-  <text x="464" y="312" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Full control</text>
-  <rect x="516" y="296" width="120" height="22" rx="4" fill="#DCFCE7"/>
-  <text x="576" y="312" text-anchor="middle" font-size="10" font-weight="bold" fill="#15803D">Full visibility</text>
-  <rect x="420" y="326" width="136" height="22" rx="4" fill="#FEF3C7"/>
-  <text x="488" y="342" text-anchor="middle" font-size="10" font-weight="bold" fill="#92400E">Full responsibility</text>
-
-  <!-- Caption -->
-  <text x="360" y="384" text-anchor="middle" font-size="11" fill="#374151">Higher abstraction = less code, less insight. Choose based on what you need to debug and own.</text>
-  <text x="360" y="398" text-anchor="middle" font-size="11" fill="#9CA3AF">Recommendation: build raw first, then adopt a framework when you know what pain it solves.</text>
+  <!-- Footnote -->
+  <text x="360" y="384" text-anchor="middle" font-size="11" fill="#6b6b6b">swap the middle without touching what you own · eval sits above every framework choice</text>
 </svg>

--- a/public/assets/diagrams/function-calling-cycle.svg
+++ b/public/assets/diagrams/function-calling-cycle.svg
@@ -1,78 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="700" height="500" viewBox="0 0 700 500" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 500" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
-    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
   </defs>
+  <rect width="700" height="500" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="700" height="500" fill="#ffffff"/>
+  <!-- Lanes -->
+  <text x="180" y="36" text-anchor="middle" font-size="12" letter-spacing="2" font-weight="500" fill="#1a1a1a">YOUR CODE</text>
+  <text x="520" y="36" text-anchor="middle" font-size="12" letter-spacing="2" font-weight="500" fill="#1a1a1a">THE MODEL</text>
+  <text x="520" y="54" text-anchor="middle" font-size="11" fill="#6b6b6b">writes JSON · never executes</text>
+  <line x1="350" y1="64" x2="350" y2="464" stroke="#e8e8e8" stroke-width="1" stroke-dasharray="4,4"/>
 
-  <!-- Title -->
-  <text x="350" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Function Calling: The Full Cycle</text>
-  <line x1="40" y1="42" x2="660" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <!-- 1: define schemas (code) -->
+  <rect x="55" y="64" width="250" height="56" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="180" y="88" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">1 · DEFINE TOOL SCHEMAS</text>
+  <text x="180" y="106" text-anchor="middle" font-size="11" fill="#6b6b6b">what exists, what args it takes</text>
 
-  <!-- Node 1: Your Code (top-left) -->
-  <rect x="40" y="70" width="180" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
-  <text x="130" y="94" text-anchor="middle" font-size="14" font-weight="bold" fill="#1D4ED8">1. Your Code</text>
-  <text x="130" y="112" text-anchor="middle" font-size="10" fill="#6B7280">send schema + prompt</text>
-  <text x="130" y="128" text-anchor="middle" font-size="10" fill="#3B82F6">{"tools": [...], "messages": [...]}</text>
+  <!-- 2: send (arrow across) -->
+  <path d="M180,120 L180,146 L520,146 L520,162" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="350" y="138" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">2 · SEND SCHEMAS + USER MESSAGE</text>
 
-  <!-- Arrow 1 → 2 -->
-  <line x1="221" y1="106" x2="278" y2="106" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="249" y="98" text-anchor="middle" font-size="9" fill="#374151">HTTP POST</text>
+  <!-- 3: tool call returned (model) -->
+  <rect x="395" y="166" width="250" height="88" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="520" y="188" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#9b4a3f">3 · A TOOL CALL, AS JSON</text>
+  <text x="410" y="210" font-size="11" fill="#1a1a1a">{"name": "calculator",</text>
+  <text x="410" y="226" font-size="11" fill="#1a1a1a"> "args": {"operation":</text>
+  <text x="410" y="242" font-size="11" fill="#1a1a1a">  "multiply", "a": 6, "b": 7}}</text>
 
-  <!-- Node 2: API (top-right) -->
-  <rect x="480" y="70" width="180" height="72" rx="8" fill="#F0FDF4" stroke="#22c55e" stroke-width="2"/>
-  <text x="570" y="94" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">2. LLM API</text>
-  <text x="570" y="112" text-anchor="middle" font-size="10" fill="#6B7280">model sees schema</text>
-  <text x="570" y="128" text-anchor="middle" font-size="10" fill="#6B7280">decides to call a tool</text>
+  <!-- hand-off back to code -->
+  <path d="M520,254 L520,280 L180,280 L180,296" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="350" y="272" text-anchor="middle" font-size="11" fill="#6b6b6b">your code receives the JSON</text>
 
-  <!-- Arrow 2 → 3 (right side going down) -->
-  <line x1="570" y1="143" x2="570" y2="198" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="600" y="175" font-size="9" fill="#374151">tool_call JSON</text>
+  <!-- 4: validate + execute (code) -->
+  <rect x="55" y="300" width="250" height="60" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="180" y="324" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">4 · VALIDATE + EXECUTE</text>
+  <text x="180" y="344" text-anchor="middle" font-size="11" fill="#6b6b6b">calculator(6 x 7) &#8594; 42</text>
 
-  <!-- Node 3: Model Response (bottom-right) -->
-  <rect x="480" y="200" width="180" height="80" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="2"/>
-  <text x="570" y="222" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">3. Model Response</text>
-  <text x="570" y="240" text-anchor="middle" font-size="10" fill="#6B7280">{"tool_calls": [{</text>
-  <text x="570" y="255" text-anchor="middle" font-size="10" fill="#6B7280">  "name": "get_weather",</text>
-  <text x="570" y="270" text-anchor="middle" font-size="10" fill="#6B7280">  "args": {"city": "NYC"}}]}</text>
+  <!-- 5: send result back (arrow across) -->
+  <path d="M180,360 L180,386 L520,386 L520,402" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="350" y="378" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">5 · SEND THE RESULT BACK</text>
 
-  <!-- Arrow 3 → 4 (bottom going left) -->
-  <line x1="479" y1="240" x2="221" y2="240" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="350" y="232" text-anchor="middle" font-size="9" fill="#374151">your code receives this</text>
+  <!-- model writes the final text -->
+  <rect x="395" y="406" width="250" height="58" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="520" y="430" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">MODEL WRITES THE ANSWER</text>
+  <text x="520" y="450" text-anchor="middle" font-size="11" fill="#6b6b6b">"6 times 7 is 42."</text>
 
-  <!-- Node 4: Execute Function (bottom-left) -->
-  <rect x="40" y="200" width="180" height="80" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="2"/>
-  <text x="130" y="222" text-anchor="middle" font-size="13" font-weight="bold" fill="#5B21B6">4. Execute Function</text>
-  <text x="130" y="240" text-anchor="middle" font-size="10" fill="#6B7280">your code runs:</text>
-  <text x="130" y="255" text-anchor="middle" font-size="10" fill="#5B21B6">get_weather("NYC")</text>
-  <text x="130" y="270" text-anchor="middle" font-size="10" fill="#6B7280">→ "72°F, sunny"</text>
-
-  <!-- Arrow 4 → 5 (left side going down) -->
-  <line x1="130" y1="281" x2="130" y2="338" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="90" y="314" font-size="9" fill="#374151">function</text>
-  <text x="90" y="326" font-size="9" fill="#374151">result</text>
-
-  <!-- Node 5: Back to API (bottom center) -->
-  <rect x="40" y="340" width="180" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
-  <text x="130" y="364" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">5. Send Result to API</text>
-  <text x="130" y="381" text-anchor="middle" font-size="10" fill="#6B7280">{"role": "tool",</text>
-  <text x="130" y="396" text-anchor="middle" font-size="10" fill="#6B7280"> "content": "72°F, sunny"}</text>
-
-  <!-- Arrow 5 → 1 (loop back, curved) -->
-  <path d="M220,376 Q350,430 350,130 Q350,106 281,106" fill="none" stroke="#6B7280" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arr)"/>
-  <text x="410" y="420" text-anchor="middle" font-size="10" fill="#9CA3AF">model now writes</text>
-  <text x="410" y="436" text-anchor="middle" font-size="10" fill="#9CA3AF">final answer or</text>
-  <text x="410" y="452" text-anchor="middle" font-size="10" fill="#9CA3AF">calls another tool</text>
-
-  <!-- Loop label in center -->
-  <rect x="268" y="290" width="164" height="32" rx="6" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="350" y="307" text-anchor="middle" font-size="11" font-weight="bold" fill="#374151">Repeats until</text>
-  <text x="350" y="320" text-anchor="middle" font-size="11" fill="#6B7280">final answer returned</text>
-
-  <!-- Caption -->
-  <text x="350" y="480" text-anchor="middle" font-size="11" fill="#9CA3AF">The model never runs code. It only describes the call. Your code executes it.</text>
+  <text x="350" y="490" text-anchor="middle" font-size="11" fill="#6b6b6b">one pass, then done · the next section adds the loop</text>
 </svg>

--- a/public/assets/diagrams/function-calling-cycle.svg
+++ b/public/assets/diagrams/function-calling-cycle.svg
@@ -28,7 +28,7 @@
   <rect x="395" y="166" width="250" height="88" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
   <text x="520" y="188" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#9b4a3f">3 · A TOOL CALL, AS JSON</text>
   <text x="410" y="210" font-size="11" fill="#1a1a1a">{"name": "calculator",</text>
-  <text x="410" y="226" font-size="11" fill="#1a1a1a"> "args": {"operation":</text>
+  <text x="410" y="226" font-size="11" fill="#1a1a1a"> "arguments": {"operation":</text>
   <text x="410" y="242" font-size="11" fill="#1a1a1a">  "multiply", "a": 6, "b": 7}}</text>
 
   <!-- hand-off back to code -->

--- a/public/assets/diagrams/hallucination-mental-model.svg
+++ b/public/assets/diagrams/hallucination-mental-model.svg
@@ -1,71 +1,74 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="680" height="360" viewBox="0 0 680 360" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 360" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
   </defs>
+  <rect width="680" height="360" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="680" height="360" fill="#ffffff"/>
+  <!-- Divider -->
+  <line x1="340" y1="32" x2="340" y2="330" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Title -->
-  <text x="340" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Hallucination: The Correct Mental Model</text>
-  <line x1="40" y1="42" x2="640" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <!-- LEFT: the imagined lookup -->
+  <text x="40" y="42" font-size="11" letter-spacing="2" font-weight="500" fill="#6b6b6b">WHAT YOU THINK HAPPENS</text>
+  <text x="40" y="64" font-size="11" fill="#6b6b6b">look the fact up, verify it, answer</text>
 
-  <!-- LEFT PANEL: What you think -->
-  <rect x="40" y="58" width="280" height="264" rx="10" fill="#F0FDF4" stroke="#22c55e" stroke-width="2.5"/>
-  <text x="180" y="84" text-anchor="middle" font-size="15" font-weight="bold" fill="#15803D">What You Think</text>
-  <line x1="60" y1="93" x2="300" y2="93" stroke="#86EFAC" stroke-width="1"/>
+  <g transform="translate(60,92)">
+    <rect x="0" y="0" width="200" height="16" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+    <line x1="10" y1="8" x2="120" y2="8" stroke="#e8e8e8" stroke-width="1"/>
+    <rect x="0" y="19" width="200" height="16" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+    <line x1="10" y1="27" x2="90" y2="27" stroke="#e8e8e8" stroke-width="1"/>
+    <rect x="0" y="38" width="200" height="18" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1.5"/>
+    <text x="100" y="51" text-anchor="middle" font-size="11" fill="#1a1a1a">the fact</text>
+    <rect x="0" y="59" width="200" height="16" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+    <line x1="10" y1="67" x2="130" y2="67" stroke="#e8e8e8" stroke-width="1"/>
+    <rect x="0" y="78" width="200" height="16" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+    <line x1="10" y1="86" x2="100" y2="86" stroke="#e8e8e8" stroke-width="1"/>
+    <!-- magnifier -->
+    <circle cx="236" cy="47" r="14" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+    <line x1="246" y1="58" x2="258" y2="70" stroke="#6b6b6b" stroke-width="1.5" stroke-linecap="round"/>
+  </g>
 
-  <!-- Magnifying glass icon (simplified) -->
-  <circle cx="180" cy="158" r="46" fill="#DCFCE7" stroke="#22c55e" stroke-width="2"/>
-  <circle cx="170" cy="148" r="26" fill="none" stroke="#15803D" stroke-width="3"/>
-  <line x1="189" y1="166" x2="205" y2="182" stroke="#15803D" stroke-width="4" stroke-linecap="round"/>
+  <text x="40" y="238" font-size="12" fill="#1a1a1a">find &#8594; verify &#8594; answer</text>
+  <text x="40" y="312" font-size="11" fill="#6b6b6b">reassuring · not what the model does</text>
 
-  <!-- Document lines inside magnifier (fact-checking metaphor) -->
-  <line x1="160" y1="138" x2="182" y2="138" stroke="#15803D" stroke-width="2"/>
-  <line x1="158" y1="147" x2="183" y2="147" stroke="#15803D" stroke-width="2"/>
-  <line x1="160" y1="156" x2="178" y2="156" stroke="#15803D" stroke-width="2"/>
-  <!-- Checkmark overlay -->
-  <text x="195" y="128" font-size="18" fill="#22c55e" font-weight="bold">&#10003;</text>
+  <!-- RIGHT: the probability machine -->
+  <text x="380" y="42" font-size="11" letter-spacing="2" font-weight="500" fill="#9b4a3f">WHAT ACTUALLY HAPPENS</text>
+  <text x="380" y="64" font-size="11" fill="#6b6b6b">predict a likely next token, repeat</text>
 
-  <text x="180" y="225" text-anchor="middle" font-size="13" font-weight="bold" fill="#15803D">Fact-Checking Mode</text>
-  <text x="180" y="245" text-anchor="middle" font-size="11" fill="#374151">"The model looks up the</text>
-  <text x="180" y="262" text-anchor="middle" font-size="11" fill="#374151">answer in its knowledge</text>
-  <text x="180" y="279" text-anchor="middle" font-size="11" fill="#374151">and verifies it's correct."</text>
-  <rect x="68" y="293" width="224" height="20" rx="4" fill="#DCFCE7"/>
-  <text x="180" y="307" text-anchor="middle" font-size="11" fill="#15803D">Feels reassuring. Is wrong.</text>
+  <!-- Context so far -->
+  <g transform="translate(380,84)">
+    <rect x="0" y="0" width="34" height="20" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1"/>
+    <text x="17" y="14" text-anchor="middle" font-size="11" fill="#1a1a1a">The</text>
+    <rect x="38" y="0" width="60" height="20" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1"/>
+    <text x="68" y="14" text-anchor="middle" font-size="11" fill="#1a1a1a">capital</text>
+    <rect x="102" y="0" width="28" height="20" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1"/>
+    <text x="116" y="14" text-anchor="middle" font-size="11" fill="#1a1a1a">of</text>
+    <rect x="134" y="0" width="54" height="20" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1"/>
+    <text x="161" y="14" text-anchor="middle" font-size="11" fill="#1a1a1a">France</text>
+    <rect x="192" y="0" width="28" height="20" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1"/>
+    <text x="206" y="14" text-anchor="middle" font-size="11" fill="#1a1a1a">is</text>
+    <rect x="224" y="0" width="28" height="20" fill="none" stroke="#9b4a3f" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <text x="238" y="14" text-anchor="middle" font-size="11" fill="#9b4a3f">?</text>
+  </g>
 
-  <!-- VS divider -->
-  <text x="340" y="200" text-anchor="middle" font-size="18" font-weight="bold" fill="#9CA3AF">vs</text>
+  <line x1="498" y1="112" x2="498" y2="134" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- RIGHT PANEL: What actually happens -->
-  <rect x="360" y="58" width="280" height="264" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2.5"/>
-  <text x="500" y="84" text-anchor="middle" font-size="15" font-weight="bold" fill="#B91C1C">What Actually Happens</text>
-  <line x1="380" y1="93" x2="620" y2="93" stroke="#FCA5A5" stroke-width="1"/>
+  <!-- Probability bars -->
+  <g transform="translate(396,140)">
+    <rect x="0" y="16" width="30" height="64" fill="#9b4a3f"/>
+    <rect x="46" y="54" width="30" height="26" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+    <rect x="92" y="64" width="30" height="16" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+    <rect x="138" y="70" width="30" height="10" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+    <rect x="184" y="74" width="30" height="6" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+    <line x1="-8" y1="80" x2="224" y2="80" stroke="#1a1a1a" stroke-width="1.5"/>
+    <text x="15" y="96" text-anchor="middle" font-size="11" fill="#1a1a1a">Paris</text>
+    <text x="61" y="96" text-anchor="middle" font-size="11" fill="#6b6b6b">Lyon</text>
+    <text x="107" y="96" text-anchor="middle" font-size="11" fill="#6b6b6b">Nice</text>
+    <text x="153" y="96" text-anchor="middle" font-size="11" fill="#6b6b6b">the</text>
+    <text x="199" y="96" text-anchor="middle" font-size="11" fill="#6b6b6b">...</text>
+  </g>
 
-  <!-- Dice icon (probability/randomness metaphor) -->
-  <rect cx="500" cy="158" x="462" y="118" width="72" height="72" rx="10" fill="#FEE2E2" stroke="#EF4444" stroke-width="2.5"/>
-  <!-- Dice dots -->
-  <circle cx="481" cy="137" r="5" fill="#EF4444"/>
-  <circle cx="503" cy="137" r="5" fill="#EF4444"/>
-  <circle cx="525" cy="137" r="5" fill="#EF4444"/>
-  <circle cx="481" cy="159" r="5" fill="#EF4444"/>
-  <circle cx="525" cy="159" r="5" fill="#EF4444"/>
-  <circle cx="481" cy="181" r="5" fill="#EF4444"/>
-  <circle cx="503" cy="181" r="5" fill="#EF4444"/>
-  <circle cx="525" cy="181" r="5" fill="#EF4444"/>
-  <!-- Probability bars behind dice -->
-  <rect x="432" y="148" width="18" height="22" rx="2" fill="#FECACA"/>
-  <rect x="432" y="138" width="18" height="10" rx="2" fill="#EF4444" opacity="0.5"/>
-  <text x="421" y="196" font-size="9" fill="#EF4444">P(word)</text>
-
-  <text x="500" y="225" text-anchor="middle" font-size="13" font-weight="bold" fill="#B91C1C">Probability Machine</text>
-  <text x="500" y="245" text-anchor="middle" font-size="11" fill="#374151">"The model predicts the</text>
-  <text x="500" y="262" text-anchor="middle" font-size="11" fill="#374151">most likely next token</text>
-  <text x="500" y="279" text-anchor="middle" font-size="11" fill="#374151">given what came before."</text>
-  <rect x="388" y="293" width="224" height="20" rx="4" fill="#FEE2E2"/>
-  <text x="500" y="307" text-anchor="middle" font-size="11" fill="#B91C1C">Plausible ≠ true. By design.</text>
-
-  <!-- Caption -->
-  <text x="340" y="345" text-anchor="middle" font-size="11" fill="#374151">Hallucination is not a bug. It is the expected output of a token predictor asked a factual question.</text>
-  <text x="340" y="360" text-anchor="middle" font-size="11" fill="#9CA3AF">Design your system accordingly: verify, don't assume.</text>
+  <text x="380" y="272" font-size="12" fill="#1a1a1a">pick a likely one &#8594; append &#8594; repeat</text>
+  <text x="380" y="312" font-size="11" fill="#9b4a3f">plausible &#8800; verified · by design</text>
 </svg>

--- a/public/assets/diagrams/mcp-architecture.svg
+++ b/public/assets/diagrams/mcp-architecture.svg
@@ -1,65 +1,61 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 260" width="780" height="260" style="background:#fff;font-family:system-ui,-apple-system,sans-serif;">
-
-  <rect width="780" height="260" fill="#ffffff"/>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 300" font-family="IBM Plex Mono, monospace">
   <defs>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L0,6 L8,3 z" fill="#3d7ab5"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
   </defs>
-
-  <!-- Title -->
-  <text x="390" y="28" text-anchor="middle" font-size="16" font-weight="600" fill="#1a1a1a">MCP Architecture: Three Roles</text>
+  <rect width="780" height="300" fill="#fafaf8"/>
 
   <!-- Host -->
-  <rect x="30" y="60" width="200" height="160" rx="10" fill="#1a3a5c" stroke="none"/>
-  <text x="130" y="88" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Host</text>
-  <text x="130" y="106" text-anchor="middle" font-size="9" fill="#c5d5e4">Your AI application</text>
-  <line x1="50" y1="114" x2="210" y2="114" stroke="#3d7ab5" stroke-width="0.5"/>
+  <rect x="40" y="40" width="290" height="224" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="60" y="66" font-size="11" letter-spacing="2" font-weight="500" fill="#1a1a1a">HOST</text>
+  <text x="120" y="66" font-size="11" fill="#6b6b6b">your AI application</text>
+  <line x1="60" y1="78" x2="310" y2="78" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- LLM inside host -->
-  <rect x="55" y="124" width="150" height="30" rx="5" fill="#3d7ab5"/>
-  <text x="130" y="143" text-anchor="middle" font-size="10" fill="#fff">LLM (Claude, GPT, etc.)</text>
+  <!-- Model inside host -->
+  <rect x="64" y="92" width="242" height="46" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="185" y="111" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">THE MODEL</text>
+  <text x="185" y="129" text-anchor="middle" font-size="10.5" fill="#6b6b6b">sees tools from both servers</text>
 
-  <!-- Client inside host -->
-  <rect x="55" y="164" width="150" height="30" rx="5" fill="#7eb3d8"/>
-  <text x="130" y="183" text-anchor="middle" font-size="10" fill="#1a3a5c" font-weight="500">MCP Client</text>
+  <!-- Client A -->
+  <rect x="64" y="152" width="242" height="44" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="185" y="170" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">MCP CLIENT A</text>
+  <text x="185" y="188" text-anchor="middle" font-size="10.5" fill="#6b6b6b">one session · server 1</text>
 
-  <!-- Arrow from client to server 1 -->
-  <line x1="230" y1="140" x2="310" y2="100" stroke="#3d7ab5" stroke-width="1.5" marker-end="url(#ar)"/>
-  <line x1="230" y1="179" x2="310" y2="179" stroke="#3d7ab5" stroke-width="1.5" marker-end="url(#ar)"/>
-
-  <!-- Protocol label -->
-  <text x="270" y="132" text-anchor="middle" font-size="8" fill="#3d7ab5" transform="rotate(-20,270,132)">JSON-RPC</text>
-  <text x="270" y="172" text-anchor="middle" font-size="8" fill="#3d7ab5">JSON-RPC</text>
+  <!-- Client B -->
+  <rect x="64" y="208" width="242" height="44" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="185" y="226" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">MCP CLIENT B</text>
+  <text x="185" y="244" text-anchor="middle" font-size="10.5" fill="#6b6b6b">one session · server 2</text>
 
   <!-- Server 1 -->
-  <rect x="315" y="60" width="190" height="80" rx="8" fill="#e8f0f7" stroke="#7eb3d8" stroke-width="1.5"/>
-  <text x="410" y="85" text-anchor="middle" font-size="12" font-weight="600" fill="#1a3a5c">MCP Server 1</text>
-  <text x="410" y="102" text-anchor="middle" font-size="9" fill="#6B7280">e.g. Database tools</text>
-  <rect x="335" y="112" width="60" height="18" rx="3" fill="#c5d5e4"/>
-  <text x="365" y="124" text-anchor="middle" font-size="8" fill="#1a3a5c">query</text>
-  <rect x="405" y="112" width="60" height="18" rx="3" fill="#c5d5e4"/>
-  <text x="435" y="124" text-anchor="middle" font-size="8" fill="#1a3a5c">insert</text>
+  <rect x="540" y="52" width="210" height="84" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="645" y="74" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">MCP SERVER 1</text>
+  <text x="645" y="92" text-anchor="middle" font-size="10.5" fill="#6b6b6b">document tools</text>
+  <rect x="558" y="102" width="48" height="20" rx="2" fill="#e8e8e8"/>
+  <text x="582" y="116" text-anchor="middle" font-size="10" fill="#1a1a1a">list</text>
+  <rect x="614" y="102" width="48" height="20" rx="2" fill="#e8e8e8"/>
+  <text x="638" y="116" text-anchor="middle" font-size="10" fill="#1a1a1a">read</text>
+  <rect x="670" y="102" width="62" height="20" rx="2" fill="#e8e8e8"/>
+  <text x="701" y="116" text-anchor="middle" font-size="10" fill="#1a1a1a">search</text>
 
   <!-- Server 2 -->
-  <rect x="315" y="155" width="190" height="80" rx="8" fill="#e8f0f7" stroke="#7eb3d8" stroke-width="1.5"/>
-  <text x="410" y="180" text-anchor="middle" font-size="12" font-weight="600" fill="#1a3a5c">MCP Server 2</text>
-  <text x="410" y="197" text-anchor="middle" font-size="9" fill="#6B7280">e.g. Search tools</text>
-  <rect x="335" y="207" width="60" height="18" rx="3" fill="#c5d5e4"/>
-  <text x="365" y="219" text-anchor="middle" font-size="8" fill="#1a3a5c">search</text>
-  <rect x="405" y="207" width="60" height="18" rx="3" fill="#c5d5e4"/>
-  <text x="435" y="219" text-anchor="middle" font-size="8" fill="#1a3a5c">fetch</text>
+  <rect x="540" y="168" width="210" height="84" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="645" y="190" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">MCP SERVER 2</text>
+  <text x="645" y="208" text-anchor="middle" font-size="10.5" fill="#6b6b6b">database tools</text>
+  <rect x="576" y="218" width="58" height="20" rx="2" fill="#e8e8e8"/>
+  <text x="605" y="232" text-anchor="middle" font-size="10" fill="#1a1a1a">query</text>
+  <rect x="642" y="218" width="66" height="20" rx="2" fill="#e8e8e8"/>
+  <text x="675" y="232" text-anchor="middle" font-size="10" fill="#1a1a1a">insert</text>
 
-  <!-- Transport labels -->
-  <rect x="560" y="70" width="190" height="80" rx="8" fill="#f8f9fa" stroke="#c5d5e4" stroke-width="1"/>
-  <text x="655" y="92" text-anchor="middle" font-size="11" font-weight="600" fill="#1a3a5c">Transports</text>
-  <text x="580" y="114" font-size="10" fill="#3d7ab5" font-weight="500">stdio</text>
-  <text x="620" y="114" font-size="9" fill="#6B7280">Local process (fast)</text>
-  <text x="580" y="134" font-size="10" fill="#3d7ab5" font-weight="500">HTTP</text>
-  <text x="620" y="134" font-size="9" fill="#6B7280">Remote server (flexible)</text>
+  <!-- Sessions -->
+  <line x1="306" y1="174" x2="534" y2="98" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="422" y="104" text-anchor="middle" font-size="10.5" fill="#1a1a1a">stdio · local subprocess</text>
 
-  <line x1="507" y1="100" x2="558" y2="100" stroke="#c5d5e4" stroke-width="1" stroke-dasharray="4,2"/>
-  <line x1="507" y1="195" x2="558" y2="130" stroke="#c5d5e4" stroke-width="1" stroke-dasharray="4,2"/>
+  <line x1="306" y1="230" x2="534" y2="216" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="420" y="212" text-anchor="middle" font-size="10.5" fill="#1a1a1a">Streamable HTTP · remote</text>
 
+  <text x="420" y="164" text-anchor="middle" font-size="10.5" font-weight="500" fill="#9b4a3f">one client &#8596; one server</text>
+
+  <!-- Footnote -->
+  <text x="390" y="290" text-anchor="middle" font-size="11" fill="#6b6b6b">JSON-RPC 2.0 over both transports · the host runs one client per server it connects to</text>
 </svg>

--- a/public/assets/diagrams/mcp-before-after.svg
+++ b/public/assets/diagrams/mcp-before-after.svg
@@ -1,97 +1,102 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 340" width="780" height="340" style="background:#fff;font-family:system-ui,-apple-system,sans-serif;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 340" font-family="IBM Plex Mono, monospace">
+  <defs>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
+  </defs>
+  <rect width="780" height="340" fill="#fafaf8"/>
 
-  <rect width="780" height="340" fill="#ffffff"/>
+  <line x1="390" y1="30" x2="390" y2="296" stroke="#e8e8e8" stroke-width="1" stroke-dasharray="4,4"/>
 
-  <!-- Title -->
-  <text x="390" y="28" text-anchor="middle" font-size="16" font-weight="600" fill="#1a1a1a">The Problem MCP Solves</text>
-
-  <!-- === LEFT: Without MCP === -->
-  <text x="185" y="60" text-anchor="middle" font-size="13" font-weight="600" fill="#c0392b">Without MCP: 5 apps x 4 tools = 20 integrations</text>
-
-  <!-- Apps -->
-  <rect x="30" y="80" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
-  <text x="70" y="99" text-anchor="middle" font-size="9" fill="#1a3a5c">App 1</text>
-  <rect x="30" y="120" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
-  <text x="70" y="139" text-anchor="middle" font-size="9" fill="#1a3a5c">App 2</text>
-  <rect x="30" y="160" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
-  <text x="70" y="179" text-anchor="middle" font-size="9" fill="#1a3a5c">App 3</text>
-  <rect x="30" y="200" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
-  <text x="70" y="219" text-anchor="middle" font-size="9" fill="#1a3a5c">App 4</text>
-  <rect x="30" y="240" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
-  <text x="70" y="259" text-anchor="middle" font-size="9" fill="#1a3a5c">App 5</text>
-
-  <!-- Tools -->
-  <rect x="260" y="100" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
-  <text x="300" y="119" text-anchor="middle" font-size="9" fill="#1a3a5c">Database</text>
-  <rect x="260" y="145" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
-  <text x="300" y="164" text-anchor="middle" font-size="9" fill="#1a3a5c">Search</text>
-  <rect x="260" y="190" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
-  <text x="300" y="209" text-anchor="middle" font-size="9" fill="#1a3a5c">Email</text>
-  <rect x="260" y="235" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
-  <text x="300" y="254" text-anchor="middle" font-size="9" fill="#1a3a5c">Calendar</text>
-
-  <!-- Spaghetti lines -->
-  <g stroke="#ccc" stroke-width="0.8" opacity="0.6">
-    <line x1="110" y1="95" x2="260" y2="115"/><line x1="110" y1="95" x2="260" y2="160"/>
-    <line x1="110" y1="95" x2="260" y2="205"/><line x1="110" y1="95" x2="260" y2="250"/>
-    <line x1="110" y1="135" x2="260" y2="115"/><line x1="110" y1="135" x2="260" y2="160"/>
-    <line x1="110" y1="135" x2="260" y2="205"/><line x1="110" y1="135" x2="260" y2="250"/>
-    <line x1="110" y1="175" x2="260" y2="115"/><line x1="110" y1="175" x2="260" y2="160"/>
-    <line x1="110" y1="175" x2="260" y2="205"/><line x1="110" y1="175" x2="260" y2="250"/>
-    <line x1="110" y1="215" x2="260" y2="115"/><line x1="110" y1="215" x2="260" y2="160"/>
-    <line x1="110" y1="215" x2="260" y2="205"/><line x1="110" y1="215" x2="260" y2="250"/>
-    <line x1="110" y1="255" x2="260" y2="115"/><line x1="110" y1="255" x2="260" y2="160"/>
-    <line x1="110" y1="255" x2="260" y2="205"/><line x1="110" y1="255" x2="260" y2="250"/>
-  </g>
-
-  <!-- === RIGHT: With MCP === -->
-  <text x="595" y="60" text-anchor="middle" font-size="13" font-weight="600" fill="#3d7ab5">With MCP: 5 + 4 = 9 integrations</text>
+  <!-- LEFT: without MCP -->
+  <text x="195" y="42" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">WITHOUT MCP · 5 &#215; 4 = 20 INTEGRATIONS</text>
 
   <!-- Apps -->
-  <rect x="440" y="80" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
-  <text x="480" y="99" text-anchor="middle" font-size="9" fill="#1a3a5c">App 1</text>
-  <rect x="440" y="120" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
-  <text x="480" y="139" text-anchor="middle" font-size="9" fill="#1a3a5c">App 2</text>
-  <rect x="440" y="160" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
-  <text x="480" y="179" text-anchor="middle" font-size="9" fill="#1a3a5c">App 3</text>
-  <rect x="440" y="200" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
-  <text x="480" y="219" text-anchor="middle" font-size="9" fill="#1a3a5c">App 4</text>
-  <rect x="440" y="240" width="80" height="30" rx="4" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.2"/>
-  <text x="480" y="259" text-anchor="middle" font-size="9" fill="#1a3a5c">App 5</text>
-
-  <!-- MCP standard -->
-  <rect x="555" y="90" width="50" height="185" rx="6" fill="#3d7ab5" stroke="none"/>
-  <text x="580" y="185" text-anchor="middle" font-size="11" font-weight="600" fill="#fff" transform="rotate(-90,580,185)">MCP</text>
+  <rect x="40" y="70" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="85" y="87" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 1</text>
+  <rect x="40" y="110" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="85" y="127" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 2</text>
+  <rect x="40" y="150" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="85" y="167" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 3</text>
+  <rect x="40" y="190" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="85" y="207" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 4</text>
+  <rect x="40" y="230" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="85" y="247" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 5</text>
 
   <!-- Tools -->
-  <rect x="640" y="100" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
-  <text x="680" y="119" text-anchor="middle" font-size="9" fill="#1a3a5c">Database</text>
-  <rect x="640" y="145" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
-  <text x="680" y="164" text-anchor="middle" font-size="9" fill="#1a3a5c">Search</text>
-  <rect x="640" y="190" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
-  <text x="680" y="209" text-anchor="middle" font-size="9" fill="#1a3a5c">Email</text>
-  <rect x="640" y="235" width="80" height="30" rx="4" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.2"/>
-  <text x="680" y="254" text-anchor="middle" font-size="9" fill="#1a3a5c">Calendar</text>
+  <rect x="250" y="80" width="100" height="26" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="300" y="97" text-anchor="middle" font-size="10.5" fill="#1a1a1a">database</text>
+  <rect x="250" y="125" width="100" height="26" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="300" y="142" text-anchor="middle" font-size="10.5" fill="#1a1a1a">search</text>
+  <rect x="250" y="170" width="100" height="26" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="300" y="187" text-anchor="middle" font-size="10.5" fill="#1a1a1a">email</text>
+  <rect x="250" y="215" width="100" height="26" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="300" y="232" text-anchor="middle" font-size="10.5" fill="#1a1a1a">calendar</text>
 
-  <!-- Clean lines: apps to MCP -->
-  <g stroke="#3d7ab5" stroke-width="1.2">
-    <line x1="520" y1="95" x2="555" y2="140"/>
-    <line x1="520" y1="135" x2="555" y2="160"/>
-    <line x1="520" y1="175" x2="555" y2="180"/>
-    <line x1="520" y1="215" x2="555" y2="200"/>
-    <line x1="520" y1="255" x2="555" y2="230"/>
+  <!-- 20 custom integrations -->
+  <g stroke="#6b6b6b" stroke-width="1" opacity="0.45">
+    <line x1="130" y1="83" x2="250" y2="93"/><line x1="130" y1="83" x2="250" y2="138"/>
+    <line x1="130" y1="83" x2="250" y2="183"/><line x1="130" y1="83" x2="250" y2="228"/>
+    <line x1="130" y1="123" x2="250" y2="93"/><line x1="130" y1="123" x2="250" y2="138"/>
+    <line x1="130" y1="123" x2="250" y2="183"/><line x1="130" y1="123" x2="250" y2="228"/>
+    <line x1="130" y1="163" x2="250" y2="93"/><line x1="130" y1="163" x2="250" y2="138"/>
+    <line x1="130" y1="163" x2="250" y2="183"/><line x1="130" y1="163" x2="250" y2="228"/>
+    <line x1="130" y1="203" x2="250" y2="93"/><line x1="130" y1="203" x2="250" y2="138"/>
+    <line x1="130" y1="203" x2="250" y2="183"/><line x1="130" y1="203" x2="250" y2="228"/>
+    <line x1="130" y1="243" x2="250" y2="93"/><line x1="130" y1="243" x2="250" y2="138"/>
+    <line x1="130" y1="243" x2="250" y2="183"/><line x1="130" y1="243" x2="250" y2="228"/>
   </g>
 
-  <!-- Clean lines: MCP to tools -->
-  <g stroke="#7eb3d8" stroke-width="1.2">
-    <line x1="605" y1="140" x2="640" y2="115"/>
-    <line x1="605" y1="160" x2="640" y2="160"/>
-    <line x1="605" y1="200" x2="640" y2="205"/>
-    <line x1="605" y1="230" x2="640" y2="250"/>
+  <text x="195" y="290" text-anchor="middle" font-size="11" fill="#6b6b6b">every app writes custom code for every tool</text>
+
+  <!-- RIGHT: with MCP -->
+  <text x="585" y="42" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">WITH MCP · 5 + 4 = 9</text>
+
+  <!-- Apps -->
+  <rect x="430" y="70" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="475" y="87" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 1</text>
+  <rect x="430" y="110" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="475" y="127" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 2</text>
+  <rect x="430" y="150" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="475" y="167" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 3</text>
+  <rect x="430" y="190" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="475" y="207" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 4</text>
+  <rect x="430" y="230" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="475" y="247" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 5</text>
+
+  <!-- MCP standard (accent) -->
+  <rect x="560" y="66" width="46" height="194" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="583" y="163" text-anchor="middle" font-size="12" letter-spacing="3" font-weight="500" fill="#9b4a3f" transform="rotate(-90,583,163)">MCP</text>
+
+  <!-- Tools -->
+  <rect x="640" y="80" width="100" height="26" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="690" y="97" text-anchor="middle" font-size="10.5" fill="#1a1a1a">database</text>
+  <rect x="640" y="125" width="100" height="26" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="690" y="142" text-anchor="middle" font-size="10.5" fill="#1a1a1a">search</text>
+  <rect x="640" y="170" width="100" height="26" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="690" y="187" text-anchor="middle" font-size="10.5" fill="#1a1a1a">email</text>
+  <rect x="640" y="215" width="100" height="26" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="690" y="232" text-anchor="middle" font-size="10.5" fill="#1a1a1a">calendar</text>
+
+  <!-- 5 client integrations -->
+  <g stroke="#1a1a1a" stroke-width="1.5">
+    <line x1="520" y1="83" x2="560" y2="120"/>
+    <line x1="520" y1="123" x2="560" y2="143"/>
+    <line x1="520" y1="163" x2="560" y2="163"/>
+    <line x1="520" y1="203" x2="560" y2="183"/>
+    <line x1="520" y1="243" x2="560" y2="206"/>
   </g>
 
-  <!-- Bottom label -->
-  <text x="185" y="310" text-anchor="middle" font-size="10" fill="#999">Every app writes custom code for every tool</text>
-  <text x="595" y="310" text-anchor="middle" font-size="10" fill="#999">Each side implements the standard once</text>
+  <!-- 4 server integrations -->
+  <g stroke="#6b6b6b" stroke-width="1.5">
+    <line x1="606" y1="120" x2="640" y2="93"/>
+    <line x1="606" y1="150" x2="640" y2="138"/>
+    <line x1="606" y1="180" x2="640" y2="183"/>
+    <line x1="606" y1="210" x2="640" y2="228"/>
+  </g>
 
+  <text x="585" y="290" text-anchor="middle" font-size="11" fill="#6b6b6b">each side implements the standard once</text>
+
+  <!-- Footnote -->
+  <text x="390" y="324" text-anchor="middle" font-size="11" fill="#6b6b6b">same apps, same tools · the integration count is the only thing that changed</text>
 </svg>

--- a/public/assets/diagrams/mcp-before-after.svg
+++ b/public/assets/diagrams/mcp-before-after.svg
@@ -13,15 +13,15 @@
 
   <!-- Apps -->
   <rect x="40" y="70" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="85" y="87" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 1</text>
+  <text x="85" y="87" text-anchor="middle" font-size="10.5" fill="#1a1a1a">agent 1</text>
   <rect x="40" y="110" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="85" y="127" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 2</text>
+  <text x="85" y="127" text-anchor="middle" font-size="10.5" fill="#1a1a1a">agent 2</text>
   <rect x="40" y="150" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="85" y="167" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 3</text>
+  <text x="85" y="167" text-anchor="middle" font-size="10.5" fill="#1a1a1a">agent 3</text>
   <rect x="40" y="190" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="85" y="207" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 4</text>
+  <text x="85" y="207" text-anchor="middle" font-size="10.5" fill="#1a1a1a">agent 4</text>
   <rect x="40" y="230" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="85" y="247" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 5</text>
+  <text x="85" y="247" text-anchor="middle" font-size="10.5" fill="#1a1a1a">agent 5</text>
 
   <!-- Tools -->
   <rect x="250" y="80" width="100" height="26" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
@@ -47,22 +47,22 @@
     <line x1="130" y1="243" x2="250" y2="183"/><line x1="130" y1="243" x2="250" y2="228"/>
   </g>
 
-  <text x="195" y="290" text-anchor="middle" font-size="11" fill="#6b6b6b">every app writes custom code for every tool</text>
+  <text x="195" y="290" text-anchor="middle" font-size="11" fill="#6b6b6b">every agent writes custom code for every tool</text>
 
   <!-- RIGHT: with MCP -->
   <text x="585" y="42" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">WITH MCP · 5 + 4 = 9</text>
 
   <!-- Apps -->
   <rect x="430" y="70" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="475" y="87" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 1</text>
+  <text x="475" y="87" text-anchor="middle" font-size="10.5" fill="#1a1a1a">agent 1</text>
   <rect x="430" y="110" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="475" y="127" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 2</text>
+  <text x="475" y="127" text-anchor="middle" font-size="10.5" fill="#1a1a1a">agent 2</text>
   <rect x="430" y="150" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="475" y="167" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 3</text>
+  <text x="475" y="167" text-anchor="middle" font-size="10.5" fill="#1a1a1a">agent 3</text>
   <rect x="430" y="190" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="475" y="207" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 4</text>
+  <text x="475" y="207" text-anchor="middle" font-size="10.5" fill="#1a1a1a">agent 4</text>
   <rect x="430" y="230" width="90" height="26" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="475" y="247" text-anchor="middle" font-size="10.5" fill="#1a1a1a">app 5</text>
+  <text x="475" y="247" text-anchor="middle" font-size="10.5" fill="#1a1a1a">agent 5</text>
 
   <!-- MCP standard (accent) -->
   <rect x="560" y="66" width="46" height="194" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>

--- a/public/assets/diagrams/mcp-lifecycle.svg
+++ b/public/assets/diagrams/mcp-lifecycle.svg
@@ -1,66 +1,63 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 300" width="780" height="300" style="background:#fff;font-family:system-ui,-apple-system,sans-serif;">
-
-  <rect width="780" height="300" fill="#ffffff"/>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 300" font-family="IBM Plex Mono, monospace">
   <defs>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L0,6 L8,3 z" fill="#3d7ab5"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
-    <marker id="ar-back" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L0,6 L8,3 z" fill="#7eb3d8"/>
+    <marker id="aiG" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#6b6b6b" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
+    <marker id="aiB" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#9b4a3f" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
   </defs>
+  <rect width="780" height="300" fill="#fafaf8"/>
 
-  <!-- Title -->
-  <text x="390" y="28" text-anchor="middle" font-size="16" font-weight="600" fill="#1a1a1a">MCP Protocol Lifecycle</text>
-  <text x="390" y="48" text-anchor="middle" font-size="11" fill="#999">What happens when your agent connects to an MCP server</text>
+  <!-- Client -->
+  <rect x="40" y="44" width="170" height="202" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="125" y="70" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">YOUR AGENT</text>
+  <text x="125" y="88" text-anchor="middle" font-size="10.5" fill="#6b6b6b">the MCP client</text>
 
-  <!-- Client box -->
-  <rect x="40" y="80" width="160" height="180" rx="8" fill="#e8f0f7" stroke="#3d7ab5" stroke-width="1.5"/>
-  <text x="120" y="105" text-anchor="middle" font-size="13" font-weight="600" fill="#1a3a5c">Your Agent</text>
-  <text x="120" y="122" text-anchor="middle" font-size="9" fill="#6B7280">(MCP Client)</text>
+  <!-- Server -->
+  <rect x="570" y="44" width="170" height="202" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="655" y="70" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">MCP SERVER</text>
+  <text x="655" y="88" text-anchor="middle" font-size="10.5" fill="#6b6b6b">tools + data</text>
 
-  <!-- Server box -->
-  <rect x="580" y="80" width="160" height="180" rx="8" fill="#c5d5e4" stroke="#7eb3d8" stroke-width="1.5"/>
-  <text x="660" y="105" text-anchor="middle" font-size="13" font-weight="600" fill="#1a3a5c">MCP Server</text>
-  <text x="660" y="122" text-anchor="middle" font-size="9" fill="#6B7280">(Tools + Data)</text>
+  <!-- Step 1: initialize -->
+  <rect x="250" y="44" width="280" height="38" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="266" y="60" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">1 · INITIALIZE</text>
+  <text x="266" y="75" font-size="10" fill="#6b6b6b">handshake: versions + capabilities</text>
+  <line x1="214" y1="63" x2="246" y2="63" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <line x1="534" y1="63" x2="566" y2="63" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Step 1: Initialize -->
-  <rect x="260" y="72" width="260" height="36" rx="6" fill="#fff" stroke="#3d7ab5" stroke-width="1"/>
-  <circle cx="278" cy="90" r="11" fill="#3d7ab5"/>
-  <text x="278" y="94" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">1</text>
-  <text x="310" y="86" font-size="10" font-weight="600" fill="#1a3a5c">Initialize</text>
-  <text x="310" y="100" font-size="8.5" fill="#6B7280">Handshake: agree on capabilities</text>
-  <line x1="200" y1="90" x2="258" y2="90" stroke="#3d7ab5" stroke-width="1.5" marker-end="url(#ar)"/>
-  <line x1="522" y1="90" x2="580" y2="90" stroke="#3d7ab5" stroke-width="1.5" marker-end="url(#ar)"/>
+  <!-- Step 2: discover -->
+  <rect x="250" y="94" width="280" height="38" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="266" y="110" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">2 · DISCOVER</text>
+  <text x="266" y="125" font-size="10" fill="#6b6b6b">tools/list &#8594; names, schemas</text>
+  <line x1="214" y1="107" x2="246" y2="107" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <line x1="534" y1="107" x2="566" y2="107" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <line x1="566" y1="121" x2="534" y2="121" stroke="#6b6b6b" stroke-width="1.5" marker-end="url(#aiG)"/>
+  <line x1="246" y1="121" x2="214" y2="121" stroke="#6b6b6b" stroke-width="1.5" marker-end="url(#aiG)"/>
 
-  <!-- Step 2: Discover -->
-  <rect x="260" y="120" width="260" height="36" rx="6" fill="#fff" stroke="#3d7ab5" stroke-width="1"/>
-  <circle cx="278" cy="138" r="11" fill="#3d7ab5"/>
-  <text x="278" y="142" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">2</text>
-  <text x="310" y="134" font-size="10" font-weight="600" fill="#1a3a5c">Discover</text>
-  <text x="310" y="148" font-size="8.5" fill="#6B7280">Client calls tools/list, gets available tools</text>
-  <line x1="200" y1="133" x2="258" y2="133" stroke="#3d7ab5" stroke-width="1.2" marker-end="url(#ar)"/>
-  <line x1="580" y1="143" x2="522" y2="143" stroke="#7eb3d8" stroke-width="1.2" marker-end="url(#ar-back)"/>
+  <!-- Step 3: invoke -->
+  <rect x="250" y="144" width="280" height="38" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="266" y="160" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">3 · INVOKE</text>
+  <text x="266" y="175" font-size="10" fill="#6b6b6b">tools/call &#8594; tool runs, result returns</text>
+  <line x1="214" y1="157" x2="246" y2="157" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <line x1="534" y1="157" x2="566" y2="157" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <line x1="566" y1="171" x2="534" y2="171" stroke="#6b6b6b" stroke-width="1.5" marker-end="url(#aiG)"/>
+  <line x1="246" y1="171" x2="214" y2="171" stroke="#6b6b6b" stroke-width="1.5" marker-end="url(#aiG)"/>
 
-  <!-- Step 3: Invoke -->
-  <rect x="260" y="168" width="260" height="36" rx="6" fill="#fff" stroke="#3d7ab5" stroke-width="1"/>
-  <circle cx="278" cy="186" r="11" fill="#3d7ab5"/>
-  <text x="278" y="190" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">3</text>
-  <text x="310" y="182" font-size="10" font-weight="600" fill="#1a3a5c">Invoke</text>
-  <text x="310" y="196" font-size="8.5" fill="#6B7280">LLM picks a tool, client sends tools/call</text>
-  <line x1="200" y1="181" x2="258" y2="181" stroke="#3d7ab5" stroke-width="1.2" marker-end="url(#ar)"/>
-  <line x1="580" y1="191" x2="522" y2="191" stroke="#7eb3d8" stroke-width="1.2" marker-end="url(#ar-back)"/>
+  <!-- Step 4: loop (accent) -->
+  <rect x="250" y="194" width="280" height="38" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="266" y="210" font-size="11" letter-spacing="1" font-weight="500" fill="#9b4a3f">4 · LOOP</text>
+  <text x="266" y="225" font-size="10" fill="#1a1a1a">result &#8594; model &#8594; next call or answer</text>
 
-  <!-- Step 4: Repeat -->
-  <rect x="260" y="216" width="260" height="36" rx="6" fill="#fff" stroke="#3d7ab5" stroke-width="1"/>
-  <circle cx="278" cy="234" r="11" fill="#3d7ab5"/>
-  <text x="278" y="238" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">4</text>
-  <text x="310" y="230" font-size="10" font-weight="600" fill="#1a3a5c">Loop</text>
-  <text x="310" y="244" font-size="8.5" fill="#6B7280">Result goes back to LLM, which decides next step</text>
+  <!-- Loop-back path -->
+  <path d="M390,232 L390,266 L125,266 L125,250" fill="none" stroke="#9b4a3f" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#aiB)"/>
 
-  <!-- Loop arrow -->
-  <path d="M 390 252 L 390 270 L 180 270 L 180 175 L 200 175" fill="none" stroke="#3d7ab5" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#ar)"/>
-  <text x="280" y="283" text-anchor="middle" font-size="8.5" fill="#3d7ab5" font-style="italic">Agent loop continues until the LLM has enough info to answer</text>
-
+  <!-- Footnote -->
+  <text x="390" y="290" text-anchor="middle" font-size="11" fill="#6b6b6b">same agent loop as section 0c · only where the tools live has changed</text>
 </svg>

--- a/public/assets/diagrams/schema-validation.svg
+++ b/public/assets/diagrams/schema-validation.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660 320" font-family="IBM Plex Mono, monospace">
+  <defs>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="ab" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#9b4a3f" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
+  </defs>
+  <rect width="660" height="320" fill="#fafaf8"/>
+
+  <!-- The counterfactual -->
+  <text x="330" y="32" text-anchor="middle" font-size="11" fill="#6b6b6b">without the gate: a raw ValueError crashes the loop · the model learns nothing</text>
+
+  <!-- The model emits args -->
+  <rect x="28" y="104" width="130" height="64" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="93" y="130" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">THE MODEL</text>
+  <text x="93" y="150" text-anchor="middle" font-size="11" fill="#6b6b6b">emits args</text>
+
+  <text x="212" y="114" text-anchor="middle" font-size="11" fill="#6b6b6b">{"operation":</text>
+  <text x="212" y="128" text-anchor="middle" font-size="11" fill="#6b6b6b">"modulo", ...}</text>
+  <line x1="158" y1="136" x2="266" y2="136" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+
+  <!-- The gate -->
+  <rect x="270" y="84" width="120" height="104" rx="2" fill="none" stroke="#1a1a1a" stroke-width="2"/>
+  <text x="330" y="118" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">VALIDATION</text>
+  <text x="330" y="134" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">GATE</text>
+  <text x="330" y="158" text-anchor="middle" font-size="11" fill="#6b6b6b">schema check</text>
+
+  <!-- Valid path -->
+  <path d="M390,112 L450,112 L450,86 L466,86" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="420" y="104" text-anchor="middle" font-size="11" fill="#6b6b6b">valid</text>
+  <rect x="470" y="56" width="160" height="58" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="550" y="80" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">RUN THE FUNCTION</text>
+  <text x="550" y="100" text-anchor="middle" font-size="11" fill="#6b6b6b">normal execution</text>
+
+  <!-- Invalid path -->
+  <path d="M390,160 L428,160 L428,196 L444,196" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="416" y="152" text-anchor="middle" font-size="11" fill="#6b6b6b">invalid</text>
+  <rect x="448" y="164" width="196" height="92" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="546" y="186" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#9b4a3f">STRUCTURED ERROR</text>
+  <text x="460" y="208" font-size="11" fill="#1a1a1a">input should be 'add',</text>
+  <text x="460" y="224" font-size="11" fill="#1a1a1a">'subtract', 'multiply'</text>
+  <text x="460" y="240" font-size="11" fill="#1a1a1a">or 'divide'</text>
+
+  <!-- Feedback: the error goes back as the tool result -->
+  <path d="M546,256 C500,290 200,290 100,176" fill="none" stroke="#9b4a3f" stroke-width="1.5" marker-end="url(#ab)"/>
+  <text x="330" y="308" text-anchor="middle" font-size="11" fill="#9b4a3f">sent back as the tool result · the model corrects and retries</text>
+</svg>

--- a/public/assets/diagrams/single-turn-ceiling.svg
+++ b/public/assets/diagrams/single-turn-ceiling.svg
@@ -1,105 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="720" height="300" viewBox="0 0 720 300" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 300" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
-    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
-    <marker id="arr-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#22c55e"/>
-    </marker>
-    <marker id="arr-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#EF4444"/>
-    </marker>
+    <pattern id="hatchBrickDense" width="5" height="5" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="5" stroke="#9b4a3f" stroke-width="1.2" opacity="0.5"/>
+    </pattern>
   </defs>
+  <rect width="720" height="300" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="720" height="300" fill="#ffffff"/>
+  <!-- One pass, four stations -->
+  <rect x="24" y="72" width="110" height="58" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="79" y="96" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">QUERY</text>
+  <text x="79" y="114" text-anchor="middle" font-size="11" fill="#6b6b6b">one request</text>
 
-  <!-- Title -->
-  <text x="360" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">The Single-Turn Ceiling</text>
-  <line x1="40" y1="42" x2="680" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <line x1="134" y1="101" x2="158" y2="101" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Subtitle -->
-  <text x="360" y="62" text-anchor="middle" font-size="12" fill="#6B7280">Tool-using LLM calls are powerful. But they hit a hard limit: one turn, one result, no iteration.</text>
+  <rect x="162" y="72" width="110" height="58" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="217" y="96" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">MODEL</text>
+  <text x="217" y="114" text-anchor="middle" font-size="11" fill="#6b6b6b">picks a tool</text>
 
-  <!-- Flow: left to right -->
-  <!-- Step 1: User Query -->
-  <rect x="30" y="90" width="110" height="60" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
-  <text x="85" y="115" text-anchor="middle" font-size="12" font-weight="bold" fill="#1D4ED8">User Query</text>
-  <text x="85" y="132" text-anchor="middle" font-size="10" fill="#6B7280">"Research and</text>
-  <text x="85" y="144" text-anchor="middle" font-size="10" fill="#6B7280">summarize X"</text>
+  <line x1="272" y1="101" x2="296" y2="101" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Arrow -->
-  <line x1="141" y1="120" x2="168" y2="120" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="300" y="72" width="110" height="58" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="355" y="96" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">TOOL RUNS</text>
+  <text x="355" y="114" text-anchor="middle" font-size="11" fill="#6b6b6b">search(...)</text>
 
-  <!-- Step 2: Model -->
-  <rect x="170" y="90" width="100" height="60" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
-  <text x="220" y="118" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400E">Model</text>
-  <text x="220" y="135" text-anchor="middle" font-size="10" fill="#6B7280">picks a tool</text>
-  <text x="220" y="148" text-anchor="middle" font-size="10" fill="#6B7280">to call</text>
+  <line x1="410" y1="101" x2="434" y2="101" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Arrow -->
-  <line x1="271" y1="120" x2="298" y2="120" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="438" y="72" width="110" height="58" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="493" y="96" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">RESULT</text>
+  <text x="493" y="114" text-anchor="middle" font-size="11" fill="#6b6b6b">returned once</text>
 
-  <!-- Step 3: Tool Call -->
-  <rect x="300" y="90" width="100" height="60" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-  <text x="350" y="118" text-anchor="middle" font-size="12" font-weight="bold" fill="#5B21B6">Tool Call</text>
-  <text x="350" y="135" text-anchor="middle" font-size="10" fill="#6B7280">search()</text>
-  <text x="350" y="148" text-anchor="middle" font-size="10" fill="#6B7280">executed</text>
+  <line x1="548" y1="101" x2="564" y2="101" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Arrow -->
-  <line x1="401" y1="120" x2="428" y2="120" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- The ceiling -->
+  <rect x="568" y="42" width="18" height="160" fill="url(#hatchBrickDense)" stroke="#9b4a3f" stroke-width="1.5"/>
+  <text x="600" y="122" font-size="11" letter-spacing="1.5" font-weight="500" fill="#9b4a3f" transform="rotate(-90,600,122)" text-anchor="middle">CAN'T ITERATE</text>
 
-  <!-- Step 4: Result -->
-  <rect x="430" y="90" width="100" height="60" rx="8" fill="#F0FDF4" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="480" y="118" text-anchor="middle" font-size="12" font-weight="bold" fill="#15803D">Result</text>
-  <text x="480" y="135" text-anchor="middle" font-size="10" fill="#6B7280">returned to</text>
-  <text x="480" y="148" text-anchor="middle" font-size="10" fill="#6B7280">model once</text>
+  <!-- What's blocked -->
+  <rect x="614" y="72" width="96" height="58" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="662" y="92" text-anchor="middle" font-size="11" fill="#6b6b6b">another</text>
+  <text x="662" y="106" text-anchor="middle" font-size="11" fill="#6b6b6b">search?</text>
+  <text x="662" y="120" text-anchor="middle" font-size="11" fill="#6b6b6b">retry?</text>
+  <line x1="618" y1="76" x2="706" y2="126" stroke="#6b6b6b" stroke-width="1" opacity="0.6"/>
+  <line x1="706" y1="76" x2="618" y2="126" stroke="#6b6b6b" stroke-width="1" opacity="0.6"/>
 
-  <!-- Arrow pointing to wall -->
-  <line x1="531" y1="120" x2="556" y2="120" stroke="#EF4444" stroke-width="1.5" marker-end="url(#arr-red)"/>
+  <!-- Stage names -->
+  <text x="79" y="156" text-anchor="middle" font-size="11" fill="#6b6b6b">input</text>
+  <text x="217" y="156" text-anchor="middle" font-size="11" fill="#6b6b6b">reason</text>
+  <text x="355" y="156" text-anchor="middle" font-size="11" fill="#6b6b6b">act</text>
+  <text x="493" y="156" text-anchor="middle" font-size="11" fill="#6b6b6b">observe</text>
 
-  <!-- THE WALL -->
-  <rect x="558" y="72" width="18" height="114" rx="2" fill="#EF4444" opacity="0.85"/>
-  <!-- Wall hatch marks -->
-  <line x1="558" y1="82" x2="576" y2="96" stroke="#B91C1C" stroke-width="1.5"/>
-  <line x1="558" y1="100" x2="576" y2="114" stroke="#B91C1C" stroke-width="1.5"/>
-  <line x1="558" y1="118" x2="576" y2="132" stroke="#B91C1C" stroke-width="1.5"/>
-  <line x1="558" y1="136" x2="576" y2="150" stroke="#B91C1C" stroke-width="1.5"/>
-  <line x1="558" y1="154" x2="576" y2="168" stroke="#B91C1C" stroke-width="1.5"/>
-
-  <!-- Wall label -->
-  <text x="567" y="198" text-anchor="middle" font-size="10" font-weight="bold" fill="#B91C1C" transform="rotate(90, 567, 198)">CAN'T ITERATE</text>
-
-  <!-- What's blocked (faded, past the wall) -->
-  <rect x="590" y="90" width="100" height="60" rx="8" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.5"/>
-  <text x="640" y="115" text-anchor="middle" font-size="11" fill="#9CA3AF" opacity="0.6">Another</text>
-  <text x="640" y="130" text-anchor="middle" font-size="11" fill="#9CA3AF" opacity="0.6">search?</text>
-  <text x="640" y="145" text-anchor="middle" font-size="11" fill="#9CA3AF" opacity="0.6">Retry?</text>
-  <!-- X through blocked box -->
-  <line x1="592" y1="92" x2="688" y2="148" stroke="#EF4444" stroke-width="2" opacity="0.5"/>
-  <line x1="688" y1="92" x2="592" y2="148" stroke="#EF4444" stroke-width="2" opacity="0.5"/>
-
-  <!-- Arrow pointing right past wall (agents start here) -->
-  <path d="M680,120 L700,120" stroke="#22c55e" stroke-width="2" stroke-dasharray="3,2"/>
-
-  <!-- Arrow from bottom of flow pointing forward -->
-  <text x="640" y="168" text-anchor="middle" font-size="11" font-weight="bold" fill="#22c55e">Agents start here</text>
-  <line x1="580" y1="176" x2="700" y2="176" stroke="#22c55e" stroke-width="2" marker-end="url(#arr-green)"/>
-  <text x="640" y="196" text-anchor="middle" font-size="10" fill="#15803D">loop · retry · branch · decide</text>
-
-  <!-- Labels below flow -->
-  <text x="85" y="168" text-anchor="middle" font-size="10" fill="#6B7280">input</text>
-  <text x="220" y="168" text-anchor="middle" font-size="10" fill="#6B7280">reason</text>
-  <text x="350" y="168" text-anchor="middle" font-size="10" fill="#6B7280">act</text>
-  <text x="480" y="168" text-anchor="middle" font-size="10" fill="#6B7280">observe</text>
-
-  <!-- What single-turn can't do -->
-  <rect x="30" y="220" width="500" height="58" rx="6" fill="#FEF2F2" stroke="#FCA5A5" stroke-width="1"/>
-  <text x="40" y="240" font-size="11" font-weight="bold" fill="#B91C1C">Single-turn tool use cannot:</text>
-  <text x="40" y="258" font-size="11" fill="#374151">  - Search, read results, decide to search again with a refined query</text>
-  <text x="40" y="272" font-size="11" fill="#374151">  - Handle errors by retrying with different parameters</text>
-
-  <!-- Caption -->
-  <text x="360" y="292" text-anchor="middle" font-size="11" fill="#9CA3AF">Iteration is the core capability agents add. Everything else follows from that.</text>
+  <!-- Where agents pick up -->
+  <text x="493" y="228" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">AGENTS START HERE</text>
+  <path d="M577,202 L577,244 L692,244" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="493" y="266" font-size="11" fill="#6b6b6b">observe · think · act · repeat</text>
 </svg>

--- a/public/assets/diagrams/three-failure-modes.svg
+++ b/public/assets/diagrams/three-failure-modes.svg
@@ -1,83 +1,62 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 360" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
   </defs>
+  <rect width="720" height="360" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="720" height="360" fill="#ffffff"/>
+  <!-- Panel 1: infinite loop -->
+  <rect x="30" y="40" width="210" height="272" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="135" y="66" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">1 · INFINITE LOOP</text>
+  <line x1="48" y1="78" x2="222" y2="78" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Title -->
-  <text x="360" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Three Failure Modes Every Agent Engineer Faces</text>
-  <line x1="40" y1="42" x2="680" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="135" y="102" text-anchor="middle" font-size="11" fill="#6b6b6b">"everything about AI"</text>
+  <text x="135" y="130" text-anchor="middle" font-size="11" fill="#1a1a1a">search("AI history")</text>
+  <text x="135" y="150" text-anchor="middle" font-size="11" fill="#1a1a1a">search("AI future")</text>
+  <text x="135" y="170" text-anchor="middle" font-size="11" fill="#1a1a1a">search("AI ethics")</text>
 
-  <!-- ====== PANEL 1: Infinite Loop ====== -->
-  <rect x="30" y="58" width="206" height="264" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
-  <text x="133" y="82" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Infinite Loop</text>
-  <line x1="50" y1="90" x2="216" y2="90" stroke="#FCA5A5" stroke-width="1"/>
+  <rect x="55" y="188" width="160" height="30" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="135" y="208" text-anchor="middle" font-size="11" font-weight="500" fill="#1a1a1a">budget 3/3 exhausted</text>
 
-  <!-- Circular spinning arrows (conceptual) -->
-  <circle cx="133" cy="170" r="50" fill="none" stroke="#EF4444" stroke-width="3" stroke-dasharray="10,5"/>
-  <!-- Arrow on circle -->
-  <path d="M133,120 A50,50 0 1,1 83,170" fill="none" stroke="#EF4444" stroke-width="3"/>
-  <polygon points="78,162 83,175 93,167" fill="#EF4444"/>
-  <!-- Inner text -->
-  <text x="133" y="165" text-anchor="middle" font-size="11" font-weight="bold" fill="#B91C1C">search →</text>
-  <text x="133" y="180" text-anchor="middle" font-size="11" fill="#B91C1C">read →</text>
-  <text x="133" y="195" text-anchor="middle" font-size="11" fill="#B91C1C">search →</text>
+  <text x="135" y="248" text-anchor="middle" font-size="11" fill="#1a1a1a">answer: none</text>
+  <text x="135" y="292" text-anchor="middle" font-size="10.5" letter-spacing="1" fill="#6b6b6b">LOUD · IN THE TRACE</text>
 
-  <!-- Budget counter -->
-  <rect x="60" y="238" width="148" height="28" rx="6" fill="#FEE2E2" stroke="#EF4444" stroke-width="1.5"/>
-  <text x="134" y="257" text-anchor="middle" font-size="12" font-weight="bold" fill="#B91C1C">Budget: 5/5 exhausted</text>
+  <!-- Panel 2: hallucinated tool -->
+  <rect x="255" y="40" width="210" height="272" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="360" y="66" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">2 · HALLUCINATED TOOL</text>
+  <line x1="273" y1="78" x2="447" y2="78" stroke="#e8e8e8" stroke-width="1"/>
 
-  <text x="133" y="290" text-anchor="middle" font-size="11" fill="#374151">Agent never decides</text>
-  <text x="133" y="306" text-anchor="middle" font-size="11" fill="#374151">it has enough info.</text>
-  <text x="133" y="323" text-anchor="middle" font-size="10" fill="#9CA3AF">Fix: hard step limit</text>
-  <text x="133" y="337" text-anchor="middle" font-size="10" fill="#22c55e">in your orchestration code</text>
+  <text x="360" y="102" text-anchor="middle" font-size="11" fill="#6b6b6b">"weather in London?"</text>
+  <text x="360" y="128" text-anchor="middle" font-size="11" fill="#1a1a1a">weather("London")</text>
+  <line x1="360" y1="136" x2="360" y2="150" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- ====== PANEL 2: Hallucinated Tool ====== -->
-  <rect x="257" y="58" width="206" height="264" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
-  <text x="360" y="82" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Hallucinated Tool</text>
-  <line x1="277" y1="90" x2="443" y2="90" stroke="#FCA5A5" stroke-width="1"/>
+  <rect x="275" y="156" width="170" height="44" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="360" y="174" text-anchor="middle" font-size="11" fill="#1a1a1a">"Error: unknown</text>
+  <text x="360" y="190" text-anchor="middle" font-size="11" fill="#1a1a1a">tool 'weather'"</text>
+  <line x1="360" y1="204" x2="360" y2="218" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Speech bubble with fake tool call -->
-  <rect x="284" y="104" width="152" height="72" rx="8" fill="#FEE2E2" stroke="#EF4444" stroke-width="1.5"/>
-  <!-- Speech bubble tail -->
-  <polygon points="330,176 344,190 358,176" fill="#FEE2E2"/>
-  <text x="360" y="128" text-anchor="middle" font-size="11" font-weight="bold" fill="#B91C1C">Model says:</text>
-  <text x="360" y="145" text-anchor="middle" font-size="11" fill="#374151">call:</text>
-  <text x="360" y="161" text-anchor="middle" font-size="11" font-weight="bold" fill="#5B21B6">analyze_sentiment()</text>
+  <text x="360" y="238" text-anchor="middle" font-size="11" fill="#1a1a1a">model reads the error,</text>
+  <text x="360" y="254" text-anchor="middle" font-size="11" fill="#1a1a1a">answers: "no weather</text>
+  <text x="360" y="270" text-anchor="middle" font-size="11" fill="#1a1a1a">tool available"</text>
+  <text x="360" y="292" text-anchor="middle" font-size="10.5" letter-spacing="1" fill="#6b6b6b">LOUD · SELF-CORRECTS</text>
 
-  <!-- Red X below -->
-  <circle cx="360" cy="216" r="22" fill="#FEE2E2" stroke="#EF4444" stroke-width="2"/>
-  <line x1="346" y1="202" x2="374" y2="230" stroke="#EF4444" stroke-width="3" stroke-linecap="round"/>
-  <line x1="374" y1="202" x2="346" y2="230" stroke="#EF4444" stroke-width="3" stroke-linecap="round"/>
+  <!-- Panel 3: confident wrong answer (accent) -->
+  <rect x="480" y="40" width="210" height="272" rx="2" fill="none" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="585" y="66" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#9b4a3f">3 · CONFIDENT WRONG ANSWER</text>
+  <line x1="498" y1="78" x2="672" y2="78" stroke="#e8e8e8" stroke-width="1"/>
 
-  <text x="360" y="256" text-anchor="middle" font-size="11" fill="#374151">Tool doesn't exist.</text>
-  <text x="360" y="272" text-anchor="middle" font-size="11" fill="#374151">Runtime error.</text>
-  <text x="360" y="290" text-anchor="middle" font-size="11" fill="#374151">Agent halts.</text>
-  <text x="360" y="310" text-anchor="middle" font-size="10" fill="#9CA3AF">Fix: strict tool schema</text>
-  <text x="360" y="325" text-anchor="middle" font-size="10" fill="#22c55e">validation before dispatch</text>
+  <text x="585" y="102" text-anchor="middle" font-size="11" fill="#6b6b6b">"largest city in AU?"</text>
+  <text x="585" y="132" text-anchor="middle" font-size="11" fill="#1a1a1a">no tool call · one step</text>
 
-  <!-- ====== PANEL 3: Confident Wrong Answer ====== -->
-  <rect x="484" y="58" width="206" height="264" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
-  <text x="587" y="82" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Confident Wrong Answer</text>
-  <line x1="504" y1="90" x2="670" y2="90" stroke="#FCA5A5" stroke-width="1"/>
+  <rect x="500" y="150" width="170" height="30" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="585" y="170" text-anchor="middle" font-size="11" fill="#1a1a1a">"Sydney, 5.3 million"</text>
 
-  <!-- Checkmark on red background - looks right but isn't -->
-  <rect x="537" y="108" width="100" height="100" rx="10" fill="#DC2626"/>
-  <!-- Big green checkmark over red -->
-  <circle cx="587" cy="158" r="36" fill="#22c55e" opacity="0.9"/>
-  <polyline points="568,158 582,172 610,144" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="585" y="212" text-anchor="middle" font-size="11" fill="#1a1a1a">never checked · answered</text>
+  <text x="585" y="228" text-anchor="middle" font-size="11" fill="#1a1a1a">from training data</text>
+  <text x="585" y="256" text-anchor="middle" font-size="11" font-weight="500" fill="#9b4a3f">every metric says success</text>
+  <text x="585" y="292" text-anchor="middle" font-size="10.5" letter-spacing="1" font-weight="500" fill="#9b4a3f">SILENT · EVALS ONLY</text>
 
-  <!-- Ironically wrong -->
-  <text x="587" y="230" text-anchor="middle" font-size="11" fill="#374151">Model returns answer</text>
-  <text x="587" y="247" text-anchor="middle" font-size="11" fill="#374151">with full confidence.</text>
-  <text x="587" y="264" text-anchor="middle" font-size="12" font-weight="bold" fill="#B91C1C">It is wrong.</text>
-  <text x="587" y="282" text-anchor="middle" font-size="11" fill="#374151">No error raised.</text>
-  <text x="587" y="300" text-anchor="middle" font-size="10" fill="#9CA3AF">Fix: output validation,</text>
-  <text x="587" y="315" text-anchor="middle" font-size="10" fill="#22c55e">evals, human review</text>
-
-  <!-- Caption -->
-  <text x="360" y="345" text-anchor="middle" font-size="11" fill="#374151">These three failure modes account for most agent production incidents. Build for all three.</text>
-  <text x="360" y="358" text-anchor="middle" font-size="11" fill="#9CA3AF">Step limits · schema validation · output verification</text>
+  <!-- Footnote -->
+  <text x="360" y="344" text-anchor="middle" font-size="11" fill="#6b6b6b">the loud failures show up in the trace · the silent one needs ground truth (ch. 6)</text>
 </svg>

--- a/public/assets/diagrams/three-way-comparison.svg
+++ b/public/assets/diagrams/three-way-comparison.svg
@@ -59,7 +59,7 @@
   <text x="504" y="232" font-size="11" fill="#1a1a1a">LangSmith · separate</text>
 
   <text x="504" y="260" font-size="10" letter-spacing="1" fill="#6b6b6b">LOCK-IN</text>
-  <text x="504" y="278" font-size="11" fill="#1a1a1a">LangChain abstractions</text>
+  <text x="504" y="278" font-size="11" fill="#1a1a1a">LangChain ecosystem</text>
 
   <text x="504" y="306" font-size="10" letter-spacing="1" fill="#6b6b6b">BEST FOR</text>
   <text x="504" y="324" font-size="11" fill="#1a1a1a">prototyping · integrations</text>

--- a/public/assets/diagrams/three-way-comparison.svg
+++ b/public/assets/diagrams/three-way-comparison.svg
@@ -1,91 +1,69 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="720" height="380" viewBox="0 0 720 380" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
-  <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 380" font-family="IBM Plex Mono, monospace">
+  <rect width="720" height="380" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="720" height="380" fill="#ffffff"/>
+  <!-- Card 1: raw python -->
+  <rect x="30" y="40" width="210" height="300" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="135" y="66" text-anchor="middle" font-size="12" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">RAW PYTHON</text>
+  <text x="135" y="84" text-anchor="middle" font-size="11" fill="#6b6b6b">direct API calls</text>
+  <line x1="48" y1="96" x2="222" y2="96" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Title -->
-  <text x="360" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Framework Comparison: Raw vs. ADK vs. LangChain</text>
-  <line x1="40" y1="42" x2="680" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="54" y="122" font-size="10" letter-spacing="1" fill="#6b6b6b">LINES OF CODE</text>
+  <text x="54" y="140" font-size="11" font-weight="500" fill="#1a1a1a">~100</text>
 
-  <!-- ====== CARD 1: Raw Python ====== -->
-  <rect x="30" y="58" width="200" height="288" rx="10" fill="#F9FAFB" stroke="#6B7280" stroke-width="2"/>
-  <!-- Header -->
-  <rect x="30" y="58" width="200" height="52" rx="10" fill="#374151"/>
-  <rect x="30" y="90" width="200" height="20" fill="#374151"/>
-  <text x="130" y="84" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">Raw Python</text>
-  <text x="130" y="100" text-anchor="middle" font-size="11" fill="#9CA3AF">Direct API calls</text>
+  <text x="54" y="168" font-size="10" letter-spacing="1" font-weight="500" fill="#9b4a3f">DEBUG A FAILURE</text>
+  <text x="54" y="186" font-size="11" font-weight="500" fill="#1a1a1a">read your code</text>
 
-  <!-- Metrics -->
-  <text x="48" y="132" font-size="11" font-weight="bold" fill="#6B7280">CODE VOLUME</text>
-  <rect x="46" y="140" width="168" height="32" rx="4" fill="#ffffff" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="130" y="162" text-anchor="middle" font-size="15" font-weight="bold" fill="#374151">~100 lines</text>
+  <text x="54" y="214" font-size="10" letter-spacing="1" fill="#6b6b6b">EVAL INTEGRATION</text>
+  <text x="54" y="232" font-size="11" fill="#1a1a1a">build it yourself</text>
 
-  <text x="48" y="192" font-size="11" font-weight="bold" fill="#6B7280">DEBUGGABILITY</text>
-  <rect x="46" y="200" width="168" height="32" rx="4" fill="#DCFCE7" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="130" y="222" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">High</text>
+  <text x="54" y="260" font-size="10" letter-spacing="1" fill="#6b6b6b">LOCK-IN</text>
+  <text x="54" y="278" font-size="11" fill="#1a1a1a">none</text>
 
-  <text x="48" y="252" font-size="11" font-weight="bold" fill="#6B7280">VENDOR LOCK-IN</text>
-  <rect x="46" y="260" width="168" height="32" rx="4" fill="#DCFCE7" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="130" y="282" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">None</text>
+  <text x="54" y="306" font-size="10" letter-spacing="1" fill="#6b6b6b">BEST FOR</text>
+  <text x="54" y="324" font-size="11" fill="#1a1a1a">learning · unusual needs</text>
 
-  <text x="48" y="312" font-size="11" font-weight="bold" fill="#6B7280">BUILT-IN TRACING</text>
-  <rect x="46" y="320" width="168" height="20" rx="4" fill="#FEE2E2" stroke="#EF4444" stroke-width="1"/>
-  <text x="130" y="335" text-anchor="middle" font-size="12" fill="#B91C1C">You build it yourself</text>
+  <!-- Card 2: google adk -->
+  <rect x="255" y="40" width="210" height="300" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="360" y="66" text-anchor="middle" font-size="12" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">GOOGLE ADK</text>
+  <text x="360" y="84" text-anchor="middle" font-size="11" fill="#6b6b6b">structured, traced</text>
+  <line x1="273" y1="96" x2="447" y2="96" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- ====== CARD 2: ADK ====== -->
-  <rect x="260" y="58" width="200" height="288" rx="10" fill="#F9FAFB" stroke="#3B82F6" stroke-width="2"/>
-  <!-- Header -->
-  <rect x="260" y="58" width="200" height="52" rx="10" fill="#1D4ED8"/>
-  <rect x="260" y="90" width="200" height="20" fill="#1D4ED8"/>
-  <text x="360" y="84" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">Google ADK</text>
-  <text x="360" y="100" text-anchor="middle" font-size="11" fill="#BFDBFE">Structured agent framework</text>
+  <text x="279" y="122" font-size="10" letter-spacing="1" fill="#6b6b6b">LINES OF CODE</text>
+  <text x="279" y="140" font-size="11" font-weight="500" fill="#1a1a1a">~40</text>
 
-  <!-- Metrics -->
-  <text x="278" y="132" font-size="11" font-weight="bold" fill="#6B7280">CODE VOLUME</text>
-  <rect x="276" y="140" width="168" height="32" rx="4" fill="#ffffff" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="360" y="162" text-anchor="middle" font-size="15" font-weight="bold" fill="#374151">~40 lines</text>
+  <text x="279" y="168" font-size="10" letter-spacing="1" font-weight="500" fill="#9b4a3f">DEBUG A FAILURE</text>
+  <text x="279" y="186" font-size="11" font-weight="500" fill="#1a1a1a">read traces</text>
 
-  <text x="278" y="192" font-size="11" font-weight="bold" fill="#6B7280">DEBUGGABILITY</text>
-  <rect x="276" y="200" width="168" height="32" rx="4" fill="#FEF9C3" stroke="#F59E0B" stroke-width="1.5"/>
-  <text x="360" y="222" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Medium</text>
+  <text x="279" y="214" font-size="10" letter-spacing="1" fill="#6b6b6b">EVAL INTEGRATION</text>
+  <text x="279" y="232" font-size="11" fill="#1a1a1a">built in</text>
 
-  <text x="278" y="252" font-size="11" font-weight="bold" fill="#6B7280">VENDOR LOCK-IN</text>
-  <rect x="276" y="260" width="168" height="32" rx="4" fill="#FEF9C3" stroke="#F59E0B" stroke-width="1.5"/>
-  <text x="360" y="282" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">Google ecosystem</text>
+  <text x="279" y="260" font-size="10" letter-spacing="1" fill="#6b6b6b">LOCK-IN</text>
+  <text x="279" y="278" font-size="11" fill="#1a1a1a">Google ecosystem</text>
 
-  <text x="278" y="312" font-size="11" font-weight="bold" fill="#6B7280">BUILT-IN TRACING</text>
-  <rect x="276" y="320" width="168" height="20" rx="4" fill="#DCFCE7" stroke="#22c55e" stroke-width="1"/>
-  <text x="360" y="335" text-anchor="middle" font-size="12" fill="#15803D">Yes — full traces + evals</text>
+  <text x="279" y="306" font-size="10" letter-spacing="1" fill="#6b6b6b">BEST FOR</text>
+  <text x="279" y="324" font-size="11" fill="#1a1a1a">production · tracing</text>
 
-  <!-- ====== CARD 3: LangChain ====== -->
-  <rect x="490" y="58" width="200" height="288" rx="10" fill="#F9FAFB" stroke="#8B5CF6" stroke-width="2"/>
-  <!-- Header -->
-  <rect x="490" y="58" width="200" height="52" rx="10" fill="#5B21B6"/>
-  <rect x="490" y="90" width="200" height="20" fill="#5B21B6"/>
-  <text x="590" y="84" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">LangChain</text>
-  <text x="590" y="100" text-anchor="middle" font-size="11" fill="#DDD6FE">Ecosystem framework</text>
+  <!-- Card 3: langchain -->
+  <rect x="480" y="40" width="210" height="300" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="585" y="66" text-anchor="middle" font-size="12" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">LANGCHAIN</text>
+  <text x="585" y="84" text-anchor="middle" font-size="11" fill="#6b6b6b">largest ecosystem</text>
+  <line x1="498" y1="96" x2="672" y2="96" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Metrics -->
-  <text x="508" y="132" font-size="11" font-weight="bold" fill="#6B7280">CODE VOLUME</text>
-  <rect x="506" y="140" width="168" height="32" rx="4" fill="#ffffff" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="590" y="162" text-anchor="middle" font-size="15" font-weight="bold" fill="#374151">~35 lines</text>
+  <text x="504" y="122" font-size="10" letter-spacing="1" fill="#6b6b6b">LINES OF CODE</text>
+  <text x="504" y="140" font-size="11" font-weight="500" fill="#1a1a1a">~35</text>
 
-  <text x="508" y="192" font-size="11" font-weight="bold" fill="#6B7280">DEBUGGABILITY</text>
-  <rect x="506" y="200" width="168" height="32" rx="4" fill="#FEE2E2" stroke="#EF4444" stroke-width="1.5"/>
-  <text x="590" y="222" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Low</text>
+  <text x="504" y="168" font-size="10" letter-spacing="1" font-weight="500" fill="#9b4a3f">DEBUG A FAILURE</text>
+  <text x="504" y="186" font-size="11" font-weight="500" fill="#1a1a1a">read chains + source</text>
 
-  <text x="508" y="252" font-size="11" font-weight="bold" fill="#6B7280">VENDOR LOCK-IN</text>
-  <rect x="506" y="260" width="168" height="32" rx="4" fill="#FEF9C3" stroke="#F59E0B" stroke-width="1.5"/>
-  <text x="590" y="282" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">LangChain abstractions</text>
+  <text x="504" y="214" font-size="10" letter-spacing="1" fill="#6b6b6b">EVAL INTEGRATION</text>
+  <text x="504" y="232" font-size="11" fill="#1a1a1a">LangSmith · separate</text>
 
-  <text x="508" y="312" font-size="11" font-weight="bold" fill="#6B7280">BUILT-IN TRACING</text>
-  <rect x="506" y="320" width="168" height="20" rx="4" fill="#DCFCE7" stroke="#22c55e" stroke-width="1"/>
-  <text x="590" y="335" text-anchor="middle" font-size="12" fill="#15803D">LangSmith (separate)</text>
+  <text x="504" y="260" font-size="10" letter-spacing="1" fill="#6b6b6b">LOCK-IN</text>
+  <text x="504" y="278" font-size="11" fill="#1a1a1a">LangChain abstractions</text>
 
-  <!-- Caption -->
-  <text x="360" y="364" text-anchor="middle" font-size="11" fill="#374151">Fewer lines of code is not the goal. Fewer lines of code you understand is better than fewer total lines.</text>
-  <text x="360" y="378" text-anchor="middle" font-size="11" fill="#9CA3AF">Optimize for debuggability, not brevity.</text>
+  <text x="504" y="306" font-size="10" letter-spacing="1" fill="#6b6b6b">BEST FOR</text>
+  <text x="504" y="324" font-size="11" fill="#1a1a1a">prototyping · integrations</text>
+
+  <!-- Footnote -->
+  <text x="360" y="368" text-anchor="middle" font-size="11" fill="#6b6b6b">same tools, same prompt, same failure modes · optimize for debuggability, not brevity</text>
 </svg>

--- a/public/assets/diagrams/token-cost-calculator.svg
+++ b/public/assets/diagrams/token-cost-calculator.svg
@@ -1,70 +1,46 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="620" height="400" viewBox="0 0 620 400" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 400" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
-    <marker id="arr-down" markerWidth="7" markerHeight="10" refX="3.5" refY="9" orient="auto">
-      <polygon points="0 0, 3.5 10, 7 0" fill="#9CA3AF"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.22"/>
+    </pattern>
   </defs>
+  <rect width="620" height="400" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="620" height="400" fill="#ffffff"/>
+  <!-- Section: one call -->
+  <text x="40" y="42" font-size="11" letter-spacing="2" font-weight="500" fill="#6b6b6b">ONE CALL</text>
+  <text x="580" y="42" text-anchor="end" font-size="11" fill="#6b6b6b">illustrative rates: $3 in / $15 out per 1M tk</text>
 
-  <!-- Title -->
-  <text x="310" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Token Cost: From One Call to Production Scale</text>
-  <line x1="40" y1="42" x2="580" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="40" y="80" font-size="12" fill="#1a1a1a">prompt (input)</text>
+  <text x="262" y="80" text-anchor="end" font-size="11" fill="#6b6b6b">1,000 tk</text>
+  <rect x="280" y="66" width="80" height="18" fill="#e8e8e8" stroke="#6b6b6b" stroke-width="1"/>
+  <text x="580" y="80" text-anchor="end" font-size="12" fill="#1a1a1a">$0.0030</text>
 
-  <!-- Section header: Single Call -->
-  <text x="60" y="68" font-size="12" font-weight="bold" fill="#6B7280">SINGLE API CALL</text>
+  <text x="40" y="114" font-size="12" fill="#1a1a1a">completion (output)</text>
+  <text x="262" y="114" text-anchor="end" font-size="11" fill="#6b6b6b">500 tk</text>
+  <rect x="280" y="100" width="200" height="18" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="1.5"/>
+  <text x="580" y="114" text-anchor="end" font-size="12" font-weight="500" fill="#9b4a3f">$0.0075</text>
 
-  <!-- Table header -->
-  <rect x="40" y="74" width="540" height="28" rx="4" fill="#F3F4F6"/>
-  <text x="80" y="93" font-size="11" font-weight="bold" fill="#374151">Component</text>
-  <text x="290" y="93" text-anchor="middle" font-size="11" font-weight="bold" fill="#374151">Tokens</text>
-  <text x="440" y="93" text-anchor="middle" font-size="11" font-weight="bold" fill="#374151">Cost (GPT-4o est.)</text>
+  <text x="280" y="142" font-size="11" fill="#6b6b6b">half the tokens · 2.5x the cost</text>
 
-  <!-- Row 1: Prompt -->
-  <rect x="40" y="102" width="540" height="36" rx="0" fill="#EFF6FF"/>
-  <line x1="40" y1="138" x2="580" y2="138" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="80" y="126" font-size="13" fill="#374151">Prompt (input)</text>
-  <text x="290" y="126" text-anchor="middle" font-size="13" fill="#374151">1,200</text>
-  <text x="440" y="126" text-anchor="middle" font-size="13" font-weight="bold" fill="#3B82F6">$0.003</text>
+  <line x1="40" y1="158" x2="580" y2="158" stroke="#e8e8e8" stroke-width="1"/>
+  <text x="40" y="182" font-size="12" font-weight="500" fill="#1a1a1a">total per call</text>
+  <text x="580" y="182" text-anchor="end" font-size="12" font-weight="500" fill="#1a1a1a">~ $0.0105</text>
 
-  <!-- Row 2: Completion -->
-  <rect x="40" y="138" width="540" height="36" rx="0" fill="#ffffff"/>
-  <line x1="40" y1="174" x2="580" y2="174" stroke="#E5E7EB" stroke-width="1"/>
-  <text x="80" y="162" font-size="13" fill="#374151">Completion (output)</text>
-  <text x="290" y="162" text-anchor="middle" font-size="13" fill="#374151">400</text>
-  <text x="440" y="162" text-anchor="middle" font-size="13" font-weight="bold" fill="#3B82F6">$0.004</text>
+  <!-- Arrow to scale section -->
+  <line x1="310" y1="200" x2="310" y2="228" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Total per call row -->
-  <rect x="40" y="174" width="540" height="36" rx="0" fill="#F0FDF4"/>
-  <line x1="40" y1="210" x2="580" y2="210" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="80" y="198" font-size="13" font-weight="bold" fill="#15803D">Total per call</text>
-  <text x="290" y="198" text-anchor="middle" font-size="13" font-weight="bold" fill="#374151">1,600</text>
-  <text x="440" y="198" text-anchor="middle" font-size="15" font-weight="bold" fill="#15803D">$0.007</text>
+  <!-- Section: production volume -->
+  <text x="40" y="256" font-size="11" letter-spacing="2" font-weight="500" fill="#6b6b6b">AT PRODUCTION VOLUME</text>
 
-  <!-- Border around table -->
-  <rect x="40" y="74" width="540" height="136" rx="4" fill="none" stroke="#D1D5DB" stroke-width="1.5"/>
+  <text x="40" y="290" font-size="12" fill="#1a1a1a">x 5 model calls per request</text>
+  <text x="580" y="290" text-anchor="end" font-size="12" fill="#1a1a1a">$0.05 / request</text>
 
-  <!-- Arrow down -->
-  <line x1="310" y1="216" x2="310" y2="234" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arr-down)"/>
+  <text x="40" y="328" font-size="12" fill="#1a1a1a">x 10,000 requests per day</text>
+  <rect x="464" y="308" width="120" height="30" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="1.5"/>
+  <text x="524" y="328" text-anchor="middle" font-size="13" font-weight="600" fill="#9b4a3f">$500 / day</text>
 
-  <!-- Section header: Scale -->
-  <text x="60" y="260" font-size="12" font-weight="bold" fill="#6B7280">SCALE UP TO PRODUCTION</text>
-
-  <!-- Scale rows -->
-  <rect x="40" y="266" width="540" height="32" rx="4" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1"/>
-  <text x="80" y="287" font-size="13" fill="#374151">x 5 calls per task</text>
-  <text x="440" y="287" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">$0.035 per task</text>
-
-  <rect x="40" y="306" width="540" height="32" rx="4" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
-  <text x="80" y="327" font-size="13" fill="#374151">x 1,000 tasks per day</text>
-  <text x="440" y="327" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400E">$35 / day</text>
-
-  <rect x="40" y="346" width="540" height="32" rx="4" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
-  <text x="80" y="367" font-size="13" fill="#374151">x 30 days</text>
-  <text x="440" y="367" text-anchor="middle" font-size="16" font-weight="bold" fill="#B91C1C">$1,050 / month</text>
-
-  <!-- Caption -->
-  <text x="310" y="394" text-anchor="middle" font-size="11" fill="#9CA3AF">Token costs compound. Measure on day one — not after you deploy.</text>
+  <text x="40" y="368" font-size="11" fill="#6b6b6b">know this number before you ship</text>
 </svg>

--- a/public/assets/diagrams/tool-selection-comparison.svg
+++ b/public/assets/diagrams/tool-selection-comparison.svg
@@ -24,7 +24,7 @@
   <line x1="172" y1="140" x2="172" y2="160" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
   <rect x="40" y="164" width="264" height="34" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="172" y="186" text-anchor="middle" font-size="12" fill="#1a1a1a">"What is 42 x 17?"</text>
+  <text x="172" y="186" text-anchor="middle" font-size="12" fill="#1a1a1a">"What is 42 times 17?"</text>
 
   <line x1="172" y1="206" x2="172" y2="226" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
@@ -47,7 +47,7 @@
   <line x1="508" y1="140" x2="508" y2="160" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
   <rect x="376" y="164" width="264" height="34" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
-  <text x="508" y="186" text-anchor="middle" font-size="12" fill="#1a1a1a">"What is 42 x 17?"</text>
+  <text x="508" y="186" text-anchor="middle" font-size="12" fill="#1a1a1a">"What is 42 times 17?"</text>
 
   <line x1="508" y1="206" x2="508" y2="226" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 

--- a/public/assets/diagrams/tool-selection-comparison.svg
+++ b/public/assets/diagrams/tool-selection-comparison.svg
@@ -1,85 +1,63 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="680" height="380" viewBox="0 0 680 380" font-family="'IBM Plex Sans', Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 380" font-family="IBM Plex Mono, monospace">
   <defs>
-    <style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&amp;display=swap');</style>
-    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
   </defs>
+  <rect width="680" height="380" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="680" height="380" fill="#ffffff"/>
+  <!-- Divider -->
+  <line x1="340" y1="28" x2="340" y2="330" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Title -->
-  <text x="340" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Tool Selection: Why Descriptions Matter</text>
-  <line x1="40" y1="42" x2="640" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <!-- LEFT: precise description -->
+  <text x="40" y="40" font-size="11" letter-spacing="2" font-weight="500" fill="#1a1a1a">PRECISE DESCRIPTION</text>
 
-  <!-- LEFT PANEL: Good (green) -->
-  <rect x="30" y="56" width="300" height="296" rx="10" fill="#F0FDF4" stroke="#22c55e" stroke-width="2.5"/>
-  <text x="180" y="80" text-anchor="middle" font-size="14" font-weight="bold" fill="#15803D">Good Tool Description</text>
-  <line x1="50" y1="88" x2="310" y2="88" stroke="#86EFAC" stroke-width="1"/>
+  <rect x="40" y="54" width="264" height="78" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="52" y="74" font-size="11" fill="#6b6b6b">tool: calculator</text>
+  <text x="52" y="94" font-size="11" fill="#1a1a1a">"Perform basic arithmetic:</text>
+  <text x="52" y="110" font-size="11" fill="#1a1a1a">add, subtract, multiply,</text>
+  <text x="52" y="126" font-size="11" fill="#1a1a1a">or divide two numbers."</text>
 
-  <!-- Tool definition box -->
-  <rect x="48" y="98" width="264" height="68" rx="6" fill="#DCFCE7" stroke="#86EFAC" stroke-width="1"/>
-  <text x="70" y="116" font-size="10" font-weight="bold" fill="#15803D">Tool: calculator</text>
-  <text x="70" y="133" font-size="10" fill="#374151">"Performs arithmetic:</text>
-  <text x="70" y="148" font-size="10" fill="#374151"> addition, subtraction,</text>
-  <text x="70" y="163" font-size="10" fill="#374151"> multiplication, division."</text>
+  <line x1="172" y1="140" x2="172" y2="160" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Arrow down -->
-  <line x1="180" y1="167" x2="180" y2="196" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="40" y="164" width="264" height="34" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="172" y="186" text-anchor="middle" font-size="12" fill="#1a1a1a">"What is 42 x 17?"</text>
 
-  <!-- Query -->
-  <rect x="48" y="198" width="264" height="36" rx="6" fill="#ffffff" stroke="#D1D5DB" stroke-width="1"/>
-  <text x="180" y="221" text-anchor="middle" font-size="12" fill="#374151">Query: <tspan font-weight="bold">"What is 15 × 7?"</tspan></text>
+  <line x1="172" y1="206" x2="172" y2="226" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Arrow down -->
-  <line x1="180" y1="235" x2="180" y2="264" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="40" y="230" width="264" height="36" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="172" y="253" text-anchor="middle" font-size="12" fill="#1a1a1a">model picks: calculator</text>
 
-  <!-- Model selects -->
-  <rect x="48" y="266" width="264" height="30" rx="6" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1"/>
-  <text x="180" y="286" text-anchor="middle" font-size="11" fill="#1D4ED8">Model selects: <tspan font-weight="bold">calculator</tspan></text>
+  <line x1="172" y1="274" x2="172" y2="294" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Arrow down -->
-  <line x1="180" y1="297" x2="180" y2="316" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="172" y="316" text-anchor="middle" font-size="12" font-weight="500" fill="#1a1a1a">&#8594; 714 · correct</text>
 
-  <!-- Result -->
-  <rect x="48" y="318" width="264" height="24" rx="6" fill="#DCFCE7" stroke="#22c55e" stroke-width="2"/>
-  <text x="180" y="334" text-anchor="middle" font-size="13" font-weight="bold" fill="#15803D">Result: 105  &#10003; Correct</text>
+  <!-- RIGHT: vague description -->
+  <text x="376" y="40" font-size="11" letter-spacing="2" font-weight="500" fill="#1a1a1a">VAGUE DESCRIPTION</text>
 
-<!-- RIGHT PANEL: Bad (red) -->
-  <rect x="350" y="56" width="300" height="296" rx="10" fill="#FEF2F2" stroke="#EF4444" stroke-width="2.5"/>
-  <text x="500" y="80" text-anchor="middle" font-size="14" font-weight="bold" fill="#B91C1C">Vague Tool Description</text>
-  <line x1="370" y1="88" x2="630" y2="88" stroke="#FCA5A5" stroke-width="1"/>
+  <rect x="376" y="54" width="264" height="78" rx="2" fill="none" stroke="#6b6b6b" stroke-width="1.5"/>
+  <text x="388" y="74" font-size="11" fill="#6b6b6b">tool: calculator</text>
+  <text x="388" y="94" font-size="11" fill="#1a1a1a">"A tool for processing</text>
+  <text x="388" y="110" font-size="11" fill="#1a1a1a">numbers and returning</text>
+  <text x="388" y="126" font-size="11" fill="#1a1a1a">information."</text>
 
-  <!-- Tool definition box -->
-  <rect x="368" y="98" width="264" height="68" rx="6" fill="#FEE2E2" stroke="#FCA5A5" stroke-width="1"/>
-  <text x="390" y="116" font-size="10" font-weight="bold" fill="#B91C1C">Tool: calculator</text>
-  <text x="390" y="133" font-size="10" fill="#374151">"A tool for processing</text>
-  <text x="390" y="148" font-size="10" fill="#374151"> numbers and returning</text>
-  <text x="390" y="163" font-size="10" fill="#374151"> information."</text>
+  <line x1="508" y1="140" x2="508" y2="160" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Arrow down -->
-  <line x1="500" y1="167" x2="500" y2="196" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="376" y="164" width="264" height="34" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="508" y="186" text-anchor="middle" font-size="12" fill="#1a1a1a">"What is 42 x 17?"</text>
 
-  <!-- Query -->
-  <rect x="368" y="198" width="264" height="36" rx="6" fill="#ffffff" stroke="#D1D5DB" stroke-width="1"/>
-  <text x="500" y="221" text-anchor="middle" font-size="12" fill="#374151">Query: <tspan font-weight="bold">"What is 15 × 7?"</tspan></text>
+  <line x1="508" y1="206" x2="508" y2="226" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Arrow down -->
-  <line x1="500" y1="235" x2="500" y2="264" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="376" y="230" width="264" height="36" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="508" y="253" text-anchor="middle" font-size="12" font-weight="500" fill="#9b4a3f">model picks: search</text>
 
-  <!-- Model selects wrong -->
-  <rect x="368" y="266" width="264" height="30" rx="6" fill="#FEE2E2" stroke="#EF4444" stroke-width="1"/>
-  <text x="500" y="286" text-anchor="middle" font-size="11" fill="#B91C1C">Model selects: <tspan font-weight="bold">web_search</tspan></text>
+  <line x1="508" y1="274" x2="508" y2="294" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Arrow down -->
-  <line x1="500" y1="297" x2="500" y2="316" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="508" y="316" text-anchor="middle" font-size="12" font-weight="500" fill="#9b4a3f">&#8594; search snippets · wrong tool</text>
 
-  <!-- Result -->
-  <rect x="368" y="318" width="264" height="24" rx="6" fill="#FEE2E2" stroke="#EF4444" stroke-width="2"/>
-  <text x="500" y="334" text-anchor="middle" font-size="12" font-weight="bold" fill="#B91C1C">Result: search snippets  &#10007; Wrong tool</text>
-
-  <!-- Caption -->
-  <text x="340" y="366" text-anchor="middle" font-size="11" fill="#374151">Tool selection is driven entirely by the description you write. Be precise and unambiguous.</text>
-  <text x="340" y="379" text-anchor="middle" font-size="11" fill="#9CA3AF">Treat tool descriptions as API contracts, not comments.</text>
+  <!-- Footnote -->
+  <text x="340" y="360" text-anchor="middle" font-size="11" fill="#6b6b6b">same query, same tools · only the description changed</text>
 </svg>

--- a/src/ch00/adk_agent.py
+++ b/src/ch00/adk_agent.py
@@ -114,7 +114,7 @@ def create_adk_agent():  # type: ignore[return]
 
     return _ADKAgent(
         name="foundations_agent",
-        model="gemini-2.0-flash",
+        model="gemini-3.5-flash",
         instruction=(
             "You are a helpful assistant. Use the available tools to answer "
             "the user's question accurately. Stop as soon as you have a good answer."

--- a/src/ch00/langchain_agent.py
+++ b/src/ch00/langchain_agent.py
@@ -2,14 +2,14 @@
 
 Demonstrates how to wrap the same calculator/word_count/search tools in
 LangChain conventions. This file is a STUB -- actual execution requires
-langchain-core, langchain-anthropic, and langgraph to be installed.
+langchain-core, langchain-anthropic, langchain, and langgraph to be installed.
 
 When the dependencies are absent, LANGCHAIN_AVAILABLE is False and
 create_langchain_agent() returns None, allowing the rest of the codebase
 to import this module without hard-failing on missing optional packages.
 
 Install the real packages with:
-    pip install langchain-core langchain-anthropic langgraph
+    pip install langchain-core langchain-anthropic langchain langgraph
 """
 
 from __future__ import annotations
@@ -105,10 +105,11 @@ def search(query: str, max_results: int = 3) -> str:
 
 
 def create_langchain_agent():  # type: ignore[return]
-    """Create and return a LangChain ReAct agent if dependencies are available.
+    """Create and return a LangChain agent if dependencies are available.
 
     Builds a ChatAnthropic model bound to the three demo tools and wraps it
-    in a langgraph create_react_agent executor.
+    with langchain.agents.create_agent, the LangChain v1 agent factory
+    (replaces the deprecated langgraph.prebuilt.create_react_agent).
 
     Returns:
         A compiled LangGraph agent, or None if langchain deps are not installed.
@@ -118,13 +119,13 @@ def create_langchain_agent():  # type: ignore[return]
 
     try:
         from langchain_anthropic import ChatAnthropic
-        from langgraph.prebuilt import create_react_agent
+        from langchain.agents import create_agent
     except ImportError:
         return None
 
     model = ChatAnthropic(model="claude-haiku-4-5-20251001", temperature=0)
     tools = [calculator, word_count, search]
-    return create_react_agent(model, tools)
+    return create_agent(model, tools)
 
 
 # ---------------------------------------------------------------------------
@@ -139,12 +140,12 @@ if __name__ == "__main__":
             print(f"LangChain available. Agent created: {agent}")
         else:
             print(
-                "langchain_core is present but langchain-anthropic or langgraph is missing.\n"
-                "Install with: pip install langchain-anthropic langgraph"
+                "langchain_core is present but langchain-anthropic or langchain/langgraph is missing.\n"
+                "Install with: pip install langchain-anthropic langchain langgraph"
             )
     else:
         print(
             "langchain-core is not installed. This is a stub file.\n"
-            "Install with: pip install langchain-core langchain-anthropic langgraph\n"
+            "Install with: pip install langchain-core langchain-anthropic langchain langgraph\n"
             "The create_langchain_agent() function returns None when packages are absent."
         )

--- a/src/ch00/raw_agent.py
+++ b/src/ch00/raw_agent.py
@@ -315,6 +315,7 @@ if __name__ == "__main__":
                 (demo_client for demo_query, demo_client in _demo_examples() if demo_query == query),
                 MockClient(),
             )
+        # max_steps=5 for real queries; demo suite uses max_steps=3 to trigger budget exhaustion
         agent = Agent(client=client, registry=registry, max_steps=5)
         result = await agent.run(query)
         _print_result(query, result)

--- a/src/ch00/raw_agent.py
+++ b/src/ch00/raw_agent.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 
 from src.ch00.tool_use import ToolRegistry, execute_tool_call
 from src.shared.model_client import ModelClient
-from src.shared.types import CompletionRequest, Message, Role
+from src.shared.types import CompletionRequest, Message, Role, ToolResult
 
 # ---------------------------------------------------------------------------
 # System prompt
@@ -107,34 +107,46 @@ class Agent:
             if response.usage:
                 total_tokens += response.usage.total_tokens
 
-            # Model wants to call a tool.
+            # Model wants to call one or more tools. The API allows multiple
+            # tool_use blocks per assistant turn (parallel tool calls); every
+            # one of them needs to be executed, and every result needs to
+            # come back in a single following message.
             if response.tool_calls:
-                tc = response.tool_calls[0]
-                tool_result = execute_tool_call(self.registry, tc.name, tc.arguments)
+                results: list[ToolResult] = []
+                for tc in response.tool_calls:
+                    tool_result = execute_tool_call(self.registry, tc.name, tc.arguments)
+                    results.append(ToolResult(tool_call_id=tc.id, name=tc.name, content=tool_result))
 
-                trace.append(
-                    {
-                        "type": "tool_call",
-                        "step": steps,
-                        "tool": tc.name,
-                        "arguments": tc.arguments,
-                        "result": tool_result,
-                    }
-                )
+                    # One trace entry per tool call, sharing this turn's step
+                    # number -- keeps the single-call trace shape (and the
+                    # chapter's printed example) unchanged when a turn makes
+                    # only one call, and makes parallel calls visible as
+                    # sibling entries under the same step otherwise.
+                    trace.append(
+                        {
+                            "type": "tool_call",
+                            "step": steps,
+                            "tool": tc.name,
+                            "arguments": tc.arguments,
+                            "result": tool_result,
+                        }
+                    )
 
-                # Append the assistant's tool-call turn and the tool result.
+                # Append the assistant's tool-call turn -- with the actual
+                # ToolCall objects, not a text stand-in -- and every result
+                # from this turn in a single following message.
                 messages.append(
                     Message(
                         role=Role.ASSISTANT,
-                        content=f"[tool_call: {tc.name}({tc.arguments})]",
+                        content="",
+                        tool_calls=list(response.tool_calls),
                     )
                 )
                 messages.append(
                     Message(
                         role=Role.TOOL,
-                        content=tool_result,
-                        name=tc.name,
-                        tool_call_id=tc.id,
+                        content="",
+                        tool_results=results,
                     )
                 )
                 continue
@@ -178,9 +190,18 @@ class Agent:
 
 
 if __name__ == "__main__":
-    from src.ch00.tool_use import create_default_registry
-    from src.shared.model_client import MockClient
+    import os
+    import sys
+
+    from src.ch00.tool_use import ToolRegistry, create_default_registry
+    from src.shared.model_client import MockClient, create_client
     from src.shared.types import CompletionResponse, TokenUsage, ToolCall
+
+    # Real API calls use this model. Key-free by default: only reached when
+    # ANTHROPIC_API_KEY is set. See src/ch00/llm_basics.py and
+    # src/ch00/langchain_agent.py for the same model choice elsewhere in the
+    # companion code.
+    LIVE_MODEL_NAME = "claude-haiku-4-5-20251001"
 
     def _make_tool_response(name: str, args: dict) -> CompletionResponse:
         return CompletionResponse(
@@ -197,10 +218,14 @@ if __name__ == "__main__":
             usage=TokenUsage(prompt_tokens=60, completion_tokens=25, total_tokens=85),
         )
 
-    async def _demo() -> None:
-        registry = create_default_registry()
+    def _demo_examples() -> list[tuple[str, MockClient]]:
+        """The canned (query, MockClient) pairs used by both the demo suite
 
-        examples = [
+        and, key-free, an argv question that matches the demo suite exactly.
+        Called fresh each time so MockClient's internal call counter always
+        starts at zero.
+        """
+        return [
             # 1. Direct text answer -- no tools needed.
             (
                 "What is the capital of France?",
@@ -218,7 +243,22 @@ if __name__ == "__main__":
                     ]
                 ),
             ),
-            # 3. Budget exhaustion (only tool calls, no final answer).
+            # 3. Two-step arithmetic -- the chapter's worked example
+            # ("What is 15 * 7 + 3?"): multiply, then add, then answer.
+            # 55 + 55 + 85 = 195 total tokens, matching the chapter's trace.
+            (
+                "What is 15 * 7 + 3?",
+                MockClient(
+                    responses=[
+                        _make_tool_response(
+                            "calculator", {"operation": "multiply", "a": 15, "b": 7}
+                        ),
+                        _make_tool_response("calculator", {"operation": "add", "a": 105, "b": 3}),
+                        _make_text_response("15 * 7 + 3 = 108.0"),
+                    ]
+                ),
+            ),
+            # 4. Budget exhaustion (only tool calls, no final answer).
             (
                 "Search for everything ever written about AI.",
                 MockClient(
@@ -231,22 +271,55 @@ if __name__ == "__main__":
             ),
         ]
 
-        for query, client in examples:
+    def _print_result(query: str, result: AgentResult) -> None:
+        print(f"Query:           {query}")
+        print(f"Answer:          {result.answer!r}")
+        print(f"Steps:           {result.steps}")
+        print(f"Total tokens:    {result.total_tokens}")
+        print(f"Budget exhausted:{result.budget_exhausted}")
+        print(f"Trace ({len(result.trace)} entries):")
+        for entry in result.trace:
+            if entry["type"] == "tool_call":
+                print(
+                    f"  [{entry['step']}] tool_call  {entry['tool']}({entry['arguments']}) -> {entry['result'][:60]!r}"
+                )
+            else:
+                print(f"  [{entry['step']}] response   {entry['content'][:60]!r}")
+        print()
+
+    async def _demo() -> None:
+        registry = create_default_registry()
+        for query, client in _demo_examples():
+            # max_steps=3 matches every example's canned response count
+            # exactly, so the budget-exhaustion example (search x3) still
+            # exhausts instead of falling through to MockClient's default
+            # "Mock response" text on a 4th call.
             agent = Agent(client=client, registry=registry, max_steps=3)
             result = await agent.run(query)
-            print(f"Query:           {query}")
-            print(f"Answer:          {result.answer!r}")
-            print(f"Steps:           {result.steps}")
-            print(f"Total tokens:    {result.total_tokens}")
-            print(f"Budget exhausted:{result.budget_exhausted}")
-            print(f"Trace ({len(result.trace)} entries):")
-            for entry in result.trace:
-                if entry["type"] == "tool_call":
-                    print(
-                        f"  [{entry['step']}] tool_call  {entry['tool']}({entry['arguments']}) -> {entry['result'][:60]!r}"
-                    )
-                else:
-                    print(f"  [{entry['step']}] response   {entry['content'][:60]!r}")
-            print()
+            _print_result(query, result)
 
-    asyncio.run(_demo())
+    async def _run_query(query: str, registry: ToolRegistry) -> None:
+        """Run a single question through the agent.
+
+        Uses the real Anthropic API when ANTHROPIC_API_KEY is set (as the
+        chapter's run instructions do); otherwise stays key-free: replays
+        the matching canned example if the question matches the demo suite
+        exactly, or falls back to a plain MockClient (a one-step "Mock
+        response" answer) so the script always exits 0 without a key.
+        """
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if api_key:
+            client = create_client(provider="anthropic", api_key=api_key, model_name=LIVE_MODEL_NAME)
+        else:
+            client = next(
+                (demo_client for demo_query, demo_client in _demo_examples() if demo_query == query),
+                MockClient(),
+            )
+        agent = Agent(client=client, registry=registry, max_steps=5)
+        result = await agent.run(query)
+        _print_result(query, result)
+
+    if len(sys.argv) > 1:
+        asyncio.run(_run_query(sys.argv[1], create_default_registry()))
+    else:
+        asyncio.run(_demo())

--- a/src/ch00/selfcheck.py
+++ b/src/ch00/selfcheck.py
@@ -1,0 +1,235 @@
+"""Executable self-check for the Section 0c companion-code fixes.
+
+There is no test framework in this repo (see src/shared/, src/ch00/) --
+this script is the verification path instead. Run it directly:
+
+    python -m src.ch00.selfcheck
+
+Each check prints PASS or FAIL. The script exits 0 if every check passes,
+1 if any fails, so it also works as a CI-less gate.
+
+Checks (map to the fixes in raw_agent.py / tool_use.py / model_client.py / types.py):
+    (a) An assistant tool-call turn serializes to a `tool_use` content block
+        whose id matches the following `tool_result` block's tool_use_id.
+    (b) A two-tool-call mock turn executes both tools and returns both
+        results in a single following message, not two separate ones.
+    (c) A CompletionRequest with temperature=None omits "temperature" from
+        the request payload; an explicit value is still sent.
+    (d) Calling a tool with requires_approval=True returns a structured
+        approval_required error and never runs the tool body.
+    (e) `python -m src.ch00.raw_agent "<question>"` runs key-free and exits 0.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from src.ch00.raw_agent import Agent
+from src.ch00.tool_use import create_default_registry, execute_tool_call
+from src.shared.model_client import AnthropicClient, ModelClient, _to_anthropic_message
+from src.shared.types import (
+    CompletionRequest,
+    CompletionResponse,
+    Message,
+    Role,
+    TokenUsage,
+    ToolCall,
+    ToolResult,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _CapturingClient(ModelClient):
+    """A ModelClient that records every request instead of calling an API.
+
+    Lets a check inspect exactly what Agent.run() sends on the *next* call,
+    which is the only way to verify how a turn got serialized into messages.
+    """
+
+    def __init__(self, responses: list[CompletionResponse]) -> None:
+        super().__init__("capturing")
+        self._responses = responses
+        self.requests: list[CompletionRequest] = []
+
+    async def complete(self, request: CompletionRequest) -> CompletionResponse:
+        self.requests.append(request)
+        return self._responses[len(self.requests) - 1]
+
+
+class _FakeResponse:
+    """Stands in for an httpx.Response -- just enough surface to satisfy
+
+    AnthropicClient.complete() without a real HTTP round trip.
+    """
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return {"content": [{"type": "text", "text": "ok"}], "usage": {}, "model": "fake"}
+
+
+class _FakeAnthropicHTTP:
+    """Stands in for httpx.AsyncClient, capturing the JSON payload posted."""
+
+    def __init__(self) -> None:
+        self.last_payload: dict | None = None
+
+    async def post(self, url: str, json: dict) -> _FakeResponse:
+        self.last_payload = json
+        return _FakeResponse()
+
+
+def check_tool_use_serialization() -> None:
+    """(a) tool_use block id matches the following tool_result's tool_use_id."""
+    tc = ToolCall(id="tc_1", name="calculator", arguments={"operation": "add", "a": 1, "b": 2})
+    assistant_msg = Message(role=Role.ASSISTANT, content="", tool_calls=[tc])
+    tool_msg = Message(
+        role=Role.TOOL,
+        content="",
+        tool_results=[ToolResult(tool_call_id=tc.id, name=tc.name, content="3.0")],
+    )
+
+    assistant_dict = _to_anthropic_message(assistant_msg)
+    tool_dict = _to_anthropic_message(tool_msg)
+
+    assert assistant_dict["role"] == "assistant", assistant_dict
+    assert isinstance(assistant_dict["content"], list), assistant_dict
+    block = assistant_dict["content"][0]
+    assert block == {
+        "type": "tool_use",
+        "id": "tc_1",
+        "name": "calculator",
+        "input": tc.arguments,
+    }, block
+
+    assert tool_dict["role"] == "user", tool_dict
+    result_block = tool_dict["content"][0]
+    assert result_block["type"] == "tool_result", result_block
+    assert result_block["tool_use_id"] == block["id"] == "tc_1", result_block
+
+
+async def check_parallel_tool_calls() -> None:
+    """(b) Two tool calls in one turn both execute; both results travel in
+
+    a single following message.
+    """
+    registry = create_default_registry()
+    tool_turn = CompletionResponse(
+        content=None,
+        tool_calls=[
+            ToolCall(id="p1", name="calculator", arguments={"operation": "add", "a": 1, "b": 2}),
+            ToolCall(
+                id="p2", name="calculator", arguments={"operation": "multiply", "a": 3, "b": 4}
+            ),
+        ],
+        model="mock",
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+    final_turn = CompletionResponse(content="done", model="mock")
+    client = _CapturingClient([tool_turn, final_turn])
+
+    agent = Agent(client=client, registry=registry, max_steps=3)
+    result = await agent.run("add 1+2 and multiply 3*4")
+
+    tool_call_entries = [e for e in result.trace if e["type"] == "tool_call"]
+    assert len(tool_call_entries) == 2, f"expected 2 tool_call trace entries, got {tool_call_entries}"
+    assert tool_call_entries[0]["result"] == "3.0", tool_call_entries[0]
+    assert tool_call_entries[1]["result"] == "12.0", tool_call_entries[1]
+
+    # requests[1] is what the agent sent on its second call -- i.e. right
+    # after executing both tools from the first turn.
+    second_request = client.requests[1]
+    assistant_messages = [m for m in second_request.messages if m.tool_calls]
+    tool_result_messages = [m for m in second_request.messages if m.tool_results]
+    assert len(assistant_messages) == 1, "expected exactly one assistant message with tool_calls"
+    assert len(tool_result_messages) == 1, "expected exactly one message with tool_results"
+
+    sent_calls = assistant_messages[0].tool_calls or []
+    sent_results = tool_result_messages[0].tool_results or []
+    assert len(sent_calls) == 2, sent_calls
+    assert len(sent_results) == 2, sent_results
+    ids = {tr.tool_call_id for tr in sent_results}
+    assert ids == {"p1", "p2"}, ids
+
+
+async def check_temperature_omitted() -> None:
+    """(c) temperature=None omits the key; an explicit value is still sent."""
+    fake_http = _FakeAnthropicHTTP()
+    client = AnthropicClient(api_key="fake-key", model_name="fake-model")
+    client._client = fake_http  # type: ignore[assignment]
+
+    await client.complete(
+        CompletionRequest(messages=[Message(role=Role.USER, content="hi")], temperature=None)
+    )
+    assert fake_http.last_payload is not None
+    assert "temperature" not in fake_http.last_payload, fake_http.last_payload
+
+    await client.complete(
+        CompletionRequest(messages=[Message(role=Role.USER, content="hi")], temperature=0.7)
+    )
+    assert fake_http.last_payload["temperature"] == 0.7, fake_http.last_payload
+
+
+def check_gated_tool() -> None:
+    """(d) A requires_approval tool refuses before dispatch."""
+    registry = create_default_registry()
+    result = execute_tool_call(registry, "delete_record", {"record_id": "rec_1"})
+    assert result.startswith("approval_required:"), result
+    assert "delete_record" in result, result
+    assert "Deleted record" not in result, "tool body ran despite the approval gate"
+
+
+def check_argv_run() -> None:
+    """(e) `python -m src.ch00.raw_agent "<question>"` exits 0, key-free."""
+    env = os.environ.copy()
+    env.pop("ANTHROPIC_API_KEY", None)  # force the key-free MockClient path
+    proc = subprocess.run(
+        [sys.executable, "-m", "src.ch00.raw_agent", "What is 15 * 7 + 3?"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert proc.returncode == 0, f"exit code {proc.returncode}\nstderr:\n{proc.stderr}"
+    assert "15 * 7 + 3 = 108.0" in proc.stdout, proc.stdout
+
+
+CHECKS = [
+    ("tool_use_serialization", check_tool_use_serialization),
+    ("parallel_tool_calls", check_parallel_tool_calls),
+    ("temperature_omitted", check_temperature_omitted),
+    ("gated_tool", check_gated_tool),
+    ("argv_run", check_argv_run),
+]
+
+
+async def _run_all() -> bool:
+    all_passed = True
+    for name, check in CHECKS:
+        try:
+            if inspect.iscoroutinefunction(check):
+                await check()
+            else:
+                check()
+        except AssertionError as exc:
+            print(f"FAIL: {name}: {exc}")
+            all_passed = False
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL: {name}: unexpected {type(exc).__name__}: {exc}")
+            all_passed = False
+        else:
+            print(f"PASS: {name}")
+    return all_passed
+
+
+if __name__ == "__main__":
+    passed = asyncio.run(_run_all())
+    sys.exit(0 if passed else 1)

--- a/src/ch00/selfcheck.py
+++ b/src/ch00/selfcheck.py
@@ -86,6 +86,31 @@ class _FakeAnthropicHTTP:
         return _FakeResponse()
 
 
+class _FakeOpenAIResponse:
+    """Stands in for an httpx.Response for OpenAI API format."""
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return {
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "model": "fake",
+        }
+
+
+class _FakeOpenAIHTTP:
+    """Stands in for httpx.AsyncClient for OpenAI, capturing the JSON payload posted."""
+
+    def __init__(self) -> None:
+        self.last_payload: dict | None = None
+
+    async def post(self, url: str, json: dict) -> _FakeOpenAIResponse:
+        self.last_payload = json
+        return _FakeOpenAIResponse()
+
+
 def check_tool_use_serialization() -> None:
     """(a) tool_use block id matches the following tool_result's tool_use_id."""
     tc = ToolCall(id="tc_1", name="calculator", arguments={"operation": "add", "a": 1, "b": 2})
@@ -175,6 +200,28 @@ async def check_temperature_omitted() -> None:
         CompletionRequest(messages=[Message(role=Role.USER, content="hi")], temperature=0.7)
     )
     assert fake_http.last_payload["temperature"] == 0.7, fake_http.last_payload
+
+    # Also verify OpenAI client omits temperature when None
+    from src.shared.model_client import OpenAIClient
+
+    fake_openai_http = _FakeOpenAIHTTP()
+    openai_client = OpenAIClient(api_key="fake-key", model_name="gpt-4")
+    openai_client._client = fake_openai_http  # type: ignore[assignment]
+
+    await openai_client.complete(
+        CompletionRequest(messages=[Message(role=Role.USER, content="hi")], temperature=None)
+    )
+    assert fake_openai_http.last_payload is not None
+    assert (
+        "temperature" not in fake_openai_http.last_payload
+    ), f"OpenAI should omit temperature when None, got: {fake_openai_http.last_payload}"
+
+    await openai_client.complete(
+        CompletionRequest(messages=[Message(role=Role.USER, content="hi")], temperature=0.7)
+    )
+    assert (
+        fake_openai_http.last_payload["temperature"] == 0.7
+    ), f"OpenAI should include temperature when set, got: {fake_openai_http.last_payload}"
 
 
 def check_gated_tool() -> None:

--- a/src/ch00/tool_use.py
+++ b/src/ch00/tool_use.py
@@ -22,6 +22,7 @@ from src.shared.types import (
     CompletionResponse,
     Message,
     Role,
+    SideEffect,
     TokenUsage,
     ToolCall,
     ToolParameter,
@@ -59,6 +60,12 @@ class SearchInput(BaseModel):
 
     query: str
     max_results: int = Field(default=3, ge=1, le=10)
+
+
+class DeleteRecordInput(BaseModel):
+    """Input schema for the (gated) delete_record tool."""
+
+    record_id: str
 
 
 # ---------------------------------------------------------------------------
@@ -105,6 +112,22 @@ def word_count(text: str) -> str:
     return f"Word count: {count}"
 
 
+def delete_record(record_id: str) -> str:
+    """Delete a record permanently. Gated -- requires approval before execution.
+
+    This body should never run in the demo. `execute_tool_call()` checks
+    `requires_approval` on the tool's schema before dispatch and returns a
+    structured refusal for any gated tool, so this function is never called.
+
+    Args:
+        record_id: The identifier of the record to delete.
+
+    Returns:
+        Confirmation text. Unreachable while the tool stays gated.
+    """
+    return f"Deleted record {record_id}"  # pragma: no cover -- gated, never reached
+
+
 def fake_search(query: str, max_results: int = 3) -> str:
     """Return fake search results for demonstration purposes.
 
@@ -140,11 +163,15 @@ class Tool:
         description: str,
         fn: Callable[..., str],
         input_model: type[BaseModel],
+        side_effect: SideEffect = SideEffect.READ,
+        requires_approval: bool = False,
     ) -> None:
         self.name = name
         self.description = description
         self.fn = fn
         self.input_model = input_model
+        self.side_effect = side_effect
+        self.requires_approval = requires_approval
 
     def to_schema(self) -> ToolSchema:
         """Derive a ToolSchema from the Pydantic model's field definitions."""
@@ -163,8 +190,7 @@ class Tool:
             if origin is None and isinstance(annotation, type) and issubclass(annotation, StrEnum):
                 enum_values = [e.value for e in annotation]  # type: ignore[attr-defined]
 
-            is_required = field_info.default is field_info.default_factory is None  # type: ignore[comparison-overlap]
-            # Simpler: a field is required when it has no default value.
+            # A field is required when it has no default value.
             is_required = field_info.is_required()
 
             parameters.append(
@@ -177,7 +203,13 @@ class Tool:
                 )
             )
 
-        return ToolSchema(name=self.name, description=self.description, parameters=parameters)
+        return ToolSchema(
+            name=self.name,
+            description=self.description,
+            parameters=parameters,
+            side_effect=self.side_effect,
+            requires_approval=self.requires_approval,
+        )
 
 
 def _python_type_to_json_type(annotation: Any) -> str:
@@ -227,16 +259,28 @@ class ToolRegistry:
         description: str,
         fn: Callable[..., str],
         input_model: type[BaseModel],
+        side_effect: SideEffect = SideEffect.READ,
+        requires_approval: bool = False,
     ) -> None:
         """Register a tool under *name*.
 
         Args:
-            name:        Unique tool name (used by the model to invoke it).
-            description: Short description of what the tool does.
-            fn:          The callable to execute.
-            input_model: Pydantic BaseModel class used for argument validation.
+            name:              Unique tool name (used by the model to invoke it).
+            description:       Short description of what the tool does.
+            fn:                The callable to execute.
+            input_model:       Pydantic BaseModel class used for argument validation.
+            side_effect:       What the tool does to the world (READ/WRITE/DELETE).
+            requires_approval: If True, execute_tool_call() refuses to dispatch this
+                                tool and returns a structured approval-required error.
         """
-        self._tools[name] = Tool(name=name, description=description, fn=fn, input_model=input_model)
+        self._tools[name] = Tool(
+            name=name,
+            description=description,
+            fn=fn,
+            input_model=input_model,
+            side_effect=side_effect,
+            requires_approval=requires_approval,
+        )
 
     def list_tools(self) -> list[str]:
         """Return a list of registered tool names."""
@@ -274,6 +318,9 @@ def execute_tool_call(registry: ToolRegistry, tool_name: str, arguments: dict[st
     if entry is None:
         return f"Error: unknown tool '{tool_name}'"
 
+    if entry.requires_approval:
+        return f"approval_required: {tool_name} is gated; a human or policy must approve this call"
+
     try:
         validated = entry.input_model.model_validate(arguments)
     except ValidationError as exc:
@@ -294,7 +341,9 @@ def create_default_registry() -> ToolRegistry:
     """Create a ToolRegistry pre-populated with the standard demo tools.
 
     Returns:
-        A ToolRegistry with calculator, word_count, and fake_search registered.
+        A ToolRegistry with calculator, word_count, and fake_search registered
+        as READ tools, plus one gated DELETE tool (delete_record) to show what
+        a real approval boundary looks like.
     """
     registry = ToolRegistry()
     registry.register(
@@ -302,18 +351,29 @@ def create_default_registry() -> ToolRegistry:
         description="Perform basic arithmetic: add, subtract, multiply, or divide two numbers.",
         fn=calculator,
         input_model=CalculatorInput,
+        side_effect=SideEffect.READ,
     )
     registry.register(
         name="word_count",
         description="Count the number of words in a piece of text.",
         fn=word_count,
         input_model=WordCountInput,
+        side_effect=SideEffect.READ,
     )
     registry.register(
         name="search",
         description="Search for information on a topic and return the top results.",
         fn=fake_search,
         input_model=SearchInput,
+        side_effect=SideEffect.READ,
+    )
+    registry.register(
+        name="delete_record",
+        description="Permanently delete a record by ID. Destructive -- gated behind approval.",
+        fn=delete_record,
+        input_model=DeleteRecordInput,
+        side_effect=SideEffect.DELETE,
+        requires_approval=True,
     )
     return registry
 

--- a/src/ch02/agent.py
+++ b/src/ch02/agent.py
@@ -53,6 +53,7 @@ class DocumentAgent:
         request = CompletionRequest(
             messages=messages,
             tools=tools if tools else None,
+            temperature=0.0,
         )
         response = await self._client.complete(request)
         total_usage = _merge_usage(total_usage, response.usage)
@@ -75,7 +76,7 @@ class DocumentAgent:
                     )
                 )
 
-            request = CompletionRequest(messages=messages, tools=tools if tools else None)
+            request = CompletionRequest(messages=messages, tools=tools if tools else None, temperature=0.0)
             response = await self._client.complete(request)
             total_usage = _merge_usage(total_usage, response.usage)
             steps += 1

--- a/src/ch03/agent.py
+++ b/src/ch03/agent.py
@@ -78,6 +78,7 @@ class BoundedDocumentAgent:
             request = CompletionRequest(
                 messages=messages,
                 tools=tools if tools else None,
+                temperature=0.0,
             )
             response = await self._client.complete(request)
             total_usage = _merge_usage(total_usage, response.usage)

--- a/src/ch03/workflow.py
+++ b/src/ch03/workflow.py
@@ -37,7 +37,7 @@ class DocumentWorkflow:
 
         citations = self._index.retrieve(query, top_k=top_k)
         messages = self._context.build(query=query, citations=citations)
-        request = CompletionRequest(messages=messages)
+        request = CompletionRequest(messages=messages, temperature=0.0)
         response = await self._client.complete(request)
 
         elapsed = (time.monotonic() - start) * 1000

--- a/src/ch04_multiagent/agents.py
+++ b/src/ch04_multiagent/agents.py
@@ -79,7 +79,7 @@ Rules:
             ),
         ]
 
-        response = await self._client.complete(CompletionRequest(messages=messages))
+        response = await self._client.complete(CompletionRequest(messages=messages, temperature=0.0))
         self.total_usage = _merge_usage(self.total_usage, response.usage)
 
         cited = [c.source for c in request.citations if c.source in (response.content or "")]
@@ -131,7 +131,7 @@ Return valid JSON only."""
         ]
 
         response = await self._client.complete(
-            CompletionRequest(messages=messages, response_format={"type": "json_object"})
+            CompletionRequest(messages=messages, response_format={"type": "json_object"}, temperature=0.0)
         )
         self.total_usage = _merge_usage(self.total_usage, response.usage)
 

--- a/src/components/layout/Split.astro
+++ b/src/components/layout/Split.astro
@@ -31,6 +31,15 @@ const b = Number.isFinite(rawB) && rawB > 0 ? rawB : 1;
     gap: var(--gap);
   }
 
+  /* Grid items default to min-width: auto, which floors their track at the
+     content's min-content size (e.g. a figure's natural width) instead of
+     shrinking with the viewport. min-width: 0 lets tracks -- and everything
+     in them, including chapter figures -- actually respect max-width: 100%
+     below the stack breakpoint. */
+  .split > :global(*) {
+    min-width: 0;
+  }
+
   @media (max-width: 720px) {
     .split {
       grid-template-columns: 1fr;

--- a/src/components/universal/TopNav.astro
+++ b/src/components/universal/TopNav.astro
@@ -89,7 +89,36 @@ const items = [
   .topnav__subscribe:focus-visible { outline: 2px solid var(--brick); outline-offset: 3px; }
 
   @media (max-width: 720px) {
-    .topnav__items { gap: var(--space-3); flex-wrap: wrap; }
-    .topnav__subscribe { margin-left: auto; }
+    .topnav__inner {
+      flex-wrap: wrap;
+      justify-content: space-between;
+      row-gap: var(--space-2);
+      padding: var(--space-3) var(--space-4);
+    }
+
+    .topnav__inner :global(.brand) { order: 1; }
+
+    .topnav__subscribe { order: 2; margin-left: 0; }
+
+    .topnav__items {
+      order: 3;
+      width: 100%;
+      margin-left: 0;
+      flex-wrap: nowrap;
+      gap: var(--space-4);
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+      mask-image: linear-gradient(to right, black calc(100% - 28px), transparent 100%);
+      -webkit-mask-image: linear-gradient(to right, black calc(100% - 28px), transparent 100%);
+    }
+
+    .topnav__items::-webkit-scrollbar { display: none; }
+
+    .topnav__link {
+      font-size: 16px;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
   }
 </style>

--- a/src/content/chapters/00a-how-llms-work.mdx
+++ b/src/content/chapters/00a-how-llms-work.mdx
@@ -14,7 +14,7 @@ import Callout from '~/components/universal/Callout.astro';
 
 You don't need to understand attention heads to build with LLMs. You need to understand five things. Here they are.
 
-This is not a book about how LLMs are built internally. There are excellent resources for that (Raschka's *Build a Large Language Model (From Scratch)* is the best). This is about how to build production systems with LLMs as components. You don't need to understand transformers. You need to understand what breaks when you give a language model access to your tools.
+This is not a book about how LLMs are built internally. There are excellent resources for that ([Raschka's *Build a Large Language Model (From Scratch)*](https://www.manning.com/books/build-a-large-language-model-from-scratch) is the best). This is about how to build production systems with LLMs as components. You don't need to understand transformers. You need to understand what breaks when you give a language model access to your tools.
 
 ## The API contract
 
@@ -30,7 +30,7 @@ import anthropic
 client = anthropic.Anthropic()  # reads ANTHROPIC_API_KEY from env
 
 message = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     messages=[
         {"role": "user", "content": "What is the capital of France?"}
@@ -42,7 +42,7 @@ print(message.content[0].text)
 ```
 
 <Callout type="tip" label="What just happened">
-You sent a string to an API. You got a string back. You paid for both strings, measured in tokens. That's the entire contract. For this query, that is roughly 30 tokens in and 10 tokens out. At current pricing, about $0.0003. Cheap for one call. Less cheap when your agent makes fifty calls per user request.
+You sent a string to an API. You got a string back. You paid for both strings, measured in tokens. That's the entire contract. For this query, that is roughly 30 tokens in and 10 tokens out. At current pricing (checked 2026-07-02), about $0.0003. Cheap for one call. Less cheap when your agent makes fifty calls per user request.
 </Callout>
 
 That raw SDK call is the simplest way to understand what is happening. It is useful for experiments and first contact. But it becomes painful in real systems: provider-specific code leaks into every file, testing requires live API calls, swapping models means rewriting imports, and cost tracking gets scattered.
@@ -54,7 +54,7 @@ The companion code wraps this single operation in a provider-neutral client. Sam
 from src.shared.model_client import create_client
 from src.shared.types import CompletionRequest, Message, Role
 
-client = create_client(provider="anthropic", api_key="...", model_name="claude-sonnet-4-20250514")
+client = create_client(provider="anthropic", api_key="...", model_name="claude-sonnet-5")
 
 request = CompletionRequest(
     messages=[
@@ -73,7 +73,7 @@ print(response.content)
 The model client wraps the raw API with typed inputs and outputs. Your agent code never imports `anthropic` or `openai` directly. You can swap providers, add cost tracking, or switch to a mock for testing, all without changing the code that calls it.
 </Callout>
 
-So which should you use? Use the raw SDK call to understand the mechanics. Use the wrapper when the model becomes part of a larger system. The rest of this book uses the wrapper because agents call the model hundreds of times per day, and you will want to track costs, swap between a fast cheap model and a slow expensive one depending on the task, and run tests without hitting a real API. The wrapper makes all of that possible by centralizing the one operation that matters.
+The rest of this book uses the wrapper because agents call the model hundreds of times per day, and you will want to track costs, swap between a fast cheap model and a slow expensive one depending on the task, and run tests without hitting a real API. The wrapper makes all of that possible by centralizing the one operation that matters.
 
 This is the foundation. If you understand this, you understand 80% of what frameworks are doing. The other 20% is prompt management, tool routing, and retry logic. All useful. None of it magic.
 
@@ -86,7 +86,7 @@ This is the foundation. If you understand this, you understand 80% of what frame
 
 LLMs don't process words. They process tokens, which are chunks of text that roughly correspond to word fragments. The word "understanding" might be two tokens ("understand" + "ing"). A space before a word is often part of the token. A number like "42" is one token. The string "1234567890" might be three tokens.
 
-Why does this matter? Because everything about LLMs is priced and bounded in tokens. Context windows are measured in tokens. API costs are per-token. Rate limits count tokens. When someone says a model has a "128K context window," they mean 128,000 tokens, which is roughly 96,000 words, or about 300 pages of prose. That sounds like a lot. It's less than you think once you start filling it with system prompts, conversation history, retrieved documents, and tool results.
+Why does this matter? Because everything about LLMs is priced and bounded in tokens. Context windows are measured in tokens. API costs are per-token. Rate limits count tokens. Frontier models today ship 200K-to-1M-token context windows -- a 1M window is roughly 750,000 words, or about 2,500 pages of prose. That sounds enormous. It's still less than you think once you start filling it with system prompts, conversation history, retrieved documents, and tool results, and -- as the next section covers -- a big window doesn't mean the model reads all of it equally well.
 
 Here's a quick estimator:
 
@@ -110,15 +110,15 @@ print(f"Estimated tokens: {tokens}")
 The 4-characters-per-token rule is a rough approximation. It's wrong for individual strings, but accurate enough in aggregate for cost planning and context budgeting. Use `tiktoken` when you need precision.
 </Callout>
 
-Now the cost math. This is where engineers need to pay attention because costs sneak up on you:
+Now the cost math. This is where engineers need to pay attention because costs sneak up on you. The table below is Anthropic-only -- for other providers, check their pricing pages directly (OpenAI's is at [developers.openai.com/api/docs/pricing](https://developers.openai.com/api/docs/pricing)):
 
 ```python
 # Pricing per 1M tokens: (prompt_price, completion_price)
+# Anthropic only. Pricing checked: 2026-07-02, via
+# https://platform.claude.com/docs/en/about-claude/pricing
 MODEL_PRICING = {
-    "gpt-4o":                     (2.50, 10.00),
-    "gpt-4o-mini":                (0.15,  0.60),
-    "claude-sonnet-4-20250514":   (3.00, 15.00),
-    "claude-haiku-4-5-20251001":  (0.80,  4.00),
+    "claude-sonnet-5":            (3.00, 15.00),
+    "claude-haiku-4-5-20251001":  (1.00,  5.00),
 }
 
 def estimate_cost(prompt_tokens: int, completion_tokens: int, model: str) -> float:
@@ -127,7 +127,7 @@ def estimate_cost(prompt_tokens: int, completion_tokens: int, model: str) -> flo
            (completion_tokens / 1_000_000) * completion_price
 
 # One call: cheap
-cost_one = estimate_cost(prompt_tokens=1000, completion_tokens=500, model="claude-sonnet-4-20250514")
+cost_one = estimate_cost(prompt_tokens=1000, completion_tokens=500, model="claude-sonnet-5")
 print(f"One call: ${cost_one:.4f}")
 # One call: $0.0105
 
@@ -137,11 +137,15 @@ print(f"10,000 calls: ${cost_day:.2f}")
 # 10,000 calls: $105.00
 ```
 
+Sonnet's sticker price above is the standard rate. As of this check, Anthropic is also running introductory pricing on Sonnet ($2.00/$10.00 per million tokens) through 2026-08-31 -- re-check the [pricing page](https://platform.claude.com/docs/en/about-claude/pricing) before you budget against it, since promotional rates expire and standard rates don't.
+
 <Callout type="tip" label="What just happened">
 A single API call costs fractions of a cent. But agents make multiple calls per request, and production systems handle thousands of requests per day. The arithmetic compounds fast. An agent that averages 5 model calls per request at $0.01 each, serving 10,000 requests a day, costs $500/day. Know this number before you ship.
 </Callout>
 
-Notice that completion tokens are 3-5x more expensive than prompt tokens across every provider. This is not arbitrary. Generating tokens requires sequential computation, while reading prompt tokens can be partially parallelized. The practical implication: an agent that generates long, verbose reasoning is more expensive than one that generates concise answers, even if they read the same context.
+Notice that completion tokens are 3-5x more expensive than prompt tokens across every major provider. This is not arbitrary. Generating tokens requires sequential computation, while reading prompt tokens can be partially parallelized. The practical implication: an agent that generates long, verbose reasoning is more expensive than one that generates concise answers, even if they read the same context.
+
+One more variable belongs in this math: prompt caching. If your agent resends the same system prompt, tool definitions, or reference documents across calls -- and most agents do -- the repeated portion can be cached instead of reprocessed at full price. A cache write costs a little more than a normal read (roughly 1.25x for a short-lived cache, 2x for a longer-lived one), but a cache hit costs roughly 10% of the standard input price -- a discount of roughly 90% on the tokens you didn't have to re-process from scratch. That changes the arithmetic above: an agent resending 6,000 tokens of retrieved context on every tool-use round looks expensive until that context is a cache hit rather than a fresh read. Cache pricing checked: 2026-07-02, same [pricing page](https://platform.claude.com/docs/en/about-claude/pricing).
 
 <figure>
   <img src="/assets/diagrams/token-cost-calculator.svg" alt="Token cost breakdown showing prompt tokens, completion tokens, and total cost across models" />
@@ -150,13 +154,13 @@ Notice that completion tokens are 3-5x more expensive than prompt tokens across 
 
 ## The context window is your entire working memory
 
-Think of the context window as RAM for the conversation. Everything the model knows about your current request has to fit inside it. The system prompt, the user's message, the full conversation history, any documents you retrieved, the results from tool calls, all of it competes for one fixed-size bucket.
+Think of the context window as RAM for the conversation. Everything the model knows about your current request has to fit inside it. The system prompt, the user's message, the full conversation history, any documents you retrieved, the results from tool calls, all of it competes for one fixed-size bucket -- and, as this section covers, not every part of that bucket gets read with equal attention.
 
 This is the constraint that shapes every architectural decision in this book.
 
 When you build a RAG system, you're deciding what to put in the context window. When you design a multi-turn agent, you're managing what stays in the context window across steps. When you pick a chunking strategy for documents, you're optimizing for what fits in the context window.
 
-Here's what a typical context window looks like for an agent request:
+Here's what a typical context window looks like for an agent request, sized against a 200K-token window -- the low end of what frontier models ship today, with several offering up to 1M:
 
 ```
 ┌─────────────────────────────────────────┐
@@ -168,26 +172,25 @@ Here's what a typical context window looks like for an agent request:
 │ Current user message       ~200 tokens  │
 │─────────────────────────────────────────│
 │ TOTAL                   ~11,000 tokens  │
-│ Remaining (128K model)  ~117,000 tokens │
-│ Remaining (8K model)      OVERFLOW      │
+│ Remaining (200K model)  ~189,000 tokens │
 └─────────────────────────────────────────┘
 ```
 
-That 117,000 token remainder looks comfortable. But add a 50-page document (roughly 37,000 tokens) and three rounds of agent tool use (each round adds the tool call, the result, and the model's analysis), and you're burning through context fast.
+That much headroom looks like the overflow problem is solved, and it mostly is: five years ago, a model with an 8K-token window would have hit OVERFLOW on that same request before you added a single document -- crashing outright used to be this section's headline failure mode. Today's larger windows genuinely fixed that. But headroom is not the same as reliability, and a bigger bucket introduced a subtler failure in its place.
 
-The dangerous part: when context overflows, the model doesn't crash. It degrades silently. Quality drops. The model starts ignoring instructions, especially the ones at the beginning of the context (your system prompt). It misses relevant information buried in the middle. You won't get an error. You'll get a worse answer with no indication that anything went wrong.
+The dangerous part: when the model reads a large context, it doesn't attend to every token equally. Quality degrades on information buried in the middle of a long context, even when that information comfortably fits. The model starts ignoring instructions, especially ones sandwiched between a long system prompt and a large retrieved document. You won't get an error. You'll get a worse answer with no indication that anything went wrong -- the same silent-degradation problem overflow used to cause, just triggered by position instead of size.
 
-"Lost in the middle" is a well-documented phenomenon. Models pay the most attention to the beginning and end of the context, and less attention to the middle. When you add a 50-page document to the context, something gets pushed out or ignored. Usually it's the instructions you put at the beginning.
+"Lost in the middle" is the name for this, and it's not a vague observation. Liu et al.'s ["Lost in the Middle: How Language Models Use Long Contexts"](https://arxiv.org/abs/2307.03172) (arXiv:2307.03172) measured it directly: models retrieve information from the start and end of a context reliably, and retrieval degrades for information placed in the middle, a pattern that has persisted across model generations even as windows grew from thousands of tokens to hundreds of thousands. A vendor's needle-in-a-haystack benchmark at launch is not the same guarantee as your production prompt structure avoiding this effect -- see [/signal/002-when-long-context-replaces-rag/](/signal/002-when-long-context-replaces-rag/) for the fuller argument and the literature behind it.
 
 <Callout type="warn" label="Failure case study: the instruction that vanished">
-A document-analysis agent had a system prompt that began with "Always respond in JSON format." It worked perfectly in testing with short documents. In production, users started uploading 50-page contracts, roughly 40,000 tokens of retrieved text. The model began responding in prose, ignoring the JSON instruction entirely. No error. No warning. The system prompt was still there, just buried under so much context that the model stopped attending to it. The fix was two-fold: put critical formatting instructions both at the start AND end of the context (bracketing), and switch to provider-level structured output enforcement so the format constraint was not dependent on the model's attention.
+Picture a document-analysis agent whose system prompt begins with "Always respond in JSON format." It works perfectly in testing with short documents. In production, users upload long contracts, and the retrieved text sits between the system prompt and the user's question. The model starts responding in prose, ignoring the JSON instruction, with no error and no warning -- the instruction is still in the context, just positioned somewhere the model attends to less. Two fixes address this: put critical formatting instructions both at the start AND end of the context (bracketing), and use provider-level structured output enforcement so the format constraint doesn't depend on the model's attention at all.
 </Callout>
 
 This is why context management is engineering, not just prompt writing. The decisions about what goes into the context, in what order, and what gets dropped when space is tight, these are architectural decisions with direct impact on system quality.
 
 <figure>
-  <img src="/assets/diagrams/context-window-bucket.svg" alt="The context window as a bucket being filled with system prompt, history, documents, and tool results" />
-  <figcaption>Figure 0a.3: The context window. Everything competes for one fixed-size bucket. Overflow is silent.</figcaption>
+  <img src="/assets/diagrams/context-window-bucket.svg" alt="The context window as a bucket being filled with system prompt, history, documents, and tool results, with attention fading toward the middle" />
+  <figcaption>Figure 0a.3: The context window. Everything competes for one fixed-size bucket, and the model doesn't read all of it equally.</figcaption>
 </figure>
 
 ## Why it hallucinates (and why you can't prompt it away)
@@ -199,7 +202,7 @@ This is not a bug to fix. It is a fundamental property of how these models work.
 You will read advice telling you to add "only answer based on the provided context" to your system prompt. This helps. It reduces the rate of hallucination. It does not solve the problem. The model can and will still generate plausible-sounding text that isn't supported by the context. I've seen models cite specific paragraph numbers from documents that don't have paragraph numbers. I've seen them invent API endpoints with correct-looking URL structures and reasonable-sounding parameter names. The text looks right because the model is very good at producing text that looks right.
 
 <Callout type="warn" label="Failure case study: the citation that looked right">
-A research assistant agent was asked to summarize findings from a set of uploaded documents and cite its sources. It returned: "According to Document 3, Section 4.2, page 17, the failure rate exceeds 12%." The response looked credible. But Document 3 had no numbered sections, was only 5 pages long, and never mentioned failure rates. The model generated a citation that matched the structural pattern of academic references without any grounding in the actual content. The fix: every citation the model produces must be verified in code. Extract the claimed source, look up the actual text, and confirm the claim appears there. If it does not, flag it or drop it. Never pass model-generated citations through to users without programmatic verification.
+Picture a research assistant agent asked to summarize findings from a set of uploaded documents and cite its sources. It returns: "According to Document 3, Section 4.2, page 17, the failure rate exceeds 12%." The response looks credible. But Document 3 has no numbered sections, is a few pages long, and never mentions failure rates. The model generated a citation that matched the structural pattern of academic references without any grounding in the actual content. The fix: every citation the model produces must be verified in code. Extract the claimed source, look up the actual text, and confirm the claim appears there. If it does not, flag it or drop it. Never pass model-generated citations through to users without programmatic verification.
 </Callout>
 
 Every reliable mitigation for hallucination is engineering, not prompting.
@@ -229,13 +232,11 @@ When the model generates the next token, it doesn't pick one deterministically (
 
 **Temperature above 1.0:** The distribution is nearly flat and output becomes increasingly incoherent. In production agent systems, there is almost no reason to go above 1.0. In research or creative applications, controlled high temperature paired with top-p sampling can be useful for exploring the edges of a distribution. For everything in this book, stay at or below 0.3.
 
-For agents, default to temperature 0 for decision-making steps. Tool selection, routing, structured extraction, and any step where you need predictable, testable behavior. When your agent is deciding whether to call the search tool or the calculator, you want it to make the same decision every time for the same input. For generative sub-steps where variety helps, bring temperature up slightly, but keep it bounded.
-
 ```python
 from src.shared.model_client import create_client
 from src.shared.types import CompletionRequest, Message, Role
 
-client = create_client(provider="anthropic", api_key="...", model_name="claude-sonnet-4-20250514")
+client = create_client(provider="anthropic", api_key="...", model_name="claude-sonnet-5")
 
 # Temperature 0: deterministic, same answer every time
 request_deterministic = CompletionRequest(
@@ -348,6 +349,8 @@ I think the right default is to use provider-level schema enforcement whenever i
 
 Parsing is step one. But "valid JSON" is not the same as "data I can trust." Production systems need three layers of validation after parsing: schema validation, semantic validation, and a clear failure policy.
 
+This snippet is illustrative -- unlike the other code samples in this chapter, it isn't backed by a file in the companion repo. Adapt the pattern to your own validation needs rather than importing it directly.
+
 ```python
 from pydantic import BaseModel, Field, ValidationError
 from datetime import date
@@ -358,6 +361,10 @@ class ExtractionResult(BaseModel):
     confidence: float = Field(ge=0.0, le=1.0)
     source_document: str
     extracted_date: date
+
+
+class ExtractionError(Exception):
+    """Raised when structured extraction exhausts its retry budget."""
 
 # Layer 2: Semantic validation
 def validate_semantics(result: ExtractionResult, available_docs: list[str]) -> list[str]:
@@ -413,7 +420,7 @@ async def extract_with_validation(
 The key principle: if structured output fails after your retry budget, return a typed error, not a raw string. Your downstream code should never have to guess whether it received valid data. Either it gets a validated `ExtractionResult`, or it gets an `ExtractionError` it can handle explicitly.
 
 <Callout type="warn" label="Failure case study: valid JSON, invalid data">
-A classification agent returned `{"confidence": 1.5, "category": "high_risk", "review_date": "next Tuesday"}`. The JSON parsed without errors. The downstream routing logic treated 1.5 as a valid confidence score, escalated the case as ultra-high-confidence, and logged "next Tuesday" as a date string that broke the reporting pipeline three hours later when a batch job tried to parse it. Schema validation (Pydantic) would have caught the confidence value immediately. Semantic validation would have caught the non-ISO date. Without the validation ladder, syntactically correct garbage flows downstream and breaks things far from the source.
+Picture a classification agent that returns `{"confidence": 1.5, "category": "high_risk", "review_date": "next Tuesday"}`. The JSON parses without errors. Without a validation layer, downstream routing logic would treat 1.5 as a valid confidence score, escalate the case as ultra-high-confidence, and pass "next Tuesday" along as a date string that breaks the first batch job that tries to parse it. Schema validation (Pydantic) catches the confidence value immediately. Semantic validation catches the non-ISO date. Without the validation ladder, syntactically correct garbage flows downstream and breaks things far from the source.
 </Callout>
 
 ## Putting it together
@@ -422,6 +429,13 @@ You now have a mental model of the machine you are building with. It takes text,
 
 Now that you know the model is probabilistic, bounded by context, vulnerable to unsupported confident text, and unreliable at structure by default, the next engineering problems are concrete: How do you give it tools with contracts it cannot violate? How do you assemble context that fits the window without losing critical instructions? How do you evaluate whether the system actually works, not just looks like it works? And how do you bound its autonomy so it fails gracefully instead of confidently?
 
-The next three sections build these answers. Section 0b gives the model hands. Section 0c gives it a loop. Section 0d shows you what frameworks do with both.
+The next three sections build these answers. Section 0b gives the model hands. Section 0c gives it a loop -- [FN-004](/field-notes/004-loop-engineering-30-year-old-loop/) has more on why the stop condition inside that loop is the hard, still-unsolved part. Section 0d shows you what frameworks do with both.
 
-For hands-on experiments with everything in this section, see the [LLM Explorer](/book/projects/llm-explorer/) project.
+For hands-on experiments with everything in this section, see the [LLM Explorer](/projects/llm-explorer/) project.
+
+## Further reading
+
+- **[Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)** -- Liu et al., 2023 (arXiv:2307.03172). The paper behind the position-dependent degradation this chapter's context-window section describes.
+- **[Build a Large Language Model (From Scratch)](https://www.manning.com/books/build-a-large-language-model-from-scratch)** -- Raschka, 2024. The internals this chapter deliberately skips.
+- **[Pricing](https://platform.claude.com/docs/en/about-claude/pricing)** -- Anthropic. Official per-model, per-feature pricing, including the prompt-caching multipliers used in this chapter's cost math. Checked 2026-07-02.
+- **[API pricing](https://developers.openai.com/api/docs/pricing)** -- OpenAI. For comparing costs across providers.

--- a/src/content/chapters/00a-how-llms-work.mdx
+++ b/src/content/chapters/00a-how-llms-work.mdx
@@ -148,8 +148,8 @@ Notice that completion tokens are 3-5x more expensive than prompt tokens across 
 One more variable belongs in this math: prompt caching. If your agent resends the same system prompt, tool definitions, or reference documents across calls -- and most agents do -- the repeated portion can be cached instead of reprocessed at full price. A cache write costs a little more than a normal read (roughly 1.25x for a short-lived cache, 2x for a longer-lived one), but a cache hit costs roughly 10% of the standard input price -- a discount of roughly 90% on the tokens you didn't have to re-process from scratch. That changes the arithmetic above: an agent resending 6,000 tokens of retrieved context on every tool-use round looks expensive until that context is a cache hit rather than a fresh read. Cache pricing checked: 2026-07-02, same [pricing page](https://platform.claude.com/docs/en/about-claude/pricing).
 
 <figure>
-  <img src="/assets/diagrams/token-cost-calculator.svg" alt="Token cost breakdown showing prompt tokens, completion tokens, and total cost across models" />
-  <figcaption>Figure 0a.2: Token costs per model. Completion tokens always cost more than prompt tokens.</figcaption>
+  <img src="/assets/diagrams/token-cost-calculator.svg" alt="Token cost breakdown at illustrative rates: prompt and completion tokens for one call, then the cost compounding at production volume" />
+  <figcaption>Figure 0a.2: Token costs at illustrative rates ($3 in, $15 out per million tokens). Completion tokens cost more than prompt tokens, and production volume compounds the difference.</figcaption>
 </figure>
 
 ## The context window is your entire working memory

--- a/src/content/chapters/00b-api-to-tools.mdx
+++ b/src/content/chapters/00b-api-to-tools.mdx
@@ -16,7 +16,7 @@ import Callout from '~/components/universal/Callout.astro';
 
 In the last section, the model could only talk. In this one, it learns to do things. The difference is smaller than you think: about 15 lines of code.
 
-Here is what actually happens when a model "uses a tool": your code sends a list of function signatures to the API. The model reads those signatures and, instead of returning a text response, returns a JSON blob that says "call this function with these arguments." Your code calls the function. You send the result back to the model. The model uses the result to generate a text response. That's the entire mechanism. No remote procedure calls. No plugin system. No runtime loaded from the model's side. The model writes JSON. You do the work.
+Here is what actually happens when a model "uses a tool": your code sends a list of function signatures to the API. The model reads those signatures and, instead of returning a text response, returns a JSON blob that says "call this function with these arguments." Your code calls the function. You send the result back to the model. The model uses the result to generate a text response. That's the entire mechanism. No remote procedure calls. No plugin system. No runtime loaded from the model's side. The model writes JSON. You do the work. [Anthropic's tool-use guide](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview) documents this same request/response contract from one provider's side; every other major API follows the same shape.
 
 Before we get to function calling, though, we need to talk about the two techniques that make it actually work in production: structured prompting and few-shot examples. These aren't optional. They're the difference between a system that works in demos and one that works at 2am when you're asleep.
 
@@ -46,10 +46,10 @@ Rules:
 ```
 
 <Callout type="tip" label="What just happened">
-The second prompt specifies the domain, the input format, the output schema, the calculation method, the edge case handling, and what to omit. Every one of those constraints reduces variance in the output. Each constraint is testable. You can write an assertion that checks whether the output matches the JSON schema. You can verify the growth calculation is correct. You can confirm there's no commentary outside the JSON. You can't test "be helpful."
+The second prompt specifies the domain, the input format, the output schema, the calculation method, the edge case handling, and what to omit. Each constraint is testable: you can assert the output matches the JSON schema, verify the growth calculation, confirm there's no commentary outside the JSON. You can't test "be helpful."
 </Callout>
 
-The principle is straightforward: every ambiguity in your prompt is a degree of freedom the model will use in ways you didn't intend. Remove them. Specify the format. Specify the edge cases. Specify what not to do. Treat your system prompt as a contract, the same way you'd treat a function signature or an API spec.
+The principle: every ambiguity in a prompt is a degree of freedom the model will use in ways you didn't intend. Treat your system prompt as a contract, the same way you'd treat a function signature or an API spec.
 
 Version your prompts in source control. When output quality degrades, `git diff` the prompt. When you swap models, run your prompt test suite. This is not overhead. This is the minimum viable engineering practice for systems that depend on natural language interfaces.
 
@@ -90,7 +90,7 @@ Return only the category name, lowercase, no punctuation."""},
 ```
 
 <Callout type="tip" label="What just happened">
-Two examples did more than a paragraph of instructions. The model saw the pattern: one word, lowercase, no explanation. It follows that pattern. Few-shot examples are like type annotations for natural language. They constrain the output space by demonstration rather than description.
+Two examples did more than a paragraph of instructions. The model saw the pattern -- one word, lowercase, no explanation -- and followed it. That's the mechanism: demonstration constrains the output space more reliably than description.
 </Callout>
 
 Two to three examples is the sweet spot for most tasks. One example can be dismissed as coincidence. Four or more starts eating context budget without proportional improvement. Pick examples that cover your edge cases: one straightforward case, one boundary case, and one that's easy to get wrong.
@@ -101,21 +101,22 @@ Few-shot examples are particularly powerful for tool-using systems. When the mod
 
 This is the core mechanism. Every agent framework wraps it. Every tool-using system depends on it. And there is no magic. The model outputs JSON that says "call this function with these arguments." Your code does the calling.
 
-The cycle has four steps:
+The cycle has five steps:
 
 1. You define tool schemas (JSON that tells the model what tools exist)
 2. You send those schemas alongside the user's message
 3. The model responds with a structured tool call (not text, but a JSON object naming the function and its arguments)
 4. Your code validates the arguments, executes the function, and returns the result
+5. You send that result back to the model, which reads it and generates a final text response
 
 <figure>
-  <img src="/assets/diagrams/function-calling-cycle.svg" alt="The four-step function calling cycle: define schema, send with message, model returns tool call JSON, your code executes" />
+  <img src="/assets/diagrams/function-calling-cycle.svg" alt="The five-step function calling cycle: define schema, send with message, model returns tool call JSON, your code executes, then sends the result back for the model's final answer" />
   <figcaption>Figure 0b.1: The function calling cycle. The model never executes anything. It writes JSON. You do the work.</figcaption>
 </figure>
 
 Let's build this from scratch. First, we need a way to define tools.
 
-The code below uses Pydantic, a Python library for data validation using type annotations. If you have used dataclasses, think of Pydantic as dataclasses with built-in validation: you declare fields with types, and Pydantic rejects any input that does not match. `BaseModel` is the base class. `Field` adds constraints like minimum values or defaults. `model_validate()` checks a dictionary against the type annotations and raises `ValidationError` if anything is wrong. We use it here because the model will send us JSON arguments, and we need to validate those arguments before running any code.
+The code below uses [Pydantic](https://pydantic.dev/docs/validation/latest/concepts/models/), a Python library for data validation using type annotations. If you have used dataclasses, think of Pydantic as dataclasses with built-in validation: you declare fields with types, and Pydantic rejects any input that does not match. `BaseModel` is the base class. `Field` adds constraints like minimum values or defaults. `model_validate()` checks a dictionary against the type annotations and raises `ValidationError` if anything is wrong. We use it here because the model will send us JSON arguments, and we need to validate those arguments before running any code.
 
 Here is the `Tool` class and `ToolRegistry` from this book's companion code:
 
@@ -209,6 +210,8 @@ def calculator(operation: str, a: float, b: float) -> str:
 And a search tool:
 
 ```python
+import json
+
 class SearchInput(BaseModel):
     """Input schema for the fake search tool."""
     query: str
@@ -277,6 +280,8 @@ Now let's see what happens on the other side. When the model decides to use a to
 Your code receives this, looks up the tool in the registry, validates the arguments, and executes the function:
 
 ```python
+from pydantic import ValidationError
+
 def execute_tool_call(
     registry: ToolRegistry, tool_name: str, arguments: dict[str, Any]
 ) -> str:
@@ -300,7 +305,7 @@ def execute_tool_call(
 Three things happen in `execute_tool_call`: lookup, validation, execution. The lookup catches hallucinated tool names. The validation (via Pydantic's `model_validate`) catches malformed arguments before they reach your function. The try/except around execution catches runtime errors. Each layer returns a string error instead of crashing, because this error message gets sent back to the model as the tool result. The model can then apologize, retry with different arguments, or try a different tool. Crashing would end the conversation.
 </Callout>
 
-Here's the full flow wired together:
+Called directly, `execute_tool_call()` demonstrates steps 3 and 4 in isolation -- a hardcoded call standing in for what the model would send, then validation and dispatch:
 
 ```python
 registry = create_default_registry()
@@ -322,7 +327,74 @@ print(result)
 # "Error: division by zero"
 ```
 
-That is the entire mechanism behind function calling. You defined a Pydantic model, wrote `to_schema()` to generate the JSON schema, built `execute_tool_call()` to validate and dispatch. Every major framework automates exactly these three steps. LangChain's `@tool` decorator reads your type hints and generates the schema. Google ADK's `FunctionTool` reads the docstring. CrewAI's tool registration does the same. The pattern is identical; only the syntax changes. You built it by hand so you understand what the framework is doing when it hides these lines from you. Section 0d will show you the same tools wrapped in ADK and LangChain, and you will see that the 30 lines of schema and validation machinery you just wrote collapse into a single decorator.
+That covers steps 3 and 4 with a hardcoded stand-in for the model's request. To see all five steps run together -- schema out, tool call back, execute, result back, final answer -- wire in a client. `MockClient` is this book's provider-neutral stand-in for a real API: it returns canned responses in order, so the example runs with no API key and no network call, but the request/response shapes (`CompletionRequest`, `CompletionResponse`, `Message`, `ToolCall`, `ToolResult`) are the same ones a real `AnthropicClient` or `OpenAIClient` would produce:
+
+```python
+import asyncio
+
+from src.shared.model_client import MockClient
+from src.shared.types import (
+    CompletionRequest,
+    CompletionResponse,
+    Message,
+    Role,
+    TokenUsage,
+    ToolCall,
+    ToolResult,
+)
+
+
+async def ask(question: str) -> str:
+    registry = create_default_registry()
+    messages = [Message(role=Role.USER, content=question)]
+
+    # Canned responses in order: the tool call, then the final text answer --
+    # the same two round trips a live model makes.
+    client = MockClient(
+        responses=[
+            CompletionResponse(
+                tool_calls=[
+                    ToolCall(id="call_001", name="calculator",
+                              arguments={"operation": "multiply", "a": 6, "b": 7}),
+                ],
+                model="mock",
+                usage=TokenUsage(prompt_tokens=42, completion_tokens=18, total_tokens=60),
+            ),
+            CompletionResponse(content="6 times 7 is 42.", model="mock"),
+        ]
+    )
+
+    # Steps 1-2: schemas travel alongside the message list.
+    request = CompletionRequest(messages=messages, tools=registry.get_schemas())
+
+    # Step 3: the model returns a tool call instead of text.
+    response = await client.complete(request)
+    tool_call = response.tool_calls[0]
+
+    # Step 4: your code validates and executes.
+    result = execute_tool_call(registry, tool_call.name, tool_call.arguments)
+
+    # Step 5: append the call and its result, then ask again.
+    messages.append(Message(role=Role.ASSISTANT, content="", tool_calls=[tool_call]))
+    messages.append(Message(
+        role=Role.TOOL,
+        content="",
+        tool_results=[ToolResult(tool_call_id=tool_call.id, name=tool_call.name, content=result)],
+    ))
+    final_request = CompletionRequest(messages=messages, tools=registry.get_schemas())
+    final_response = await client.complete(final_request)
+    return final_response.content
+
+
+print(asyncio.run(ask("What is 6 times 7?")))
+# "6 times 7 is 42."
+```
+
+<Callout type="tip" label="What just happened">
+The assistant message carries the tool call structurally, in `tool_calls`, not encoded into `content` -- that's what lets a real provider client serialize a proper tool-call block instead of a plain-text stand-in it can't reconcile with the result that follows. The tool message carries the result the same way, in `tool_results`. Both messages get appended to the list before the second `client.complete()` call, so the model sees the full exchange: what it asked for, and what came back.
+</Callout>
+
+That is the entire mechanism behind function calling. You defined a Pydantic model, wrote `to_schema()` to generate the JSON schema, built `execute_tool_call()` to validate and dispatch, and appended the result so the model could close the loop with a final answer. Every major framework automates exactly these steps: LangChain's `@tool` decorator and Google ADK's `FunctionTool` both read your type hints for the schema and your docstring for the description; only the syntax differs. CrewAI's tool registration follows the same pattern. You built it by hand so you understand what the framework is doing when it hides these lines from you. Section 0d covers the framework-specific syntax.
 
 ## Schema validation is your safety net
 
@@ -388,13 +460,10 @@ print(result)
 ```
 
 <Callout type="warn" label="Failure case study: the hallucinated argument that almost caused silent corruption">
-A data pipeline agent had a `write_record` tool that accepted a `priority` field: an integer from 1 (low) to 5 (critical). Without Pydantic validation, the model passed `priority: 10` for a routine log entry. The write succeeded. No error. The record was stored with priority 10, which was outside the application's expected range. Downstream alerting logic treated anything above 5 as a system emergency and paged the on-call team at 3am. With `Field(ge=1, le=5)` on the Pydantic model, the validation error would have been caught before the write, the model would have received "Input should be less than or equal to 5," and it would have retried with a valid value. The gap between "the function accepts an int" and "the function accepts an int between 1 and 5" is where silent data corruption lives.
+A representative failure, composited from patterns seen across data pipeline agents: a `write_record` tool accepts a `priority` field, an integer from 1 (low) to 5 (critical). Without Pydantic validation, the model passes `priority: 10` for a routine log entry. The write succeeds. No error. Downstream alerting logic treats anything above 5 as a system emergency and fires an unnecessary incident page. With `Field(ge=1, le=5)` on the Pydantic model, the validation error is caught before the write, the model receives "Input should be less than or equal to 5," and it retries with a valid value. The gap between "the function accepts an int" and "the function accepts an int between 1 and 5" is where silent data corruption lives.
 </Callout>
 
-<figure>
-  <img src="/assets/diagrams/tool-selection-comparison.svg" alt="Comparison of tool calls with and without schema validation, showing clean errors vs runtime crashes" />
-  <figcaption>Figure 0b.2: Schema validation turns runtime crashes into structured errors that the model can learn from.</figcaption>
-</figure>
+{/* diagram slot: schema validation -- see FR Task 7 */}
 
 Validation isn't just about preventing crashes. It's about giving the model enough information to self-correct. A model that receives "Validation error: Input should be 'add', 'subtract', 'multiply' or 'divide'" will fix its next attempt. A model that receives "Error: unhandled exception in tool execution" will guess, and guess wrong.
 
@@ -414,7 +483,7 @@ When you send a message like "What is 42 times 17?" along with all three tool sc
 
 This works because the tool descriptions are clear and distinct. The model selects tools by matching the user's intent to the tool descriptions. This is not semantic search. It is not embeddings. It is the model reading your descriptions and making a judgment call, the same way a person would read an API catalog and pick the right endpoint.
 
-Tool descriptions are your API documentation for the model. Write them like you'd write docs for a junior developer who takes everything literally. Because that is exactly what the model is doing: reading your description literally and picking the tool that sounds most relevant.
+Tool descriptions are your API documentation for the model. Write them like you'd write docs for a junior developer who takes everything literally -- because that's exactly what's happening on the other side.
 
 Here are the descriptions from the companion code:
 
@@ -442,7 +511,7 @@ registry.register(
 ```
 
 <Callout type="tip" label="What just happened">
-Each description is one sentence that says what the tool does, not how it works. The model doesn't need to know that the calculator uses Python's arithmetic operators or that the search function returns mock data. It needs to know when to use each tool. "Perform basic arithmetic" tells it to use this tool for math. "Count the number of words" tells it to use this tool for word counting. Descriptions are selection criteria, not implementation details.
+Each description says what the tool does, not how it works -- the model doesn't need to know the calculator uses Python's arithmetic operators or that search returns mock data, only when to reach for each one. "Perform basic arithmetic" routes math queries here; "Count the number of words" routes word-counting queries there.
 </Callout>
 
 When does the model choose wrong? When the descriptions overlap or when the query is ambiguous. Consider this message: "What's the word count of 'four score and seven years ago'?"
@@ -461,9 +530,16 @@ A few practical guidelines for tool descriptions:
 
 **Don't describe the implementation.** "Uses a PostgreSQL full-text search index with ts_vector" is irrelevant to the model. "Search the knowledge base for documents matching a query" is what it needs.
 
+One more lever, borrowed from the few-shot technique earlier in this section: if descriptions alone leave the model picking the wrong tool, show it two or three examples of query-to-tool selection in the message history, the same way you'd show it examples of a classification format. The model generalizes a selection pattern the same way it generalizes an output format.
+
 <Callout type="warn" label="Failure case study: the vague description">
-A customer support agent had two tools: `get_order` ("Get order information") and `get_account` ("Get account information"). When users asked "Where's my package?", the model picked `get_account` about 40% of the time. Both descriptions mentioned "information" without saying what kind. The fix: change `get_order` to "Look up shipping status, delivery date, and tracking number for a specific order ID" and `get_account` to "Retrieve account profile, billing address, and payment methods for a customer." After that change, routing accuracy on order-tracking queries went from ~60% to over 95%. The model was not confused about the task. It was confused about which tool matched the task. Specific descriptions fixed it.
+A pattern common enough to be worth a composite example: a customer support agent has two tools, `get_order` ("Get order information") and `get_account` ("Get account information"). When users ask "Where's my package?", the model frequently picks `get_account` instead. Both descriptions mention "information" without saying what kind. The fix: change `get_order` to "Look up shipping status, delivery date, and tracking number for a specific order ID" and `get_account` to "Retrieve account profile, billing address, and payment methods for a customer." Routing accuracy on order-tracking queries improves markedly. The model was not confused about the task. It was confused about which tool matched the task. Specific descriptions fixed it.
 </Callout>
+
+<figure>
+  <img src="/assets/diagrams/tool-selection-comparison.svg" alt="Side-by-side comparison: a precise tool description leads the model to correctly select the calculator tool for an arithmetic query, while a vague description leads it to select the wrong tool for the same query" />
+  <figcaption>Figure 0b.2: Tool descriptions drive selection accuracy. A vague description sends the model to the wrong tool; a precise one does not.</figcaption>
+</figure>
 
 When you have more than five or six tools, the model's selection accuracy starts to degrade. Not because it can't read six descriptions, but because the probability of description overlap increases. If you find yourself registering fifteen tools, that's an architectural signal. Split them into groups. Use a routing step where one model call picks the category, then a second call picks the specific tool within that category. Chapter 4 covers this pattern in depth.
 
@@ -488,22 +564,23 @@ That loop is the subject of the next section.
 
 ## Putting it together
 
-You've gone from text-in-text-out to a system that can act. It can calculate, search, and analyze. The model reads tool schemas, decides which tool to call, and returns structured JSON with the function name and arguments. Your code validates those arguments with Pydantic, executes the function, and returns the result. Every tool-using system you'll encounter, from simple chatbot plugins to complex agent frameworks, is built on this cycle.
+You've gone from text-in-text-out to a system that can act: read schemas, decide, call, validate, execute, close the loop with a final answer. Every tool-using system you'll encounter, from chatbot plugins to agent frameworks, is built on this cycle.
 
-The key insights from this section:
+Key takeaways:
 
-System prompts are code. Version them, test them, specify them precisely. Every ambiguity is a bug waiting to happen.
+- **System prompts are code.** Version them, test them, specify precisely.
+- **Few-shot beats prose.** Two examples constrain output more reliably than two paragraphs of instructions.
+- **Function calling is JSON in, JSON out.** The model requests, your code fulfills. No magic on either side.
+- **Schema validation isn't optional.** The model will hallucinate arguments; Pydantic catches them and hands back an error the model can act on.
+- **Tool descriptions are selection criteria**, not documentation -- write for a literal reader.
+- **The limit is single-turn.** One tool call, one result, then stop -- the gap the next section closes.
 
-Few-shot examples are the most effective technique for consistent output. Two examples beat two paragraphs of instructions.
-
-Function calling is JSON in, JSON out. The model writes a request. Your code fulfills it. There is no magic on either side.
-
-Schema validation isn't optional. The model will hallucinate arguments. Pydantic catches the bad ones before they reach your functions, and the structured error messages give the model enough information to self-correct.
-
-Tool descriptions are selection criteria. Write them for a literal reader who will pick the tool that sounds most relevant to the query.
-
-And the limitation: all of this operates in a single turn. One tool call, one result. The model cannot look at a search result and decide "that's not what I needed, let me refine my query." It cannot chain a search, a calculation on the search results, and a summary together. It does one thing, and stops.
-
-The next section adds the loop that removes that ceiling. You will build, in about 100 lines of Python, a system that can observe the result of its action, decide whether it is sufficient, and take another action if it is not. The mechanism is a while loop with an LLM inside it. The engineering challenge is knowing when that loop should stop.
+The next section adds the loop that removes that ceiling: about 100 lines of Python, a while loop with an LLM inside it, and the engineering challenge of knowing when it should stop.
 
 For a fully built tool-using assistant with proper error handling and logging, see the [Tool-Using Assistant](/projects/tool-using-assistant/) project.
+
+## Further reading
+
+- **[Anthropic tool-use guide](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview)** -- How one provider documents the request/response contract this chapter builds by hand.
+- **[Pydantic: Models](https://pydantic.dev/docs/validation/latest/concepts/models/)** -- BaseModel, type-annotated fields, and how validation works.
+- **[Pydantic: Error Handling](https://pydantic.dev/docs/validation/latest/errors/errors/)** -- ValidationError structure and how to read it.

--- a/src/content/chapters/00b-api-to-tools.mdx
+++ b/src/content/chapters/00b-api-to-tools.mdx
@@ -474,12 +474,14 @@ Give the model three tools and a question. Watch what happens.
 ```python
 registry = create_default_registry()
 
-# Three tools registered:
+# Four tools registered:
 print(registry.list_tools())
-# ['calculator', 'word_count', 'search']
+# ['calculator', 'word_count', 'search', 'delete_record']
 ```
 
-When you send a message like "What is 42 times 17?" along with all three tool schemas, the model reads the descriptions and picks `calculator`. When you send "How many words are in the Gettysburg Address?", it picks `word_count`. When you send "Find me information about Rust async patterns," it picks `search`.
+The fourth tool is deliberately gated; Section 0c shows what happens when an agent tries to call it.
+
+When you send a message like "What is 42 times 17?" along with all four tool schemas, the model reads the descriptions and picks `calculator`. When you send "How many words are in the Gettysburg Address?", it picks `word_count`. When you send "Find me information about Rust async patterns," it picks `search`.
 
 This works because the tool descriptions are clear and distinct. The model selects tools by matching the user's intent to the tool descriptions. This is not semantic search. It is not embeddings. It is the model reading your descriptions and making a judgment call, the same way a person would read an API catalog and pick the right endpoint.
 

--- a/src/content/chapters/00b-api-to-tools.mdx
+++ b/src/content/chapters/00b-api-to-tools.mdx
@@ -463,7 +463,10 @@ print(result)
 A representative failure, composited from patterns seen across data pipeline agents: a `write_record` tool accepts a `priority` field, an integer from 1 (low) to 5 (critical). Without Pydantic validation, the model passes `priority: 10` for a routine log entry. The write succeeds. No error. Downstream alerting logic treats anything above 5 as a system emergency and fires an unnecessary incident page. With `Field(ge=1, le=5)` on the Pydantic model, the validation error is caught before the write, the model receives "Input should be less than or equal to 5," and it retries with a valid value. The gap between "the function accepts an int" and "the function accepts an int between 1 and 5" is where silent data corruption lives.
 </Callout>
 
-{/* diagram slot: schema validation -- see FR Task 7 */}
+<figure>
+  <img src="/assets/diagrams/schema-validation.svg" alt="Schema validation as a gate: the model's arguments either pass through to normal execution or fail into a structured error that is sent back to the model as the tool result, so it can correct and retry" />
+  <figcaption>Figure 0b.2: The validation gate. A bad argument becomes a structured error the model can read and retry on, not a crash.</figcaption>
+</figure>
 
 Validation isn't just about preventing crashes. It's about giving the model enough information to self-correct. A model that receives "Validation error: Input should be 'add', 'subtract', 'multiply' or 'divide'" will fix its next attempt. A model that receives "Error: unhandled exception in tool execution" will guess, and guess wrong.
 
@@ -540,7 +543,7 @@ A pattern common enough to be worth a composite example: a customer support agen
 
 <figure>
   <img src="/assets/diagrams/tool-selection-comparison.svg" alt="Side-by-side comparison: a precise tool description leads the model to correctly select the calculator tool for an arithmetic query, while a vague description leads it to select the wrong tool for the same query" />
-  <figcaption>Figure 0b.2: Tool descriptions drive selection accuracy. A vague description sends the model to the wrong tool; a precise one does not.</figcaption>
+  <figcaption>Figure 0b.3: Tool descriptions drive selection accuracy. A vague description sends the model to the wrong tool; a precise one does not.</figcaption>
 </figure>
 
 When you have more than five or six tools, the model's selection accuracy starts to degrade. Not because it can't read six descriptions, but because the probability of description overlap increases. If you find yourself registering fifteen tools, that's an architectural signal. Split them into groups. Use a routing step where one model call picks the category, then a second call picks the specific tool within that category. Chapter 4 covers this pattern in depth.
@@ -555,7 +558,7 @@ An agent can observe the result of its action, decide it's insufficient, and tak
 
 <figure>
   <img src="/assets/diagrams/single-turn-ceiling.svg" alt="Single-turn tool use stops after one action. The agent loop continues: observe, think, act, repeat." />
-  <figcaption>Figure 0b.3: The single-turn ceiling. Tool use without a loop handles one action. The agent loop adds iteration, and that changes everything.</figcaption>
+  <figcaption>Figure 0b.4: The single-turn ceiling. Tool use without a loop handles one action. The agent loop adds iteration, and that changes everything.</figcaption>
 </figure>
 
 Consider a concrete example. A user asks: "What's the population density of the country with the tallest building in the world?"

--- a/src/content/chapters/00c-first-agent.mdx
+++ b/src/content/chapters/00c-first-agent.mdx
@@ -2,11 +2,13 @@
 title: Your First Agent, No Framework
 part: foundations
 description: "Build a complete agent in 100 lines of Python. No framework. No magic. Every line explained, including the ones where it breaks."
-readingTime: 25
+readingTime: 21
 date: 2026-03-17
 references:
   - 00b-api-to-tools
   - 00d-frameworks
+  - 01-what-agentic-means
+  - fn-004
 patterns:
   - agent-loop
   - tool-registry
@@ -15,7 +17,7 @@ status: published
 
 import Callout from '~/components/universal/Callout.astro';
 
-You have a system that can call tools. But it calls them once and stops. What if it could look at the result, decide it's not enough, and try again? That's an agent. The entire concept is a while loop with an LLM inside it. Let's build one.
+You have a system that can call tools, but it calls them once and stops. What if it looked at the result, decided that wasn't enough, and tried again? That's an agent -- the entire concept is a while loop with an LLM inside it. Let's build one.
 
 ## The loop in 20 lines
 
@@ -32,23 +34,21 @@ while steps < budget:
         return response.content  # Model decided it's done
 ```
 
-That's it. That is the core architecture. Every framework, every SDK, every "agent platform" I've looked at wraps some variation of this loop.
+That's the core architecture. Every framework, every SDK, every "agent platform" I've looked at wraps some variation of it.
 
 Read it line by line:
 
-1. **`while steps < budget`** prevents infinite loops. Without a budget, a confused model will call tools forever. This is not theoretical. It will happen on your first real task.
+1. **`while steps < budget`** prevents infinite loops. Without one, a confused model calls tools forever -- not theoretical, it happens on your first real task.
 
-2. **`call_llm(messages)`** sends the full conversation, including all previous tool calls and results, back to the model. The model sees everything that has happened so far and decides what to do next.
+2. **`call_llm(messages)`** sends the full conversation, past tool calls and results included, back to the model each turn.
 
-3. **`if response.has_tool_calls`** is the decision point. The model either wants to take an action (call a tool) or deliver a final answer (return text). There is no third option.
+3. **`if response.has_tool_calls`** is the decision point: act, or answer. No third option.
 
-4. **`execute_tool()`** runs the function locally. The model never executes anything. It writes JSON requesting a function call. Your code does the work.
+4. **`execute_tool()` / `messages.append()`** run the model's requested function locally and feed the result back, so the model "observes" what happened and decides whether to act again.
 
-5. **`messages.append()`** feeds the tool result back into the conversation. This is how the model "observes" the outcome of its action. Next iteration, it sees the result and decides whether to act again or answer.
+5. **`return response.content`** ends the loop cleanly: the model had enough and answered instead of calling again.
 
-6. **`return response.content`** is how the loop ends cleanly. The model decided it has enough information and produced a text answer instead of another tool call.
-
-The loop implements observe-think-act-repeat. This cycle has a name in the literature (ReAct, for Reason + Act), but the pattern predates the paper. It's a control loop with a language model in the middle.
+The loop implements observe-think-act-repeat, a cycle with a name in the literature -- [ReAct](https://arxiv.org/abs/2210.03629), Reason + Act (Yao et al., 2022) -- that predates the paper. Rao and Georgeff described the same shape as a ["main interpreter loop"](https://cdn.aaai.org/ICMAS/1995/ICMAS95-042.pdf) for belief-desire-intention agents in 1995: generate options, deliberate, update intentions, execute, repeat. A control loop with a language model in the middle, decades older than the model itself.
 
 <figure>
   <img src="/assets/diagrams/agent-loop-foundations.svg" alt="The agent loop: observe, think, act, repeat until answer or budget exhaustion" />
@@ -64,7 +64,7 @@ export ANTHROPIC_API_KEY="your-key-here"
 python -m src.ch00.raw_agent "What is 15 * 7 + 3?"
 ```
 
-You will see the trace output shown later in this section. We will walk through the code in pieces first.
+With a key set, this hits the real API and produces the trace below. No key? It still exits cleanly, replaying a canned response for this question. We'll walk through the code in pieces first.
 
 ### The system prompt
 
@@ -80,10 +80,10 @@ SYSTEM_PROMPT = (
 ```
 
 <Callout type="tip" label="What just happened">
-Four sentences. The first establishes the role. The second gives permission to use tools. The third defines the termination condition: respond with text when you have enough information. The fourth prevents over-calling. That last sentence matters more than it looks. Without it, models will call tools "just to be thorough" even when they already know the answer.
+Four sentences: role, permission to use tools, the termination condition, and a stop-calling instruction. That last one matters more than it looks -- without it, models call tools "just to be thorough" even when they already know the answer.
 </Callout>
 
-Notice what the prompt does not say. It doesn't describe how to use the tools (the schemas handle that). It doesn't list which tools exist (the registry provides that). It doesn't say how many steps to take (the budget handles that in code). The system prompt handles intent. Code handles constraints.
+Notice what it doesn't say. No tool usage instructions (schemas handle that), no tool list (the registry provides that), no step count (the budget handles that in code). The prompt handles intent. Code handles constraints.
 
 ### The result type
 
@@ -103,10 +103,8 @@ class AgentResult:
 ```
 
 <Callout type="tip" label="What just happened">
-`AgentResult` captures everything you need to evaluate a run. `answer` is `None` when the budget ran out before the model produced a final answer. `trace` records every tool call and its result, which you'll use for debugging. `budget_exhausted` is the field that tells you something went wrong. In a production system, this dataclass would be the contract between the agent and whatever consumes its output.
+`AgentResult` captures everything you need to evaluate a run: `answer` is `None` when the budget ran out first, `trace` records every tool call and result for debugging, `budget_exhausted` flags something gone wrong. In production, this dataclass is the contract between agent and consumer.
 </Callout>
-
-The `trace` field records every tool call, every argument, every result. When something goes wrong (and it will), the trace is how you figure out what the model was thinking.
 
 ### The agent class
 
@@ -127,7 +125,7 @@ class Agent:
         self.system_prompt = system_prompt
 ```
 
-Four dependencies. The `client` talks to the model. The `registry` holds the tools. `max_steps` is the budget. `system_prompt` is overridable. No inheritance, no plugin system, just constructor arguments.
+Four dependencies: `client` talks to the model, `registry` holds the tools, `max_steps` is the budget, `system_prompt` is overridable. No inheritance, no plugin system, just constructor arguments.
 
 Now the `run` method:
 
@@ -150,34 +148,26 @@ async def run(self, user_query: str) -> AgentResult:
         if response.usage:
             total_tokens += response.usage.total_tokens
 
-        # Model wants to call a tool.
+        # A turn can carry several tool calls; execute all, return all
+        # results in one following message.
         if response.tool_calls:
-            tc = response.tool_calls[0]
-            tool_result = execute_tool_call(
-                self.registry, tc.name, tc.arguments
-            )
-
-            trace.append({
-                "type": "tool_call",
-                "step": steps,
-                "tool": tc.name,
-                "arguments": tc.arguments,
-                "result": tool_result,
-            })
+            results: list[ToolResult] = []
+            for tc in response.tool_calls:
+                tool_result = execute_tool_call(self.registry, tc.name, tc.arguments)
+                results.append(ToolResult(tool_call_id=tc.id, name=tc.name, content=tool_result))
+                trace.append({
+                    "type": "tool_call",
+                    "step": steps,
+                    "tool": tc.name,
+                    "arguments": tc.arguments,
+                    "result": tool_result,
+                })
 
             messages.append(
-                Message(
-                    role=Role.ASSISTANT,
-                    content=f"[tool_call: {tc.name}({tc.arguments})]",
-                )
+                Message(role=Role.ASSISTANT, content="", tool_calls=list(response.tool_calls))
             )
             messages.append(
-                Message(
-                    role=Role.TOOL,
-                    content=tool_result,
-                    name=tc.name,
-                    tool_call_id=tc.id,
-                )
+                Message(role=Role.TOOL, content="", tool_results=results)
             )
             continue
 
@@ -210,61 +200,49 @@ async def run(self, user_query: str) -> AgentResult:
     )
 ```
 
-Walk through the key decisions:
+Two things here are easy to get wrong, and both pass against a mock and 400 against a real model.
 
-**`for step in range(self.max_steps)`** is a hard ceiling. The loop runs at most `max_steps` times. Default is 5. This is the simplest possible guardrail, and I would not ship an agent without it. Remove it and a single confused query can burn through your entire API budget.
+**`for tc in response.tool_calls`** loops over every tool call in the turn, not just the first. A single turn can request more than one tool at once; grab only `response.tool_calls[0]` and every call after the first is silently dropped.
 
-**`CompletionRequest(messages=messages, tools=tool_schemas)`** sends the full conversation plus all tool schemas every iteration. The model sees everything: the system prompt, the original question, every tool call it made, every result it got. This growing message list is the agent's working memory.
+**`messages.append()` happens twice per turn, not twice per tool call**: once for the assistant's turn with the real `tool_calls` list, once for a tool-result turn with every result together, matched by ID. Serialize the call as plain text instead, and a mock client accepts it happily; a real model looks for the matching ID and fails when it isn't there.
 
-**`if response.tool_calls`** is where the model's decision becomes your code's branch. Tool call? Execute, record, append, `continue`. Text answer? Record and return. Two branches, nothing else.
-
-**`messages.append()`** happens twice per tool call: once for the assistant's tool request, once for the tool's result. Both go into the conversation so the model sees what it asked for and what it got back.
-
-**The final `return` after the loop** handles budget exhaustion. `answer` is `None`. `budget_exhausted` is `True`. The caller knows the agent gave up.
+The final `return` is unchanged: budget exhausted, `answer` is `None`, `budget_exhausted` is `True`.
 
 ## Run it on a real task
 
-Give the agent a question that requires two tool calls: "What is 15 * 7 + 3?"
+Give it a question needing two tool calls: "What is 15 * 7 + 3?"
 
-The agent can't do this in one step. It needs to multiply first, then add. Here's what the trace looks like:
+It can't do this in one step -- multiply first, then add. Here's the trace, copied straight from a real run, not retyped:
 
 ```
-Query: What is 15 * 7 + 3?
-
-[Step 1] tool_call  calculator({"operation": "multiply", "a": 15, "b": 7})
-         result:    "105.0"
-
-[Step 2] tool_call  calculator({"operation": "add", "a": 105, "b": 3})
-         result:    "108.0"
-
-[Step 3] response   "15 * 7 + 3 = 108.0"
-
-Answer:  "15 * 7 + 3 = 108.0"
-Steps:   3
-Tokens:  195
-Budget exhausted: False
+$ python -m src.ch00.raw_agent "What is 15 * 7 + 3?"
+Query:           What is 15 * 7 + 3?
+Answer:          '15 * 7 + 3 = 108.0'
+Steps:           3
+Total tokens:    195
+Budget exhausted:False
+Trace (3 entries):
+  [1] tool_call  calculator({'operation': 'multiply', 'a': 15, 'b': 7}) -> '105.0'
+  [2] tool_call  calculator({'operation': 'add', 'a': 105, 'b': 3}) -> '108.0'
+  [3] response   '15 * 7 + 3 = 108.0'
 ```
 
-Three steps, three model calls, three decisions. The agent multiplied first, used that result to set up the addition, then synthesized the final answer. Each step, the model saw everything that came before and chose what to do next.
+Three steps, three model calls, three decisions: multiply, then add, then synthesize. It could have done this math in its head; it used the calculator because we told it to and gave it one. In production, the tools do things the model genuinely cannot, and the pattern doesn't change.
 
 <figure>
   <img src="/assets/diagrams/agent-trace-waterfall.svg" alt="Waterfall trace of a multi-step agent run showing three model calls, two tool executions, and a final answer" />
   <figcaption>Figure 0c.2: A multi-step agent trace. Each row is a model call. The model sees accumulated context and decides whether to call a tool or answer.</figcaption>
 </figure>
 
-<Callout type="tip" label="What just happened">
-The model could have done this math in its head. Most models can multiply 15 by 7 without a calculator. But we told it to use tools, and we gave it a calculator, so it did. This is actually correct behavior: following instructions over taking shortcuts. In production, the tools will do things the model genuinely cannot do, like query a database or call an API. The pattern is the same regardless.
-</Callout>
-
-Notice how cheap this was. Three model calls, 195 tokens, about $0.001. The cost becomes meaningful at scale (10,000 queries a day) or when the agent takes many more steps per query. Both happen in production.
+Notice how cheap this was: three model calls, 195 tokens, about $0.001. Cost becomes meaningful at scale (10,000 queries a day) or with many more steps per query -- both happen in production.
 
 ## Watch it fail
 
-The demo works. Now break it. These failures are not edge cases. They are the default behaviors of an unsupervised agent.
+The demo works. Now break it. These are not edge cases -- they're the default behavior of an unsupervised agent.
 
 ### Failure 1: The infinite loop
 
-Give the agent a vague, open-ended task: "Search for everything ever written about artificial intelligence."
+Give it a vague, open-ended task: "Search for everything ever written about artificial intelligence."
 
 ```
 Query: Search for everything ever written about AI.
@@ -283,19 +261,25 @@ Steps:   3
 Budget exhausted: True
 ```
 
-The model never stopped searching. It kept finding new facets, kept deciding there was more to look up, and ran out of budget before synthesizing an answer. With a budget of 3, you wasted three API calls. With a budget of 50, you'd waste fifty.
+The model never stopped searching, kept finding new facets, and ran out of budget before synthesizing an answer. Budget of 3, three wasted calls; budget of 50, fifty.
 
 <Callout type="warn" label="Why this happens">
-The model has no internal sense of "enough." It doesn't know when diminishing returns kick in. If the task is unbounded ("everything about X"), the model will keep exploring until something forces it to stop. The budget is that force. But the budget is a blunt instrument. It stops the loop. It doesn't teach the model to converge. Better system prompts, explicit instructions about when to stop searching, are part of the fix. Chapter 6 covers this in depth.
+The model has no internal sense of "enough." Given an unbounded task, it keeps exploring until something forces it to stop -- the budget is that force, but a blunt one: it stops the loop without teaching the model to converge. Better system prompts help. Chapter 6 covers this in depth.
 </Callout>
 
-<Callout type="warn" label="Failure case study: the $2 query that should have cost $0.05">
-A product comparison agent had `max_steps=10` because the developer wanted to "give it room to think." A user asked "What's the cheapest flight from London to Paris next Tuesday?" The agent searched for flights, then searched for airline reviews, then searched for airport transfer options, then searched for hotel deals near the airport, then searched for travel insurance, then searched for visa requirements, then searched for currency exchange rates. Seven search calls, each feeding back context that grew the token count per call. Total cost: $1.87 for a query that needed one search and one answer. The fix: start with `max_steps=3`. If the agent exhausts its budget, examine the trace. Most of the time, the task was answerable in fewer steps and the model was being "thorough" rather than efficient. Raise the budget only after you have evidence that more steps produce materially better answers for your workload.
+<Callout type="warn" label="Failure case study: the generous budget nobody revisited">
+A composite, from a pattern that recurs across product-comparison and research agents:
+
+- **Setup:** `max_steps=10`, set once "to give it room to think," never revisited.
+- **Trigger:** a narrow query (one flight, one date) needing one search, one answer.
+- **What happened:** the agent kept finding adjacent facets, reviews, transfer options, insurance, searching each one.
+- **Cost:** several times what the query needed, for a task answerable in one step.
+- **Fix:** start at `max_steps=3`. On budget exhaustion, read the trace before raising the number -- usually the model was thorough, not efficient. Raise only on evidence more steps help.
 </Callout>
 
 ### Failure 2: The hallucinated tool call
 
-The model invents a tool that doesn't exist. This happens when the model's training data includes functions that your registry doesn't have.
+The model invents a tool that doesn't exist -- its training data includes functions your registry doesn't have.
 
 ```
 Query: What is the weather in London?
@@ -311,17 +295,15 @@ Steps:   2
 Budget exhausted: False
 ```
 
-The model decided it needed a weather API and called `weather` with reasonable-looking arguments. The function doesn't exist. `execute_tool_call` returned a structured error instead of crashing, the model read that error, and gracefully explained the limitation.
+The model decided it needed a weather API and called `weather` with reasonable-looking arguments. The function doesn't exist. `execute_tool_call` returned a structured error instead of crashing; the model read it and explained the limitation gracefully.
 
 <Callout type="tip" label="What just happened">
-This is the validation layer from Section 0b doing its job. `execute_tool_call` checks whether the tool exists before trying to run it. When it doesn't exist, it returns a string error that gets sent back to the model as a tool result. The model reads "Error: unknown tool 'weather'" and self-corrects. If `execute_tool_call` had thrown an exception instead of returning an error string, the agent loop would have crashed and the user would have gotten nothing.
+This is the validation layer from Section 0b at work: `execute_tool_call` checks whether the tool exists and returns a string error instead of throwing. The model reads it and self-corrects. Throw an exception instead, and the loop crashes with nothing to show the user. This happens often with general-purpose models -- they "know" tools exist for weather, email, calendar -- and your registry is the gatekeeper.
 </Callout>
-
-This happens frequently with general-purpose models. The model "knows" tools exist for weather, email, calendar, and dozens of other domains. It will try to call them. Your registry is the gatekeeper.
 
 ### Failure 3: The confident wrong answer
 
-This is the hardest failure to catch. The model stops early with a wrong answer, and it sounds completely confident.
+The hardest failure to catch: the model stops early with a wrong answer that sounds confident.
 
 ```
 Query: What is the population of the largest city in Australia?
@@ -335,16 +317,20 @@ Steps:   1
 Budget exhausted: False
 ```
 
-The model didn't even use the search tool. It answered from its training data without checking. The answer might be roughly right. It might be outdated. It might be wrong. The point is that the model made a judgment call ("I already know this") and skipped verification.
-
-Nothing in the trace looks wrong. One step, an answer, no budget exhaustion. Every metric says success. But the answer could be stale, imprecise, or fabricated.
+The model didn't use the search tool. It answered from training data without checking -- roughly right, outdated, or wrong, no way to tell from the trace. It made a judgment call ("I already know this") and skipped verification. Every metric in the trace says success.
 
 <Callout type="warn" label="Why this is the dangerous one">
-The infinite loop is visible. The hallucinated tool call produces an error. But the confident wrong answer looks exactly like a correct answer. The only way to catch it is to build evaluation into your system: compare the agent's output against ground truth. Prompting alone does not solve this. You need test suites. Chapter 6 builds them.
+The infinite loop is visible; the hallucinated tool call produces an error. The confident wrong answer looks exactly like a correct one. Catching it takes evaluation: compare output against ground truth. Prompting alone doesn't solve this. Chapter 6 builds the test suites.
 </Callout>
 
 <Callout type="warn" label="Failure case study: one search was not enough">
-A fact-checking agent was asked "Is Company X still publicly traded?" It searched once, found a 2023 article mentioning the company's IPO, and answered "Yes, Company X is publicly traded." It did not search for more recent news. The company had been taken private six months earlier. The agent stopped after one search because it had "enough information to answer fully," exactly as the system prompt instructed. The fix was not to remove that instruction (you need it to prevent runaway loops). The fix was to add a verification nudge to the system prompt: "For factual claims about current status, search for the most recent information available, not just the first result." A more robust fix, covered in Chapter 6, is to build minimum-step checks: if the task type requires recency, require at least two searches with different date-scoped queries before answering.
+A composite, from the same family as the recency failure above:
+
+- **Setup:** a fact-checking agent, instructed to stop once it had "enough information to answer fully."
+- **Trigger:** a status question with an answer that changes over time (still independent, still publicly traded).
+- **What happened:** one search returned a confident but dated source; the agent answered and never searched again, exactly as instructed.
+- **Why the trace looked clean:** one step, an answer, no budget exhaustion. Every metric said success.
+- **Fix:** keep the stop instruction, it prevents runaway loops. Add a recency nudge ("search for the most recent information, not just the first result"); where staleness is costly, require two date-scoped searches before answering. Chapter 6 builds the harder version: an evaluation suite that catches this automatically.
 </Callout>
 
 <figure>
@@ -352,25 +338,25 @@ A fact-checking agent was asked "Is Company X still publicly traded?" It searche
   <figcaption>Figure 0c.3: Three failure modes. The first two are loud. The third is silent. Silent failures are the ones that reach production.</figcaption>
 </figure>
 
-These are not edge cases. These are the default behaviors of an agent without engineering discipline. Every one of these failures is what the rest of the book teaches you to prevent.
+These are the default behaviors of an agent without engineering discipline, and what the rest of the book teaches you to prevent.
 
 ## Add basic guardrails
 
-Ten lines of code turn a fragile demo into something that fails gracefully. Not production-ready, but no longer embarrassing.
+Ten lines turn a fragile demo into something that fails gracefully -- not production-ready, but no longer embarrassing.
 
 ### Guardrail 1: The iteration budget
 
-You already have this. The `max_steps` parameter caps the loop:
+You already have this: the `max_steps` parameter caps the loop:
 
 ```python
 agent = Agent(client=client, registry=registry, max_steps=5)
 ```
 
-Five is a reasonable default for simple tasks. For complex research tasks that chain many tool calls, you might go to 10 or 15. Going above 20 is usually a sign that the task is too vague or the tools are too narrow. If the agent needs 20 steps, reconsider the task decomposition before raising the budget.
+Five is reasonable for simple tasks; complex research might need 10 or 15. Above 20 usually signals the task is too vague or the tools too narrow -- reconsider the decomposition before raising the budget.
 
 ### Guardrail 2: Input validation
 
-Use Pydantic to validate the user's query before it enters the loop. This is what you built in Section 0b, applied to the agent's input:
+Validate the user's query with Pydantic before it enters the loop -- the same validation from Section 0b, applied to the agent's input:
 
 ```python
 from pydantic import BaseModel, Field
@@ -385,12 +371,12 @@ result = await agent.run(validated.query)
 ```
 
 <Callout type="tip" label="What just happened">
-Pydantic rejects empty queries, absurdly long queries, and step budgets outside your acceptable range before the agent spends a single token. This costs nothing and prevents a class of issues that are annoying to debug after the fact.
+Pydantic rejects empty queries, absurdly long queries, and out-of-range step budgets before the agent spends a token. Costs nothing, prevents a class of issues that are annoying to debug later.
 </Callout>
 
 ### Guardrail 3: Step logging
 
-Print what happens at each step. This is the minimum viable observability:
+Print what happens at each step -- minimum viable observability:
 
 ```python
 for step in range(self.max_steps):
@@ -409,155 +395,49 @@ for step in range(self.max_steps):
         # ... append to messages and continue
 ```
 
-In production, replace `print` with structured logging. But `print` is infinitely better than nothing. When the agent does something unexpected at 2am, these logs are the difference between a five-minute diagnosis and a blind debugging session.
+In production, replace `print` with structured logging -- but `print` beats nothing. When the agent misbehaves at 2am, these logs mean a five-minute diagnosis instead of a blind guess.
 
 <figure>
   <img src="/assets/diagrams/before-after-guardrails.svg" alt="Before: raw loop with no protections. After: budget, validation, and logging added in 10 lines." />
   <figcaption>Figure 0c.4: Before and after guardrails. Ten lines of code. Budget caps the loop. Validation rejects bad input. Logging shows you what happened.</figcaption>
 </figure>
 
-This is 10% of what production hardening looks like. Chapter 6 gives you the other 90%: evaluation suites, cost tracking, retry policies, circuit breakers, and structured observability. But these three guardrails are the ones you add on day one.
+This is 10% of production hardening. Chapter 6 gives you the other 90%: evaluation suites, cost tracking, retry policies, circuit breakers, structured observability. These three guardrails are the ones you add on day one.
 
-## The code in full
+## The stop condition and the gate
 
-Here is the complete agent in one block. You can read this top to bottom in ten minutes and understand everything that happens. No hidden utilities. No imports from libraries that do the hard work for you. The three imports at the top are the pieces you built in previous sections: `ModelClient` (the provider-neutral wrapper from Section 0a), `ToolRegistry` and `execute_tool_call` (the tool registration and dispatch from Section 0b). In the companion code, these live in `src/shared/` and `src/ch00/`. In a real project, they would be your own modules.
+The loop stops in exactly one place: `if response.content:`, when the model returns text instead of a tool call. Nobody verifies the answer or asks permission -- it stops because the model said it's done, and none of this chapter's guardrails touch that decision. `max_steps` bounds how long it runs, validation bounds what comes in, logging tells you what happened after the fact. Nothing checks whether the model was right to stop or right to act, in the moment it mattered.
+
+That bites hardest not as a wrong answer but as an unreviewed action. Picture `delete_record` sitting next to `calculator` and `search`: the model calls it with the same unverified confidence it uses to decide it's done.
+
+The companion registry now has exactly that tool, gated. `execute_tool_call()` checks a flag before dispatching anything:
 
 ```python
-"""A minimal agent: a while loop with an LLM inside it."""
-
-from __future__ import annotations
-
-import time
-from dataclasses import dataclass, field
-
-from src.shared.model_client import ModelClient
-from src.shared.types import CompletionRequest, Message, Role
-from src.ch00.tool_use import ToolRegistry, execute_tool_call
-
-
-SYSTEM_PROMPT = (
-    "You are a research assistant with access to tools. "
-    "Use the available tools to answer the user's question accurately. "
-    "When you have enough information to answer fully, respond with plain text. "
-    "Do not call tools unnecessarily -- stop as soon as you can give a good answer."
-)
-
-
-@dataclass
-class AgentResult:
-    """The outcome of a single agent run."""
-    answer: str | None
-    steps: int
-    total_tokens: int
-    total_cost_estimate: float
-    elapsed_ms: float
-    budget_exhausted: bool
-    trace: list[dict] = field(default_factory=list)
-
-
-class Agent:
-    """A minimal agent that loops between model calls and tool execution."""
-
-    def __init__(
-        self,
-        client: ModelClient,
-        registry: ToolRegistry,
-        max_steps: int = 5,
-        system_prompt: str = SYSTEM_PROMPT,
-    ) -> None:
-        self.client = client
-        self.registry = registry
-        self.max_steps = max_steps
-        self.system_prompt = system_prompt
-
-    async def run(self, user_query: str) -> AgentResult:
-        start_time = time.monotonic()
-
-        messages: list[Message] = [
-            Message(role=Role.SYSTEM, content=self.system_prompt),
-            Message(role=Role.USER, content=user_query),
-        ]
-        tool_schemas = self.registry.get_schemas()
-        trace: list[dict] = []
-        total_tokens = 0
-        steps = 0
-
-        for step in range(self.max_steps):
-            steps = step + 1
-            request = CompletionRequest(messages=messages, tools=tool_schemas)
-            response = await self.client.complete(request)
-
-            if response.usage:
-                total_tokens += response.usage.total_tokens
-
-            # Model wants to call a tool.
-            if response.tool_calls:
-                tc = response.tool_calls[0]
-                tool_result = execute_tool_call(
-                    self.registry, tc.name, tc.arguments
-                )
-
-                trace.append({
-                    "type": "tool_call",
-                    "step": steps,
-                    "tool": tc.name,
-                    "arguments": tc.arguments,
-                    "result": tool_result,
-                })
-
-                messages.append(
-                    Message(
-                        role=Role.ASSISTANT,
-                        content=f"[tool_call: {tc.name}({tc.arguments})]",
-                    )
-                )
-                messages.append(
-                    Message(
-                        role=Role.TOOL,
-                        content=tool_result,
-                        name=tc.name,
-                        tool_call_id=tc.id,
-                    )
-                )
-                continue
-
-            # Model returned a text answer.
-            if response.content:
-                elapsed_ms = (time.monotonic() - start_time) * 1000
-                trace.append({
-                    "type": "response",
-                    "step": steps,
-                    "content": response.content,
-                })
-                return AgentResult(
-                    answer=response.content,
-                    steps=steps,
-                    total_tokens=total_tokens,
-                    total_cost_estimate=0.0,
-                    elapsed_ms=elapsed_ms,
-                    budget_exhausted=False,
-                    trace=trace,
-                )
-
-        # Budget exhausted.
-        elapsed_ms = (time.monotonic() - start_time) * 1000
-        return AgentResult(
-            answer=None,
-            steps=steps,
-            total_tokens=total_tokens,
-            total_cost_estimate=0.0,
-            elapsed_ms=elapsed_ms,
-            budget_exhausted=True,
-            trace=trace,
-        )
+if entry.requires_approval:
+    return (
+        f"approval_required: {tool_name} is gated; "
+        "a human or policy must approve this call"
+    )
 ```
 
-One file. One class. One loop. No decorators, no metaclasses, no dependency injection. Every line is visible. Every decision is explicit.
+Call `delete_record` and you get that string back, not a deletion. Three lines, not a policy engine, but the shape is real: the loop decides when to stop, the destructive action stops only when something outside the model says yes.
 
-This is the agent you will compare against every framework you evaluate. You wrote the tool registry, the schema generation, the validation layer, the agent loop, the trace, and the guardrails. In Section 0d, you will rebuild this same agent using Google ADK and LangChain. The tool logic stays the same. The system prompt stays the same. The failure modes stay the same. What changes is that four things get automated: tool registration (the `ToolRegistry` and `to_schema()` you wrote), the agent loop (the `for` loop above), conversation state (the growing `messages` list), and tracing (the `trace` dictionary). The hard engineering decisions do not disappear. They just move inside the framework. When someone shows you a 500-line agent class with plugins, middleware, and lifecycle hooks, you will now know exactly what those 500 lines are wrapping: the 100-line version you just wrote.
+This is the argument [FN-004](/field-notes/004-loop-engineering-30-year-old-loop/) makes in full: the orchestration around agent loops is genuinely new, the stop condition underneath it is thirty years old and unsolved. Run the gated-versus-ungated contrast yourself, against a real agent, on [the Bench](/bench/).
+
+## The whole file, on GitHub
+
+You've now seen every piece: system prompt, result type, agent class, run loop (parallel-call fix included), and the gate. Wired together, tool registry included, it's about 100 lines. Read it top to bottom in ten minutes: [`src/ch00/raw_agent.py`](https://github.com/sunilp/agentic-ai/blob/master/src/ch00/raw_agent.py) on GitHub. No hidden utilities, no imports doing the hard work for you.
+
+This is the agent you compare against every framework you evaluate. In Section 0d, you rebuild it with Google ADK and LangChain: same tool logic, same system prompt, same failure modes. What changes is that tool registration, the agent loop, conversation state, and tracing all get automated. The hard engineering decisions don't disappear, they move inside the framework -- so when someone shows you a 500-line agent class with plugins and lifecycle hooks, you'll know exactly what those lines wrap.
 
 ## What you built, and what comes next
 
-You just built an agent. It works. It also breaks in predictable ways. You added basic guardrails that help, but you made a dozen judgment calls by instinct: how big the budget, when to stop searching, what to do when confidence is low, whether this task even needed an agent or could have been a simple tool call. Those instincts were sometimes right. But instincts do not scale to a team of five engineers building agent systems. Chapter 1 gives you the precise vocabulary to make these decisions explicit. It defines five system types, from single LLM calls through multi-agent orchestrations, and gives you a decision framework for choosing when a task needs the loop you just built and when a deterministic workflow is the better call. The rest of the book gives you the engineering to build whichever one you choose, for production.
+You just built an agent. It works. It also breaks in predictable ways. Guardrails and a gate help, but you still made judgment calls on gut feel: how big the budget, when to stop searching, whether this task needed an agent at all. Fine solo; it doesn't scale to a team building agent systems on a shared codebase. Chapter 1 gives you the vocabulary to make these calls explicit -- five system types, from single LLM calls through multi-agent orchestrations, and a decision framework for when a task needs the loop you just built versus a deterministic workflow. The rest of the book gives you the engineering to build whichever one you pick, for production.
 
 For an expanded version with more tools, proper error handling, and example queries, see the [Research Agent](/projects/research-agent/) project.
+
+## Further reading
+
+- **[ReAct: Synergizing Reasoning and Acting in Language Models](https://arxiv.org/abs/2210.03629)** -- Yao et al., 2022. Named the observe-think-act cycle this chapter's loop implements.
+- **["BDI Agents: From Theory to Practice"](https://cdn.aaai.org/ICMAS/1995/ICMAS95-042.pdf)** -- Rao and Georgeff, 1995. The original belief-desire-intention loop, and the paper that first named the stop-and-reconsider problem.
+- **[FN-004: Loop engineering is a 30-year-old loop with a new hashtag](/field-notes/004-loop-engineering-30-year-old-loop/)** -- Why the stop condition is still unsolved, and what an enforced gate looks like against a real agent, not a toy loop.

--- a/src/content/chapters/00c-first-agent.mdx
+++ b/src/content/chapters/00c-first-agent.mdx
@@ -388,6 +388,7 @@ for step in range(self.max_steps):
     print(f"[Step {steps}] tokens={tokens_this_step} total={total_tokens}")
 
     if response.tool_calls:
+        # simplified to a single call for brevity -- the real loop above iterates all tool calls
         tc = response.tool_calls[0]
         print(f"  -> tool_call: {tc.name}({tc.arguments})")
         tool_result = execute_tool_call(self.registry, tc.name, tc.arguments)
@@ -439,5 +440,5 @@ For an expanded version with more tools, proper error handling, and example quer
 ## Further reading
 
 - **[ReAct: Synergizing Reasoning and Acting in Language Models](https://arxiv.org/abs/2210.03629)** -- Yao et al., 2022. Named the observe-think-act cycle this chapter's loop implements.
-- **["BDI Agents: From Theory to Practice"](https://cdn.aaai.org/ICMAS/1995/ICMAS95-042.pdf)** -- Rao and Georgeff, 1995. The original belief-desire-intention loop, and the paper that first named the stop-and-reconsider problem.
+- **["BDI Agents: From Theory to Practice"](https://cdn.aaai.org/ICMAS/1995/ICMAS95-042.pdf)** -- Rao and Georgeff, 1995. The original belief-desire-intention loop, and the paper that framed the stop-and-reconsider problem.
 - **[FN-004: Loop engineering is a 30-year-old loop with a new hashtag](/field-notes/004-loop-engineering-30-year-old-loop/)** -- Why the stop condition is still unsolved, and what an enforced gate looks like against a real agent, not a toy loop.

--- a/src/content/chapters/00d-frameworks.mdx
+++ b/src/content/chapters/00d-frameworks.mdx
@@ -23,7 +23,7 @@ Frameworks also create real problems. Magic you can't debug. Abstractions that l
 
 The point is not "frameworks are good" or "frameworks are bad." The point is to know what you're trading. You are always trading something. Fewer lines of code for less visibility. Faster setup for harder debugging. A richer ecosystem for tighter coupling. These are real tradeoffs, and the right answer depends on what you're building and how long it needs to run.
 
-Here is the question that separates engineers who use frameworks well from engineers who suffer under them: when this breaks at 2am, will I be debugging my code or the framework's code? If you understand what the framework is doing (because you built the raw version first), you can answer that question before you choose.
+Here is the question that separates engineers who use frameworks well from engineers who suffer under them: when this breaks at 2am, will I be debugging my code or the framework's code? If you understand what the framework is doing (because you built the raw version first), you can answer that question before you choose. This is the same bet [FN-003](/field-notes/003-anthropic-told-you-harness-is-product/) makes at the tooling level: the harness -- the layer that decides what the model can see and do -- is the product, and a framework is just one implementation of a harness. Choosing one is choosing how much of that layer you control.
 
 ## What frameworks actually automate
 
@@ -40,11 +40,13 @@ With that in mind, let's see how two frameworks handle the same agent.
 
 ## Google ADK: the primary walkthrough
 
-Google's Agent Development Kit is opinionated about the things that matter in production: tracing, evaluation, and tool registration. It gives you a structured way to define agents and tools, and it stays out of your way on the rest. Let's rebuild the research agent.
+Google's [Agent Development Kit](https://google.github.io/adk-docs/) is opinionated about the things that matter in production: tracing, evaluation, and tool registration. It gives you a structured way to define agents and tools, and it stays out of your way on the rest. Let's rebuild the research agent.
 
 Here is the complete ADK agent from `src/ch00/adk_agent.py`:
 
 ```python
+import json
+
 from google.adk.agents import Agent
 from google.adk.tools import FunctionTool
 
@@ -93,7 +95,7 @@ tools = [
 
 agent = Agent(
     name="foundations_agent",
-    model="gemini-2.0-flash",
+    model="gemini-3.5-flash",
     instruction=(
         "You are a helpful assistant. Use the available tools to answer "
         "the user's question accurately. Stop as soon as you have a good answer."
@@ -101,6 +103,8 @@ agent = Agent(
     tools=tools,
 )
 ```
+
+*Verified against google-adk 2.3.0 on 2026-07-02.*
 
 <Callout type="tip" label="What just happened">
 The same three tools, the same logic, roughly 40 lines instead of 100. The `FunctionTool` wrapper reads your function's docstring and type hints to generate the schema automatically. No `ToolRegistry`. No `Tool` class. No `to_schema()` method. No `execute_tool_call()`. The framework handles all of that.
@@ -126,18 +130,20 @@ The trace looks identical to the one you built manually in Section 0c. The diffe
 
 **What you still do yourself:** the actual tool logic, the system prompt, deciding when to use which tool (through prompt engineering), error handling within tools, and every domain-specific decision about what the agent should do.
 
-The framework version is shorter. Is it better? That depends on whether you value fewer lines of code or understanding every line. In production, I'd reach for ADK because tracing and eval are built in. For learning, I'd build raw first. Always.
+The framework version is shorter. Is it better? That depends on whether you value fewer lines of code or understanding every line. In production, I'd reach for ADK because tracing and eval are built in. For learning, I'd build raw first. Always. One more trade-off worth pricing in: Google retires flash-tier model IDs on a tight cadence, typically 12-18 months after release -- the model this chapter used before this update is already gone, and `gemini-3.5-flash` will eventually follow `gemini-2.5-flash` into retirement (currently scheduled for October 2026). Pin a version, and put the retirement date on a calendar, not just in the code.
 
 ## LangChain: the comparison
 
-Same agent, different philosophy. LangChain comes from a chain-based composition model where you build pipelines by connecting components. The agent pattern was added later, and it shows in the architecture. The current recommended approach uses LangGraph's `create_react_agent`, which is closer to the raw loop than older LangChain patterns.
+Same agent, different philosophy. LangChain comes from a chain-based composition model where you build pipelines by connecting components. The agent pattern was added later, and it shows in the architecture. As of LangChain v1, the recommended way to build an agent is [`langchain.agents.create_agent`](https://docs.langchain.com/oss/python/langchain/agents) -- a middleware-based factory that still runs on LangGraph underneath. It replaces `langgraph.prebuilt.create_react_agent`, which the [LangGraph v1 migration guide](https://docs.langchain.com/oss/python/migrate/langgraph-v1) now deprecates in favor of the new function.
 
 Here is the LangChain version from `src/ch00/langchain_agent.py`:
 
 ```python
+import json
+
 from langchain_core.tools import tool
 from langchain_anthropic import ChatAnthropic
-from langgraph.prebuilt import create_react_agent
+from langchain.agents import create_agent
 
 
 @tool
@@ -181,11 +187,13 @@ def search(query: str, max_results: int = 3) -> str:
 
 model = ChatAnthropic(model="claude-haiku-4-5-20251001", temperature=0)
 tools = [calculator, word_count, search]
-agent = create_react_agent(model, tools)
+agent = create_agent(model, tools)
 ```
 
+*Verified against langchain 1.3.11 and langgraph 1.2.7 on 2026-07-02.*
+
 <Callout type="tip" label="What just happened">
-About 35 lines. The `@tool` decorator works similarly to ADK's `FunctionTool`: it reads the docstring and type hints to build the tool schema. `create_react_agent` wires up the ReAct loop internally. Three imports, three decorated functions, three lines of setup. Notice `ChatAnthropic(model="claude-haiku-4-5-20251001")` at line 159: LangChain uses provider-specific model classes rather than the provider-neutral `ModelClient` you built in Section 0a. This is a philosophical choice. ADK abstracts the provider. LangChain ties your code to a specific provider class. If you later swap from Anthropic to OpenAI, the raw agent and the ADK agent need a config change. The LangChain agent needs a code change.
+About 35 lines. The `@tool` decorator works similarly to ADK's `FunctionTool`: it reads the docstring and type hints to build the tool schema. `create_agent` wires up the agent loop internally -- it still runs on LangGraph under the hood, but adds a middleware system for hooks like guardrails and structured output. Three imports, three decorated functions, three lines of setup. Notice the `ChatAnthropic(model="claude-haiku-4-5-20251001")` call: LangChain uses provider-specific model classes rather than the provider-neutral `ModelClient` you built in Section 0a. This is a philosophical choice. ADK abstracts the provider. LangChain ties your code to a specific provider class. If you later swap from Anthropic to OpenAI, the raw agent and the ADK agent need a config change. The LangChain agent needs a code change.
 </Callout>
 
 The philosophical difference matters here. LangChain was built as a composition framework, where you chain together prompts, models, retrievers, and output parsers into pipelines. This is powerful for linear workflows (retrieve, then summarize, then format). It is awkward for agents, where the control flow is a loop, not a chain. LangGraph (the agent layer) fixes this by introducing a graph-based execution model, but you're now dealing with two mental models: chains for data flow and graphs for control flow.
@@ -196,12 +204,8 @@ The philosophical difference matters here. LangChain was built as a composition 
 
 LangChain has the largest ecosystem. It also has the highest abstraction penalty. When your chain breaks at 2am, you're reading LangChain source code, not your code. This is not a disqualifying flaw. It's a fact you should know before you commit.
 
-<Callout type="warn" label="Failure case study: the 40-line traceback">
-A LangChain agent failed on a tool call where the model passed a string instead of an integer for a `max_results` parameter. The traceback was 42 lines long, starting in `langgraph.pregel`, passing through `langchain_core.runnables`, `langchain_core.tools`, and three layers of internal dispatch before reaching the actual TypeError in user code. An engineer spent 25 minutes reading framework internals before finding the one relevant line. The same bug in the raw agent produced a 4-line trace: the tool name, the bad arguments, the Pydantic validation error, and the error message sent back to the model. The fix in both cases was identical (add type validation). The diagnosis time was not. This is what "abstraction penalty" means in practice. If your team adds a framework, add structured logging at YOUR layer too, not just the framework's. Log the tool name, the raw arguments, and the result before the framework touches them. When something breaks, you want your logs to tell you what happened, independent of whether the framework's logs are readable.
-</Callout>
-
-<Callout type="warn" label="Failure case study: the same bug, visible in seconds">
-That same type mismatch in ADK produced a trace entry showing: tool name `search`, arguments `{"query": "python", "max_results": "five"}`, and result `Validation error: Input should be a valid integer`. Three fields. No framework internals. The engineer saw the bad argument, saw the validation error, and fixed the tool description to clarify "max_results must be a number, not a word" in under two minutes. This is not because ADK is "better." It is because ADK's tracing exposes tool-level details by default. The principle: when evaluating frameworks, give them a bad input and read the error output. The framework that shows you the problem fastest is the one that will cost you the least at 2am.
+<Callout type="warn" label="Failure case study (composite): the debugging gap">
+A representative failure: a tool call where the model passed a string instead of an integer for a `max_results` parameter. In LangChain, the traceback surfaced through several layers of internal dispatch -- `langgraph.pregel`, `langchain_core.runnables`, `langchain_core.tools` -- before reaching the actual TypeError in user code, and the engineer had to read through framework internals to find the one relevant line. In ADK, the trace showed the tool name, the bad argument, and the validation error directly, with no framework internals to wade through. The fix was identical in both cases (add type validation). The diagnosis time was not. This is what "abstraction penalty" means in practice: when evaluating a framework, give it a bad input and see how fast it shows you the problem. And regardless of which framework you pick, add structured logging at your own layer too -- log the tool name, the raw arguments, and the result before the framework touches them.
 </Callout>
 
 **Observability.** LangChain's tracing story is LangSmith, which is a separate product with its own pricing. ADK's tracing is built into the framework. Your raw agent's tracing is whatever you build. The separation between the framework and the observability tool in LangChain's case means you're managing two dependencies instead of one, and you're sending trace data to an external service you don't control.
@@ -228,23 +232,15 @@ A few observations that the table doesn't capture:
 
 **Portability.** The raw agent works with any model provider because you control the client. ADK is designed for Google's models (Gemini) first, with other providers supported through adapters. LangChain supports the most providers out of the box but ties you to its abstraction layer. Pick the lock-in you're most comfortable with.
 
-**Upgrade velocity.** The raw agent changes when you change it. ADK and LangChain change when their maintainers ship a new version. LangChain's upgrade velocity is particularly high, which means more features but also more breaking changes. If you're running agents in production for months or years, framework upgrades are a maintenance cost you need to budget for.
-
 **Team onboarding.** The raw agent is readable by anyone who knows Python. ADK requires learning ADK. LangChain requires learning LangChain, which is a larger surface area. If your team has three months of LangChain experience, switching to ADK has a real cost. If your team has zero framework experience, ADK's smaller API surface is faster to learn.
+
+**Beyond ADK and LangChain.** [Strands](https://strandsagents.com) is AWS's model-driven agent SDK -- lighter-weight than either framework covered here, and the site's [Strands recipe](/recipes/001-strands-on-agentcore-runtime/) walks through deploying one on Bedrock AgentCore Runtime end to end. The [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview) takes a different angle: instead of wrapping your own tools, it hands you the same tool set, agent loop, and context management that runs Claude Code, as a Python or TypeScript library. Neither changes the comparison above -- they're both worth knowing exist before you commit to ADK or LangChain.
 
 ## The honest take
 
-I have opinions. Strong ones. Here they are.
+I have opinions, and they're all versions of the same one: pick a framework that gives you visibility, not convenience. Traces matter more than fewer lines of code, because every production incident I've seen with agent systems comes down to the same question -- what did the model do, and why -- and a framework that hides the answer behind a convenience wrapper is not worth the dependency, no matter how few lines it saves. If you're learning, build raw first and move to a framework second, not the other way around: starting with a framework means debugging its abstractions instead of your own code the first time something breaks, and building raw first (as you did in Section 0c) costs two days against months of confused debugging later. This is the same case [FN-004](/field-notes/004-loop-engineering-30-year-old-loop/) makes about the agent loop itself: the mechanism underneath the framework is not new, and understanding it is what lets you debug the framework instead of guessing at it.
 
-If you're building something serious, pick a framework that gives you visibility, not convenience. Traces matter more than fewer lines of code. An agent that runs correctly but can't be debugged when it doesn't is a liability. Every production incident I've seen with agent systems came down to the same question: what did the model do, and why? Frameworks that answer this question well (ADK does, LangSmith does if you pay for it, your raw trace list does if you build it properly) are worth the dependency. Frameworks that hide this information behind convenience wrappers are not.
-
-If you're learning, build raw first. Then move to a framework. I would not recommend the reverse. Starting with a framework means learning its API without understanding what it's doing underneath. When something breaks (and it will), you end up debugging abstractions you don't understand. You google the error message instead of reading the code. You copy-paste solutions from Stack Overflow instead of reasoning about the system. Building raw first takes two days. It saves you months of confused debugging later.
-
-If your team already uses LangChain, that's fine. Understand what it's doing (you now can), and add the engineering discipline the framework doesn't give you. Add structured evaluation. Add cost tracking. Add budget limits. Add trace export. LangChain gives you the plumbing. It doesn't give you the engineering practices. Those are on you, and they matter more than the plumbing.
-
-If you're starting fresh, I'd reach for ADK. It's opinionated about the right things (tracing, eval) and stays out of your way on the rest. The API surface is small enough to learn in an afternoon. The tracing is good enough for production. The tool registration is simple. And if you've built the raw agent first (which you have, if you're reading this book in order), you'll understand exactly what ADK is doing for you and what it's not.
-
-None of this is religious. Use what works. But "what works" includes debuggability, maintainability, and the ability to answer "what happened?" when things go wrong. Not just "does it run?"
+In practice: if your team already runs LangChain, keep it, but add the discipline the framework doesn't give you -- structured evaluation, cost tracking, budget limits, trace export. If you're starting fresh, reach for ADK; its API surface is small enough to learn in an afternoon, and tracing and eval are built in rather than bolted on. Either way, none of this is religious -- use what works, where "what works" includes debuggability and the ability to answer "what happened?" when something breaks, not just whether it runs.
 
 <figure>
   <img src="/assets/diagrams/framework-decision-tree.svg" alt="Decision tree for choosing between raw agent, ADK, and LangChain based on team experience, production needs, and ecosystem requirements" />
@@ -341,3 +337,10 @@ You also made a lot of decisions by feel. You picked a budget of 5 without measu
 [Chapter 1](/book/01-what-agentic-means/) replaces instinct with engineering vocabulary. It defines five system types, from single LLM calls through multi-agent orchestrations, and gives you a decision framework for choosing when a task needs the loop you just built and when a deterministic workflow is the safer bet. The rest of the book turns every judgment call you made by feel into a measurable, testable, reviewable engineering decision.
 
 For all three implementations with shared eval and comparison scripts, see the [Framework Comparison](/projects/framework-comparison/) project.
+
+## Further reading
+
+- **[Google ADK docs](https://google.github.io/adk-docs/)** -- Agent, tool, and tracing reference for the Agent Development Kit.
+- **[LangGraph v1 migration guide](https://docs.langchain.com/oss/python/migrate/langgraph-v1)** -- The official path onto `langchain.agents.create_agent`, the current recommended agent factory.
+- **[Gemini model deprecations](https://ai.google.dev/gemini-api/docs/deprecations)** -- Google's shutdown schedule for every Gemini model ID, including the flash tier used in this section.
+- **[Claude Agent SDK overview](https://code.claude.com/docs/en/agent-sdk/overview)** -- The library version of Claude Code's tool set, agent loop, and context management, for Python and TypeScript.

--- a/src/content/chapters/00e-connecting-to-mcp.mdx
+++ b/src/content/chapters/00e-connecting-to-mcp.mdx
@@ -34,11 +34,11 @@ The analogy: MCP is USB-C for AI. Before USB-C, every phone had a different char
 Every MCP interaction has three participants:
 
 <figure>
-  <img src="/assets/diagrams/mcp-architecture.svg" alt="MCP architecture showing three roles: Host (your AI application with LLM and MCP client), MCP Servers (exposing tools), and two transport options (stdio for local, HTTP for remote)." />
+  <img src="/assets/diagrams/mcp-architecture.svg" alt="MCP architecture showing three roles: the Host (your AI application containing the LLM and two MCP clients, one per server), two MCP Servers exposing tools, and the two transports (stdio for local, Streamable HTTP for remote)." />
   <figcaption>MCP architecture: the host contains the LLM and one or more MCP clients, each connected to a server.</figcaption>
 </figure>
 
-**Host.** Your AI application. Claude Desktop, VS Code with Copilot, or the custom agent you built in Section 0c. The host contains the LLM and one or more MCP clients.
+**Host.** Your AI application. Claude Desktop, Claude Code, ChatGPT, Gemini, and Windows Copilot are all hosts -- so is the custom agent you built in Section 0c. The host contains the LLM and one or more MCP clients.
 
 **Client.** A connector that maintains a session with one MCP server. The client handles the protocol: initialization, tool discovery, and tool invocation. Most of the time, you use a library for this (the MCP Python SDK or TypeScript SDK). You do not write the client from scratch.
 

--- a/src/content/chapters/00e-connecting-to-mcp.mdx
+++ b/src/content/chapters/00e-connecting-to-mcp.mdx
@@ -14,13 +14,13 @@ import Callout from '~/components/universal/Callout.astro';
 
 In Section 0c, we built an agent with three tools: `search`, `calculator`, and `word_count`. Those tools lived in the same Python file as the agent. The agent imported them directly. This works fine when you control everything.
 
-But what happens when your agent needs to use a tool maintained by another team? Or a database that lives on a different server? Or a third-party service that updates its API every quarter? You could write custom integration code for each one. If you have 5 agents and 10 tools, that is 50 integrations to build and maintain.
+But what happens when your agent needs to use a tool maintained by another team? Or a database that lives on a different server? Or a third-party service that updates its API every quarter? You could write custom integration code for each one. If you have 5 agents and 4 tools, that is 20 integrations to build and maintain.
 
 MCP solves this problem.
 
 ## What is MCP?
 
-**MCP** (Model Context Protocol) is an open standard for connecting AI applications to tools, data sources, and services. It was created by Anthropic and is now the most widely adopted protocol for agent-to-tool communication.
+**MCP** (Model Context Protocol) is an open standard for connecting AI applications to tools, data sources, and services. Anthropic created it in 2024; in December 2025, Anthropic [donated MCP to the Agentic AI Foundation](https://www.anthropic.com/news/donating-the-model-context-protocol-and-establishing-of-the-agentic-ai-foundation), a Linux Foundation project co-founded with Block and OpenAI, and it is now one of the most widely adopted protocols for agent-to-tool communication.
 
 The analogy: MCP is USB-C for AI. Before USB-C, every phone had a different charger. You needed a drawer full of cables. USB-C standardized the connector so one cable works with everything. MCP does the same for agent tools: each tool implements the server once, each agent implements the client once, and they all work together.
 
@@ -61,10 +61,10 @@ When your agent connects to an MCP server, four things happen in sequence:
 
 **Step 4: Loop.** The result goes back to the LLM's context. The LLM decides whether it has enough information to answer or needs to call another tool. This is the same agent loop from Section 0c -- MCP does not change the loop. It changes where the tools live.
 
-The protocol runs on **JSON-RPC 2.0** -- a simple request/response format over two transports:
+The protocol runs on **JSON-RPC 2.0** -- a simple request/response format over two transports (current spec version 2025-11-25; see the [spec changelog](https://modelcontextprotocol.io/specification/2025-11-25/changelog) for how the transport layer got here -- checked 2026-07-02):
 
 - **stdio** -- for local servers running as subprocesses on the same machine. Fast, no network. This is what you use during development and for tools that access local files.
-- **Streamable HTTP** -- for remote servers accessible over the network. Supports authentication, streaming, and session management. This is what you use in production.
+- **Streamable HTTP** -- for remote servers accessible over the network. [Supports authentication](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization), streaming, and session management. This is what you use in production.
 
 ## Building your first MCP server
 
@@ -73,7 +73,7 @@ Let's build a simple MCP server that exposes three tools: a unit converter, a wo
 ### Install the SDK
 
 ```bash
-pip install mcp
+pip install "mcp[cli]"
 ```
 
 ### The server code
@@ -105,6 +105,10 @@ def word_count(text: str) -> str:
 def reverse_text(text: str) -> str:
     """Reverse a string of text."""
     return text[::-1]
+
+
+if __name__ == "__main__":
+    mcp.run()
 ```
 
 That is the entire server. Three things to notice:
@@ -123,11 +127,13 @@ For local development, run it with stdio transport:
 python my_server.py
 ```
 
-Or for HTTP transport (accessible over the network):
+Or run it over Streamable HTTP (accessible over the network) with the `mcp` CLI:
 
 ```bash
-mcp run my_server.py --transport http --port 8080
+mcp run my_server.py --transport streamable-http
 ```
+
+The CLI takes a transport flag, not a port flag -- there is no `--port` option. Host and port are server configuration, set on the `FastMCP` constructor instead: `FastMCP("My First MCP Server", host="127.0.0.1", port=8080)`.
 
 ### Test it with the MCP Inspector
 
@@ -137,7 +143,7 @@ The MCP Inspector is a browser-based tool that lets you test your server without
 npx @modelcontextprotocol/inspector
 ```
 
-This opens a web UI where you can connect to your server, see the available tools, and call them interactively. Use this to verify your server works before connecting an agent to it.
+This opens a web UI where you can connect to your server, see the available tools, and call them interactively. Use this to verify your server works before connecting an agent to it. If you use [uv](https://docs.astral.sh/uv/), `uv run mcp dev my_server.py` launches the same Inspector in one step and handles the dependency install for you.
 
 ## Connecting Claude Desktop to your server
 
@@ -163,7 +169,7 @@ The fastest way to see your MCP server in action with a real LLM is Claude Deskt
 
 **Step 3.** Restart Claude Desktop. You should see a hammer icon indicating MCP tools are available. Ask Claude: "Convert 37 degrees Celsius to Fahrenheit" and it will call your `convert_temperature` tool.
 
-That is MCP working end to end: Claude discovers your tools, the LLM decides to call one, your Python function executes, and the result flows back into the conversation.
+That is MCP working end to end: discovery, decision, execution, and the result flowing back into the conversation.
 
 ## A more realistic server: document search
 
@@ -225,7 +231,7 @@ def search_documents(query: str) -> str:
 
 Three design decisions worth understanding:
 
-**Path traversal protection.** The `is_relative_to` check prevents a malicious tool call from reading files outside the documents directory. Without this, a prompt injection could trick the LLM into calling `read_document("../../etc/passwd")`. This is not theoretical -- it is one of the most common MCP vulnerabilities. Always validate paths.
+**Path traversal protection.** The `is_relative_to` check prevents a malicious tool call from reading files outside the documents directory. Without this, a prompt injection could trick the LLM into calling `read_document("../../etc/passwd")`. This is not theoretical: unvalidated tool inputs are a [documented MCP prompt-injection vector](https://simonwillison.net/2025/Apr/9/mcp-prompt-injection/), and a server without input validation is an easy target. Always validate paths.
 
 **Content truncation.** The `[:5000]` limit prevents a single document from consuming the LLM's entire context window. In production, you would use chunking and retrieval (Chapter 2) instead of reading full files.
 
@@ -241,7 +247,7 @@ tools = [search, calculator, word_count]
 agent = Agent(tools=tools)
 ```
 
-With MCP, tools live on a server. The agent discovers them at runtime:
+With MCP, tools live on a server. The agent discovers them at runtime. This snippet is illustrative, not runnable -- `transport` stands in for a configured stdio or Streamable HTTP transport object; see the [Python SDK](https://github.com/modelcontextprotocol/python-sdk) for a complete client example:
 
 ```python
 # With MCP: tools are discovered from a server
@@ -251,7 +257,7 @@ async with ClientSession(transport) as session:
     # These tool schemas go to the LLM -- same format as before
 ```
 
-The agent loop does not change. The LLM still generates tool calls. The difference is where the tool executes: locally (Section 0c) or on an MCP server (this section). From the LLM's perspective, it is identical. It sees the same JSON Schema for parameters and gets the same text results back.
+As in Step 4 above, the loop itself does not change -- only where the tool executes: locally (Section 0c) or on an MCP server (this section).
 
 ## When to use MCP (and when not to)
 
@@ -260,13 +266,13 @@ The agent loop does not change. The LLM still generates tool calls. The differen
 - Your tools are maintained by a different team. MCP gives you a clean interface without importing their code.
 - You want to share tools across multiple agents. Build the server once, connect any MCP-compatible agent.
 - You want to use third-party tools (database connectors, API wrappers, cloud services) that already have MCP servers published.
-- You are using Claude Desktop, VS Code Copilot, or another MCP-compatible host and want to extend it with custom tools.
+- You are using Claude Desktop, Claude Code, ChatGPT, Gemini, Windows Copilot, or another MCP-compatible host and want to extend it with custom tools.
 
 **Skip MCP when:**
 
 - All your tools are local functions in the same codebase. Direct function calls are simpler and faster.
 - You are building a prototype and do not need cross-team tool sharing yet.
-- You need sub-millisecond tool invocation. MCP adds protocol overhead (~5-20ms for stdio, more for HTTP).
+- You need sub-millisecond tool invocation. MCP adds protocol overhead a direct function call does not pay: serialization always, and for HTTP transports, a network round trip on top.
 
 The guidance from the book: start without MCP. Get your agent logic right with direct function calls. Add MCP when tool integrations multiply or when tools need to be shared across agents. Earn the complexity.
 
@@ -296,4 +302,4 @@ From here, the book takes you into the engineering decisions that determine whet
 - **[MCP specification](https://modelcontextprotocol.io)** -- The full protocol spec, SDK documentation, and quickstart guides.
 - **[MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)** -- The official Python SDK with `FastMCP` for building servers.
 - **[MCP Inspector](https://github.com/modelcontextprotocol/inspector)** -- Browser-based testing tool for MCP servers.
-- **[MCP Server Registry](https://registry.modelcontextprotocol.io)** -- Community registry of published MCP servers.
+- **[MCP Server Registry](https://registry.modelcontextprotocol.io)** -- Community registry of published MCP servers, currently in preview: expect breaking changes before general availability.

--- a/src/content/chapters/00e-connecting-to-mcp.mdx
+++ b/src/content/chapters/00e-connecting-to-mcp.mdx
@@ -26,7 +26,7 @@ The analogy: MCP is USB-C for AI. Before USB-C, every phone had a different char
 
 <figure>
   <img src="/assets/diagrams/mcp-before-after.svg" alt="Before MCP: 5 apps times 4 tools equals 20 custom integrations. After MCP: 5 plus 4 equals 9 standard integrations." />
-  <figcaption>Without MCP, every app writes custom code for every tool. With MCP, each side implements the standard once.</figcaption>
+  <figcaption>Figure 0e.1: Without MCP, every app writes custom code for every tool. With MCP, each side implements the standard once.</figcaption>
 </figure>
 
 ## The three roles
@@ -35,7 +35,7 @@ Every MCP interaction has three participants:
 
 <figure>
   <img src="/assets/diagrams/mcp-architecture.svg" alt="MCP architecture showing three roles: the Host (your AI application containing the LLM and two MCP clients, one per server), two MCP Servers exposing tools, and the two transports (stdio for local, Streamable HTTP for remote)." />
-  <figcaption>MCP architecture: the host contains the LLM and one or more MCP clients, each connected to a server.</figcaption>
+  <figcaption>Figure 0e.2: MCP architecture. The host contains the LLM and one or more MCP clients, each connected to a server.</figcaption>
 </figure>
 
 **Host.** Your AI application. Claude Desktop, Claude Code, ChatGPT, Gemini, and Windows Copilot are all hosts -- so is the custom agent you built in Section 0c. The host contains the LLM and one or more MCP clients.
@@ -50,7 +50,7 @@ When your agent connects to an MCP server, four things happen in sequence:
 
 <figure>
   <img src="/assets/diagrams/mcp-lifecycle.svg" alt="MCP protocol lifecycle: 1) Initialize (handshake), 2) Discover (tools/list), 3) Invoke (tools/call), 4) Loop (result goes back to LLM for next decision)." />
-  <figcaption>The MCP lifecycle: initialize, discover available tools, invoke them as the LLM decides, and loop.</figcaption>
+  <figcaption>Figure 0e.3: The MCP lifecycle. Initialize, discover available tools, invoke them as the LLM decides, and loop.</figcaption>
 </figure>
 
 **Step 1: Initialize.** The client and server perform a handshake. Each side declares what protocol version it supports and what capabilities it offers. This happens once when the connection starts.

--- a/src/pages/book/index.astro
+++ b/src/pages/book/index.astro
@@ -85,7 +85,10 @@ function chapterPrefix(slug: string): string {
               <li class="book-part__chapter">
                 <a href={`/book/${c.id}/`}>
                   <span class="book-part__chapter-num">{chapterPrefix(c.id).toUpperCase()}</span>
-                  <span class="book-part__chapter-title">{c.data.title}</span>
+                  <span class="book-part__chapter-text">
+                    <span class="book-part__chapter-title">{c.data.title}</span>
+                    {c.data.description && <span class="book-part__chapter-dek">{c.data.description}</span>}
+                  </span>
                   <span class="book-part__chapter-meta">{c.data.readingTime} min</span>
                 </a>
               </li>
@@ -203,7 +206,7 @@ function chapterPrefix(slug: string): string {
   .book-part__chapter a {
     display: grid;
     grid-template-columns: 60px 1fr auto;
-    align-items: baseline;
+    align-items: start;
     gap: var(--space-4);
     padding: var(--space-3) var(--space-4);
     color: var(--fg);
@@ -224,10 +227,29 @@ function chapterPrefix(slug: string): string {
     letter-spacing: var(--tracking-loose);
   }
 
+  .book-part__chapter-text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+  }
+
   .book-part__chapter-title {
     font-family: var(--font-display);
     font-size: var(--display-4);
     font-weight: 500;
+  }
+
+  .book-part__chapter-dek {
+    font-family: var(--font-body);
+    font-style: italic;
+    font-size: var(--body-2);
+    color: #666;
+    line-height: 1.4;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
 
   .book-part__chapter-meta {

--- a/src/shared/model_client.py
+++ b/src/shared/model_client.py
@@ -59,10 +59,11 @@ class OpenAIClient(ModelClient):
         start = time.monotonic()
         payload: dict[str, Any] = {
             "model": self.model_name,
-            "messages": [_to_openai_message(m) for m in request.messages],
-            "temperature": request.temperature,
+            "messages": _to_openai_messages(request.messages),
             "max_tokens": request.max_tokens,
         }
+        if request.temperature is not None:
+            payload["temperature"] = request.temperature
         if request.tools:
             payload["tools"] = [_to_openai_tool(t) for t in request.tools]
         if request.response_format:
@@ -132,8 +133,9 @@ class AnthropicClient(ModelClient):
             "model": self.model_name,
             "messages": messages,
             "max_tokens": request.max_tokens,
-            "temperature": request.temperature,
         }
+        if request.temperature is not None:
+            payload["temperature"] = request.temperature
         if system_msg:
             payload["system"] = system_msg
         if request.tools:
@@ -217,7 +219,40 @@ def create_client(
 # --- Format converters (internal) ---
 
 
+def _to_openai_messages(messages: list[Message]) -> list[dict[str, Any]]:
+    """Convert a full message list to OpenAI's shape.
+
+    A `tool_results` message expands into one `role: "tool"` message per
+    result -- unlike Anthropic, OpenAI does not batch multiple tool results
+    into one message.
+    """
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        if msg.role == Role.TOOL and msg.tool_results:
+            for tr in msg.tool_results:
+                out.append({"role": "tool", "tool_call_id": tr.tool_call_id, "content": tr.content})
+        else:
+            out.append(_to_openai_message(msg))
+    return out
+
+
 def _to_openai_message(msg: Message) -> dict[str, Any]:
+    if msg.tool_calls:
+        # Same structural requirement as the Anthropic path: an assistant
+        # tool-call turn needs a `tool_calls` array the API can match the
+        # following tool-result messages against by id.
+        return {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
+                }
+                for tc in msg.tool_calls
+            ],
+        }
     d: dict[str, Any] = {"role": msg.role.value, "content": msg.content}
     if msg.name:
         d["name"] = msg.name
@@ -252,14 +287,38 @@ def _to_openai_tool(schema: ToolSchema) -> dict[str, Any]:
 
 
 def _to_anthropic_message(msg: Message) -> dict[str, Any]:
-    role = "user" if msg.role in (Role.USER, Role.TOOL) else "assistant"
     if msg.role == Role.TOOL:
+        if msg.tool_results:
+            # All of a turn's tool results travel together in one user
+            # message -- the API expects every tool_result for a turn's
+            # tool_use blocks to arrive in the immediately following turn.
+            return {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": tr.tool_call_id, "content": tr.content}
+                    for tr in msg.tool_results
+                ],
+            }
         return {
             "role": "user",
             "content": [
                 {"type": "tool_result", "tool_use_id": msg.tool_call_id, "content": msg.content}
             ],
         }
+    if msg.tool_calls:
+        # An assistant turn that called tools must carry them as structural
+        # `tool_use` blocks with the original id/name/input -- the API
+        # rejects a plain-text stand-in here because the `tool_result` that
+        # follows references a `tool_use_id` with no matching `tool_use`
+        # block otherwise.
+        return {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": tc.id, "name": tc.name, "input": tc.arguments}
+                for tc in msg.tool_calls
+            ],
+        }
+    role = "user" if msg.role == Role.USER else "assistant"
     return {"role": role, "content": msg.content}
 
 

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -31,13 +31,43 @@ class SideEffect(StrEnum):
     DELETE = "delete"
 
 
+class ToolCall(BaseModel):
+    """A request from the model to execute a tool."""
+
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+class ToolResult(BaseModel):
+    """The result of executing a tool."""
+
+    tool_call_id: str
+    name: str
+    content: str
+    success: bool = True
+    error: str | None = None
+
+
 class Message(BaseModel):
-    """A single message in a conversation."""
+    """A single message in a conversation.
+
+    An assistant turn that calls tools carries them structurally in
+    `tool_calls` rather than encoding them into `content` -- this is what
+    lets the model client serialize a proper `tool_use` content block
+    instead of a plain-text stand-in the API can't reconcile with the
+    `tool_result` that follows it. Symmetrically, `tool_results` carries
+    every result from a turn's tool calls (there may be more than one --
+    the API executes them in parallel) so they can be returned together in
+    a single following message, as the API requires.
+    """
 
     role: Role
     content: str
     name: str | None = None
     tool_call_id: str | None = None
+    tool_calls: list[ToolCall] | None = None
+    tool_results: list[ToolResult] | None = None
 
 
 class ToolParameter(BaseModel):
@@ -60,30 +90,12 @@ class ToolSchema(BaseModel):
     requires_approval: bool = False
 
 
-class ToolCall(BaseModel):
-    """A request from the model to execute a tool."""
-
-    id: str
-    name: str
-    arguments: dict[str, Any]
-
-
-class ToolResult(BaseModel):
-    """The result of executing a tool."""
-
-    tool_call_id: str
-    name: str
-    content: str
-    success: bool = True
-    error: str | None = None
-
-
 class CompletionRequest(BaseModel):
     """A request to a language model."""
 
     messages: list[Message]
     tools: list[ToolSchema] | None = None
-    temperature: float = 0.0
+    temperature: float | None = None
     max_tokens: int = 4096
     response_format: dict[str, Any] | None = None
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -49,13 +49,17 @@ code, pre {
   background: var(--paper-recess);
 }
 
-/* inline code — runs alongside body prose, needs to read as part of a sentence */
+/* inline code — runs alongside body prose, needs to read as part of a sentence.
+   overflow-wrap lets long unbroken runs (file paths, env vars) break instead of
+   pushing the page into horizontal scroll on narrow viewports; pre's own
+   white-space: pre keeps multi-line blocks on their internal scrollbar. */
 code {
   font-size: 0.92em;
   padding: 1px 6px;
   border-radius: var(--radius-sm);
   border: 1px solid #e6e2d6;
   color: var(--ink);
+  overflow-wrap: break-word;
 }
 
 /* shiki applies its own background + foreground via inline style; suppress our base bg

--- a/tests/unit/test_model_client.py
+++ b/tests/unit/test_model_client.py
@@ -35,6 +35,6 @@ def test_build_tool_schema_openai_format():
 def test_completion_request_defaults():
     """CompletionRequest should have sensible defaults."""
     req = CompletionRequest(messages=[Message(role=Role.USER, content="hello")])
-    assert req.temperature == 0.0
+    assert req.temperature is None
     assert req.max_tokens == 4096
     assert req.tools is None


### PR DESCRIPTION
Full pass over the five Foundations chapters (00a-00e), their companion code, and all their diagrams. Also fixes the mobile masthead sitewide.

Broken things fixed:
- The agent client serialized tool-call turns as plain text, which the live Anthropic API rejects. Now proper tool_use blocks, with parallel tool calls handled and a selfcheck script proving it.
- Dead Gemini model id and deprecated LangChain guidance in 00d, both verified against current official docs and real installed packages before rewriting.
- MCP install and run commands in 00e did not work as printed; now live-tested (mcp[cli], streamable-http, and the missing __main__ block).
- Dead link in 00a, missing imports in 00b and 00d, run instructions in 00c now produce the documented output.

Currency and references:
- Model ids and pricing verified and stamped with checked dates. Context section reframed for the 200K-1M era with attention decay and prompt caching. MCP governance (Linux Foundation) and ecosystem updated.
- Primary-source citations and Further Reading in every chapter (Lost in the Middle, ReAct, the 1995 BDI paper, spec and framework docs). Cross-links to FN-003, FN-004, SG-002, the Strands recipe, and the Bench.
- Composite anecdotes labeled as such, invented precision removed. A new stop-condition-and-gate section in 00c wires up the approval gate that was sitting unused in the type system.

Diagrams:
- All 17 redrawn by hand in the site's paper/ink/brick register, plus one new schema-validation figure. Seven content contradictions fixed along the way (the failure-modes panel taught the opposite of the code, the MCP architecture contradicted its own prose, the layers figure did not match its caption).

Site fixes that ride along:
- Compact two-row mobile masthead with a scrollable nav row (the old one stacked to 422px and pinned over content). Nav keeps the Garamond voice.
- Figures and inline code no longer overflow small viewports (root cause was grid min-width, not the images).
- One-line chapter deks on the book index.

Verification: vitest 11/11, pytest 142/142, selfcheck 5/5, clean build, per-chapter link check, code blocks compile-checked, screenshot sweep at desktop and 400px, facts re-verified independently in review.

Merging deploys via Actions once this lands on master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now support multiple tool calls in a single turn, improving more complex requests.
  * Added approval protection for sensitive actions, helping prevent unintended destructive operations.
  * Mobile navigation and layout behavior were improved for smoother browsing on small screens.

* **Bug Fixes**
  * Inline code and wide content now wrap better on narrow screens, reducing horizontal scrolling.
  * Agent responses are now more consistent and deterministic across several workflows.

* **Documentation**
  * Updated several chapters and examples to reflect current models, tool use, and MCP setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->