### PR TITLE
Chapter 1: bring the free sample chapter up to the refreshed standard

### DIFF
--- a/public/assets/diagrams/agent-anatomy.svg
+++ b/public/assets/diagrams/agent-anatomy.svg
@@ -1,62 +1,58 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="0 0 500 500" font-family="Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 560" font-family="IBM Plex Mono, monospace">
   <defs>
-    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
-    <marker id="arr-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#2563EB"/>
-    </marker>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
   </defs>
+  <rect width="560" height="560" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="500" height="500" fill="#ffffff"/>
+  <!-- OBSERVATION (top) -->
+  <rect x="185" y="40" width="190" height="80" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="280" y="66" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">OBSERVATION</text>
+  <text x="280" y="88" text-anchor="middle" font-size="11" fill="#6b6b6b">query &#183; evidence &#183;</text>
+  <text x="280" y="104" text-anchor="middle" font-size="11" fill="#6b6b6b">prior state</text>
 
-  <!-- Title -->
-  <text x="250" y="32" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Agent Anatomy: The Four Components</text>
-  <line x1="40" y1="44" x2="460" y2="44" stroke="#D1D5DB" stroke-width="1"/>
+  <!-- REASONING (right); brick accent: the decision point -->
+  <rect x="382" y="234" width="158" height="96" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="461" y="262" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#9b4a3f">REASONING</text>
+  <text x="461" y="283" text-anchor="middle" font-size="11" fill="#1a1a1a">decide: act, refine,</text>
+  <text x="461" y="299" text-anchor="middle" font-size="11" fill="#1a1a1a">or answer</text>
+  <text x="461" y="318" text-anchor="middle" font-size="11" fill="#9b4a3f">the decision point</text>
 
-  <!-- Center circle: Agent Loop label -->
-  <circle cx="250" cy="272" r="58" fill="#F9FAFB" stroke="#D1D5DB" stroke-width="2"/>
-  <text x="250" y="267" text-anchor="middle" font-size="14" font-weight="bold" fill="#374151">Agent</text>
-  <text x="250" y="284" text-anchor="middle" font-size="14" font-weight="bold" fill="#374151">Loop</text>
+  <!-- ACTION (bottom) -->
+  <rect x="185" y="440" width="190" height="80" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="280" y="466" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">ACTION</text>
+  <text x="280" y="488" text-anchor="middle" font-size="11" fill="#6b6b6b">execute the tool call</text>
+  <text x="280" y="504" text-anchor="middle" font-size="11" fill="#6b6b6b">or produce an answer</text>
 
-  <!-- TOP: Observation -->
-  <rect x="155" y="62" width="190" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
-  <text x="250" y="90" text-anchor="middle" font-size="15" font-weight="bold" fill="#1D4ED8">Observation</text>
-  <text x="250" y="108" text-anchor="middle" font-size="11" fill="#6B7280">Perceive current state</text>
-  <text x="250" y="124" text-anchor="middle" font-size="11" fill="#6B7280">query · tool results · history</text>
+  <!-- STATE (left) -->
+  <rect x="20" y="234" width="158" height="96" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="99" y="262" text-anchor="middle" font-size="11" letter-spacing="1.5" font-weight="500" fill="#1a1a1a">STATE</text>
+  <text x="99" y="283" text-anchor="middle" font-size="11" fill="#6b6b6b">what carries forward</text>
+  <text x="99" y="299" text-anchor="middle" font-size="11" fill="#6b6b6b">to the next step</text>
 
-  <!-- RIGHT: Reasoning -->
-  <rect x="322" y="234" width="150" height="72" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
-  <text x="397" y="262" text-anchor="middle" font-size="15" font-weight="bold" fill="#92400E">Reasoning</text>
-  <text x="397" y="280" text-anchor="middle" font-size="11" fill="#6B7280">Decide what to do</text>
-  <text x="397" y="296" text-anchor="middle" font-size="11" fill="#6B7280">next · LLM call</text>
+  <!-- Arrows, clockwise: Observation -> Reasoning -> Action -> State -> Observation -->
+  <path d="M368,120 Q460,152 461,232" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="478" y="172" text-anchor="middle" font-size="11" fill="#6b6b6b">the model</text>
+  <text x="478" y="186" text-anchor="middle" font-size="11" fill="#6b6b6b">decides</text>
 
-  <!-- BOTTOM: Action -->
-  <rect x="155" y="378" width="190" height="72" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
-  <text x="250" y="406" text-anchor="middle" font-size="15" font-weight="bold" fill="#B91C1C">Action</text>
-  <text x="250" y="424" text-anchor="middle" font-size="11" fill="#6B7280">Execute via tools</text>
-  <text x="250" y="440" text-anchor="middle" font-size="11" fill="#6B7280">or return answer</text>
+  <path d="M461,332 Q461,398 380,440" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="478" y="382" text-anchor="middle" font-size="11" fill="#6b6b6b">chosen</text>
+  <text x="478" y="396" text-anchor="middle" font-size="11" fill="#6b6b6b">action</text>
 
-  <!-- LEFT: State -->
-  <rect x="28" y="234" width="150" height="72" rx="8" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5"/>
-  <text x="103" y="262" text-anchor="middle" font-size="15" font-weight="bold" fill="#065F46">State</text>
-  <text x="103" y="280" text-anchor="middle" font-size="11" fill="#6B7280">Memory of what</text>
-  <text x="103" y="296" text-anchor="middle" font-size="11" fill="#6B7280">happened so far</text>
+  <path d="M185,440 Q99,398 99,332" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="82" y="382" text-anchor="middle" font-size="11" fill="#6b6b6b">result</text>
+  <text x="82" y="396" text-anchor="middle" font-size="11" fill="#6b6b6b">recorded</text>
 
-  <!-- Arrow: Observation → Reasoning (top to right, clockwise) -->
-  <!-- From bottom-right of Observation box toward Reasoning -->
-  <path d="M345,134 Q420,134 420,232" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
+  <path d="M99,232 Q99,152 192,120" fill="none" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
+  <text x="82" y="172" text-anchor="middle" font-size="11" fill="#6b6b6b">carried into</text>
+  <text x="82" y="186" text-anchor="middle" font-size="11" fill="#6b6b6b">next step</text>
 
-  <!-- Arrow: Reasoning → Action (right to bottom, clockwise) -->
-  <path d="M420,308 Q420,378 345,414" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
-
-  <!-- Arrow: Action → State (bottom to left, clockwise) -->
-  <path d="M155,414 Q80,378 80,308" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
-
-  <!-- Arrow: State → Observation (left to top, clockwise) -->
-  <path d="M80,232 Q80,134 155,134" fill="none" stroke="#6B7280" stroke-width="2" marker-end="url(#arr)"/>
-
-  <!-- Small clockwise rotation hint -->
-  <text x="250" y="466" text-anchor="middle" font-size="11" fill="#9CA3AF">Each step: observe → reason → act → update state → repeat</text>
+  <!-- Center -->
+  <text x="280" y="272" text-anchor="middle" font-size="12" font-weight="500" fill="#1a1a1a">ONE ITERATION = ONE STEP</text>
+  <text x="280" y="293" text-anchor="middle" font-size="11" fill="#6b6b6b">repeats until a stop</text>
+  <text x="280" y="308" text-anchor="middle" font-size="11" fill="#6b6b6b">condition ends it</text>
 </svg>

--- a/public/assets/diagrams/system-types-spectrum.svg
+++ b/public/assets/diagrams/system-types-spectrum.svg
@@ -1,109 +1,76 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="300" viewBox="0 0 800 300" font-family="Arial, Helvetica, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 350" font-family="IBM Plex Mono, monospace">
   <defs>
-    <marker id="arr-gray" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#9CA3AF"/>
+    <marker id="ai" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M1,1 L7,4.5 L1,8" fill="none" stroke="#1a1a1a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
-    <linearGradient id="spectrumGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#93C5FD;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#EF4444;stop-opacity:0.7"/>
-    </linearGradient>
+    <pattern id="hatchBrick" width="6" height="6" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#9b4a3f" stroke-width="1" opacity="0.18"/>
+    </pattern>
   </defs>
+  <rect width="760" height="350" fill="#fafaf8"/>
 
-  <!-- Background -->
-  <rect width="800" height="300" fill="#ffffff"/>
+  <!-- Spectrum direction -->
+  <text x="380" y="22" text-anchor="middle" font-size="11" fill="#6b6b6b">increasing autonomy, capability, and risk</text>
+  <line x1="46" y1="34" x2="708" y2="34" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#ai)"/>
 
-  <!-- Title -->
-  <text x="400" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#111827">Five System Types: The Autonomy Spectrum</text>
-  <line x1="60" y1="42" x2="740" y2="42" stroke="#D1D5DB" stroke-width="1"/>
+  <!-- 1: LLM APP -->
+  <rect x="46" y="56" width="124" height="82" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="108" y="80" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">LLM APP</text>
+  <text x="108" y="100" text-anchor="middle" font-size="11" fill="#6b6b6b">single response</text>
+  <text x="108" y="116" text-anchor="middle" font-size="11" fill="#6b6b6b">one call, done</text>
 
-  <!-- Gradient bar -->
-  <rect x="60" y="56" width="680" height="10" rx="5" fill="url(#spectrumGrad)"/>
+  <!-- 2: WORKFLOW -->
+  <rect x="182" y="56" width="124" height="82" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="244" y="80" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">WORKFLOW</text>
+  <text x="244" y="100" text-anchor="middle" font-size="11" fill="#6b6b6b">fixed pipeline</text>
+  <text x="244" y="116" text-anchor="middle" font-size="11" fill="#6b6b6b">code decides</text>
 
-  <!-- Spectrum endpoints -->
-  <text x="60" y="82" text-anchor="middle" font-size="11" fill="#6B7280">Least autonomous</text>
-  <text x="740" y="82" text-anchor="middle" font-size="11" fill="#6B7280">Most autonomous</text>
+  <!-- 3: TOOL-USING -->
+  <rect x="318" y="56" width="124" height="82" rx="2" fill="none" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="380" y="80" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">TOOL-USING</text>
+  <text x="380" y="100" text-anchor="middle" font-size="11" fill="#6b6b6b">picks the tool</text>
+  <text x="380" y="116" text-anchor="middle" font-size="11" fill="#6b6b6b">a single turn</text>
 
-  <!-- Box 1: LLM App -->
-  <rect x="28" y="92" width="128" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
-  <text x="92" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">LLM App</text>
-  <text x="92" y="130" text-anchor="middle" font-size="10" fill="#6B7280">Single call</text>
-  <text x="92" y="148" text-anchor="middle" font-size="10" fill="#6B7280">No autonomy —</text>
-  <text x="92" y="160" text-anchor="middle" font-size="10" fill="#6B7280">code controls all</text>
+  <!-- 4: AGENT; brick accent: single loop -->
+  <rect x="454" y="56" width="124" height="82" rx="2" fill="url(#hatchBrick)" stroke="#9b4a3f" stroke-width="2"/>
+  <text x="516" y="80" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#9b4a3f">AGENT</text>
+  <text x="516" y="100" text-anchor="middle" font-size="11" fill="#1a1a1a">runs the loop</text>
+  <text x="516" y="116" text-anchor="middle" font-size="11" fill="#1a1a1a">model-directed</text>
 
-  <!-- Arrow 1→2 -->
-  <line x1="157" y1="128" x2="183" y2="128" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+  <!-- 5: MULTI-AGENT; position accent: stacked loops, not one box -->
+  <rect x="616" y="76" width="124" height="82" rx="2" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1.5"/>
+  <rect x="606" y="66" width="124" height="82" rx="2" fill="#fafaf8" stroke="#6b6b6b" stroke-width="1.5"/>
+  <rect x="596" y="56" width="124" height="82" rx="2" fill="#fafaf8" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="658" y="80" text-anchor="middle" font-size="11" letter-spacing="1" font-weight="500" fill="#1a1a1a">MULTI-AGENT</text>
+  <text x="658" y="100" text-anchor="middle" font-size="11" fill="#6b6b6b">several loops</text>
+  <text x="658" y="116" text-anchor="middle" font-size="11" fill="#6b6b6b">delegate tasks</text>
 
-  <!-- Box 2: Workflow -->
-  <rect x="184" y="92" width="128" height="72" rx="8" fill="#EFF6FF" stroke="#3B82F6" stroke-width="1.5"/>
-  <text x="248" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#1D4ED8">Workflow</text>
-  <text x="248" y="130" text-anchor="middle" font-size="10" fill="#6B7280">Fixed pipeline</text>
-  <text x="248" y="148" text-anchor="middle" font-size="10" fill="#6B7280">Code routes steps —</text>
-  <text x="248" y="160" text-anchor="middle" font-size="10" fill="#6B7280">model executes each</text>
+  <!-- Property table -->
+  <line x1="46" y1="182" x2="714" y2="182" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Arrow 2→3 -->
-  <line x1="313" y1="128" x2="339" y2="128" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+  <text x="46" y="202" font-size="10" letter-spacing="1" fill="#6b6b6b">AUTONOMY</text>
+  <text x="108" y="220" text-anchor="middle" font-size="11" fill="#1a1a1a">None</text>
+  <text x="244" y="220" text-anchor="middle" font-size="11" fill="#1a1a1a">None</text>
+  <text x="380" y="220" text-anchor="middle" font-size="11" fill="#1a1a1a">Single-turn</text>
+  <text x="516" y="220" text-anchor="middle" font-size="11" fill="#1a1a1a">Multi-turn loop</text>
+  <text x="658" y="213" text-anchor="middle" font-size="11" fill="#1a1a1a">Multi-loop,</text>
+  <text x="658" y="227" text-anchor="middle" font-size="11" fill="#1a1a1a">multi-actor</text>
 
-  <!-- Box 3: Tool-Using -->
-  <rect x="340" y="92" width="128" height="72" rx="8" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5"/>
-  <text x="404" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400E">Tool-Using</text>
-  <text x="404" y="130" text-anchor="middle" font-size="10" fill="#6B7280">Model picks tools</text>
-  <text x="404" y="148" text-anchor="middle" font-size="10" fill="#6B7280">Model selects actions —</text>
-  <text x="404" y="160" text-anchor="middle" font-size="10" fill="#6B7280">one turn only</text>
+  <line x1="46" y1="238" x2="714" y2="238" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Arrow 3→4 -->
-  <line x1="469" y1="128" x2="495" y2="128" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+  <text x="46" y="258" font-size="10" letter-spacing="1" fill="#6b6b6b">TESTABILITY</text>
+  <text x="108" y="276" text-anchor="middle" font-size="11" fill="#1a1a1a">Easy</text>
+  <text x="244" y="276" text-anchor="middle" font-size="11" fill="#1a1a1a">Easy</text>
+  <text x="380" y="276" text-anchor="middle" font-size="11" fill="#1a1a1a">Moderate</text>
+  <text x="516" y="276" text-anchor="middle" font-size="11" fill="#1a1a1a">Hard</text>
+  <text x="658" y="276" text-anchor="middle" font-size="11" fill="#1a1a1a">Very hard</text>
 
-  <!-- Box 4: Agent -->
-  <rect x="496" y="92" width="128" height="72" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
-  <text x="560" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#B91C1C">Agent</text>
-  <text x="560" y="130" text-anchor="middle" font-size="10" fill="#6B7280">Autonomous loop</text>
-  <text x="560" y="148" text-anchor="middle" font-size="10" fill="#6B7280">Model directs loop —</text>
-  <text x="560" y="160" text-anchor="middle" font-size="10" fill="#6B7280">multi-step decisions</text>
+  <line x1="46" y1="288" x2="714" y2="288" stroke="#e8e8e8" stroke-width="1"/>
 
-  <!-- Arrow 4→5 -->
-  <line x1="625" y1="128" x2="651" y2="128" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arr-gray)"/>
-
-  <!-- Box 5: Multi-Agent -->
-  <rect x="652" y="92" width="128" height="72" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="2"/>
-  <text x="716" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#B91C1C">Multi-Agent</text>
-  <text x="716" y="130" text-anchor="middle" font-size="10" fill="#6B7280">Coordinated agents</text>
-  <text x="716" y="148" text-anchor="middle" font-size="10" fill="#6B7280">Multiple loops —</text>
-  <text x="716" y="160" text-anchor="middle" font-size="10" fill="#6B7280">distributed decisions</text>
-
-  <!-- Bottom properties row label -->
-  <text x="400" y="196" text-anchor="middle" font-size="11" font-weight="bold" fill="#9CA3AF">KEY PROPERTIES</text>
-
-  <!-- Property row: Autonomy -->
-  <text x="92"  y="218" text-anchor="middle" font-size="11" fill="#374151">None</text>
-  <text x="248" y="218" text-anchor="middle" font-size="11" fill="#374151">None</text>
-  <text x="404" y="218" text-anchor="middle" font-size="11" fill="#374151">Single-turn</text>
-  <text x="560" y="218" text-anchor="middle" font-size="11" fill="#374151">Multi-turn</text>
-  <text x="716" y="218" text-anchor="middle" font-size="11" fill="#374151">Multi-loop</text>
-
-  <text x="14" y="218" font-size="10" font-weight="bold" fill="#6B7280">Autonomy</text>
-
-  <!-- Property row: Testability -->
-  <text x="92"  y="238" text-anchor="middle" font-size="11" fill="#10B981">Easy</text>
-  <text x="248" y="238" text-anchor="middle" font-size="11" fill="#10B981">Easy</text>
-  <text x="404" y="238" text-anchor="middle" font-size="11" fill="#F59E0B">Moderate</text>
-  <text x="560" y="238" text-anchor="middle" font-size="11" fill="#EF4444">Hard</text>
-  <text x="716" y="238" text-anchor="middle" font-size="11" fill="#EF4444">Very hard</text>
-
-  <text x="14" y="238" font-size="10" font-weight="bold" fill="#6B7280">Testability</text>
-
-  <!-- Property row: Cost -->
-  <text x="92"  y="258" text-anchor="middle" font-size="11" fill="#10B981">High</text>
-  <text x="248" y="258" text-anchor="middle" font-size="11" fill="#10B981">High</text>
-  <text x="404" y="258" text-anchor="middle" font-size="11" fill="#F59E0B">Moderate</text>
-  <text x="560" y="258" text-anchor="middle" font-size="11" fill="#EF4444">Low</text>
-  <text x="716" y="258" text-anchor="middle" font-size="11" fill="#EF4444">Very low</text>
-
-  <text x="5" y="258" font-size="10" font-weight="bold" fill="#6B7280">Predictability</text>
-
-  <!-- Horizontal separator -->
-  <line x1="28" y1="206" x2="780" y2="206" stroke="#E5E7EB" stroke-width="1"/>
-  <line x1="28" y1="270" x2="780" y2="270" stroke="#E5E7EB" stroke-width="1"/>
-
-  <!-- Bottom guidance -->
-  <text x="400" y="290" text-anchor="middle" font-size="11" fill="#6B7280">Engineering principle: start at the left. Move right only when the simpler pattern cannot solve your problem.</text>
+  <text x="46" y="308" font-size="10" letter-spacing="1" fill="#6b6b6b">COST PREDICTABILITY</text>
+  <text x="108" y="326" text-anchor="middle" font-size="11" fill="#1a1a1a">High</text>
+  <text x="244" y="326" text-anchor="middle" font-size="11" fill="#1a1a1a">High</text>
+  <text x="380" y="326" text-anchor="middle" font-size="11" fill="#1a1a1a">Moderate</text>
+  <text x="516" y="326" text-anchor="middle" font-size="11" fill="#1a1a1a">Low</text>
+  <text x="658" y="326" text-anchor="middle" font-size="11" fill="#1a1a1a">Very low</text>
 </svg>

--- a/src/content/chapters/01-what-agentic-means.mdx
+++ b/src/content/chapters/01-what-agentic-means.mdx
@@ -9,6 +9,11 @@ references:
   - 03-workflow-first-agent-second
   - 04-multi-agent-without-theater
   - fn-001
+  - fn-003
+  - fn-004
+  - sg-002
+  - sg-003
+  - lab-001
 patterns:
   - workflow-first
   - agent-loop
@@ -17,13 +22,13 @@ status: published
 
 import Callout from '~/components/universal/Callout.astro';
 
-A team spent four months building what they called an agent. It had tools, a system prompt, and an API endpoint. It processed customer queries, looked up account information, searched a knowledge base, and generated responses. The architecture diagram showed an agent loop with dynamic tool selection.
+A composite, drawn from a pattern that recurs across support and account-lookup agents: a team spent months building what they called an agent. It had tools, a system prompt, and an API endpoint. It processed customer queries, looked up account information, searched a knowledge base, and generated responses. The architecture diagram showed an agent loop with dynamic tool selection.
 
-When we instrumented it, the data told a different story. The system called the same three tools in the same order on every query. It never skipped a step. It never went back to re-retrieve after seeing the account. It never decided that a different approach was needed. It was a workflow wearing an agent costume. The agent loop added 3x latency, 2.5x token cost, and occasional random skipping behavior where the model decided to drop the account lookup step entirely, producing generic responses for customers with specific billing problems.
+When the team instrumented it, the data told a different story. The system called the same three tools in the same order on every query. It never skipped a step. It never went back to re-retrieve after seeing the account. It never decided that a different approach was needed. It was a workflow wearing an agent costume -- the same mislabeling [FN-003](/field-notes/003-anthropic-told-you-harness-is-product/) documents from the other direction, where credit for what a harness does gets attributed to the model instead. The agent loop added real latency and token cost over a fixed pipeline, plus something worse: occasional random skipping, where the model decided to drop the account lookup step entirely, producing generic responses for customers with specific billing problems.
 
-Replacing the agent with a fixed three-step pipeline improved response time, reduced cost, and eliminated the skipping behavior. Four months of engineering, rebuilt in a week, because nobody had asked the question this chapter answers: what kind of system are we actually building?
+Replacing the agent with a fixed three-step pipeline improved response time, reduced cost, and eliminated the skipping behavior. Months of engineering, rebuilt in a fraction of the time, because nobody had asked the question this chapter answers: what kind of system are we actually building?
 
-The word "agent" is used to describe everything from a chatbot with a system prompt to a multi-model orchestration system that autonomously manages infrastructure. When a term means everything, it means nothing, and engineering decisions based on ambiguous terminology produce ambiguous systems. Teams build agents when they need workflows. They add autonomy to systems that need predictability. Not because they lack skill, but because the vocabulary they are working with does not help them distinguish between fundamentally different system shapes.
+The word "agent" describes everything from a chatbot with a system prompt to a multi-model orchestration system that autonomously manages infrastructure. When a term means everything, it means nothing, and ambiguous terminology produces ambiguous engineering decisions. Teams build agents when they need workflows and add autonomy to systems that need predictability -- not for lack of skill, but because the vocabulary does not distinguish between fundamentally different system shapes.
 
 ## The five system types
 
@@ -43,7 +48,7 @@ The model's role is generation. The system's control flow is entirely in your co
 
 A workflow is a deterministic sequence of steps where some steps involve LLM calls. The key property: the control flow is fixed. Step A always happens before Step B. The code decides what happens next, never the model.
 
-Examples: a RAG pipeline (retrieve, then generate), an extraction pipeline (parse, then extract, then validate), a content pipeline (draft, then review, then format).
+Examples: a RAG pipeline (retrieve, then generate -- see [SG-002](/signal/002-when-long-context-replaces-rag/) for when long context changes that architecture), an extraction pipeline (parse, then extract, then validate), a content pipeline (draft, then review, then format).
 
 The model's role is execution within each step. Between steps, your code handles routing, error checking, and data transformation.
 
@@ -61,7 +66,7 @@ The model's role expands to include action selection. It is no longer just gener
 
 ### 4. Agent
 
-An agent is a system where the model participates in a loop, making decisions at each iteration about what to do next based on what it has observed so far. The defining characteristic is the loop: observe the current state, decide on an action, execute it, observe the result, and repeat.
+An agent is a system where the model participates in a loop, making decisions at each iteration about what to do next based on what it has observed so far. The defining characteristic is the loop: observe the current state, decide on an action, execute it, observe the result, and repeat -- the same shape Rao and Georgeff described for belief-desire-intention agents in 1995, decades before a language model sat inside it.
 
 This is where autonomy enters the picture. The model is not just executing a fixed plan. It is deciding, at each step, whether to gather more information, call a tool, refine its approach, or produce a final answer. The control flow is no longer fully in your code.
 
@@ -70,7 +75,7 @@ Examples: a research agent that searches, reads, searches again based on what it
 **Failure surface:** Everything from tool-using systems, plus: unbounded loops (the agent keeps going without converging), budget exhaustion (the agent runs out of steps before reaching an answer), compounding errors (each step's mistakes feed into the next step's context), and the fundamental unpredictability of having a probabilistic system make control-flow decisions.
 
 <figure>
-  <img src="/assets/diagrams/agent-anatomy.svg" alt="The four components of the agent loop: observe, think, act, and the iteration budget" />
+  <img src="/assets/diagrams/agent-anatomy.svg" alt="The four components of the agent loop: observe, reason, act, and state" />
   <figcaption>Figure 1.1: Agent Anatomy -- the four components of the agent loop</figcaption>
 </figure>
 
@@ -81,6 +86,8 @@ A multi-agent system involves multiple agents that communicate, delegate, or coo
 Examples: a system where a planning agent breaks down a task and delegates subtasks to specialist agents, a peer review system where one agent drafts and another critiques.
 
 **Failure surface:** Everything from single agents, multiplied by the number of agents, plus: coordination failures (agents work at cross purposes), delegation errors (the wrong agent gets the wrong subtask), communication overhead (agents spend tokens talking to each other rather than solving the problem), and emergent behaviors that no individual agent was designed to produce.
+
+Whether that failure surface is worth taking on is a property of the task, not a maturity level to graduate to -- [SG-003](/signal/003-multi-agent-decision-variable/) gives the decision rule (does the work decompose into branches that do not need to see each other, or does it share state), and [Lab-001](/labs/multi-agent-vs-router-100-queries/) measures what it costs to get that call wrong.
 
 ## Comparison table
 
@@ -106,9 +113,9 @@ Read this table from left to right as a spectrum of increasing autonomy, increas
 
 The concept that makes agents practical in production is bounded autonomy. Unbounded autonomy -- "do whatever you think is best until you are done" -- is not an engineering pattern. It is a hope. And in production, hope is not a strategy.
 
-Consider what happens without bounds. You deploy an agent that can search documents, call APIs, and generate reports. A user sends a tricky query. The agent searches, finds partial results, searches again with a refined query, finds more partial results, tries a third approach, calls an extraction tool, gets an error, retries, searches yet again. Twenty model calls later, it produces an answer that is no better than what it had after the second call. It burned $0.15 in tokens, took 45 seconds, and the user has already given up and called a human.
+Consider what happens without bounds. A representative case, composited from agents built without stop conditions: you deploy an agent that can search documents, call APIs, and generate reports. A user sends a tricky query. The agent searches, finds partial results, searches again with a refined query, finds more partial results, tries a third approach, calls an extraction tool, gets an error, retries, searches yet again. Many model calls later, it produces an answer no better than what it had several steps earlier -- burning tokens and time the user does not have, until the user gives up and calls a human.
 
-This is not a theoretical failure mode. It is the default behavior of an agent without bounds. Language models do not have an inherent sense of diminishing returns. They will keep working -- keep consuming tokens, keep adding latency -- because their training rewarded being thorough, not being efficient.
+This is not a theoretical failure mode. It is the default behavior of an agent without bounds. Language models do not have a built-in sense of diminishing returns, and knowing when to stop turns out to be a harder problem than it looks: [FN-004](/field-notes/004-loop-engineering-30-year-old-loop/) traces the stop condition back to a thirty-year-old problem in the agent literature that predates language models entirely and remains unsolved. Run a bounded agent against one without a stop condition yourself on [the Bench](/bench/).
 
 Bounded autonomy means the agent operates within explicit constraints:
 
@@ -118,13 +125,11 @@ Bounded autonomy means the agent operates within explicit constraints:
 
 A larger action space is not always better. Each additional tool increases the probability that the model picks the wrong one. It also increases the surface area for tool-argument hallucination. Design the action space to include exactly what the agent needs and nothing more.
 
-**Stop conditions.** The agent has explicit criteria for when to stop: confidence above a threshold, all required fields extracted, or budget exhausted. "I think I am done" is not a stop condition. Stop conditions are checked in code, not left to the model's judgment. The model can signal that it wants to stop (by producing text instead of tool calls), but the system verifies that the stopping criteria are met.
+**Stop conditions.** The agent has explicit criteria for when to stop: confidence above a threshold, all required fields extracted, or budget exhausted. "I think I am done" is not a stop condition. Stop conditions are checked in code, not left to the model's judgment. The model can signal that it wants to stop (by producing text instead of tool calls), but the system verifies that the stopping criteria are met. This split matters because a model grading its own stopping criteria is not a stop condition at all -- [FN-004](/field-notes/004-loop-engineering-30-year-old-loop/) traces the evidence that models cannot reliably find their own errors, which is why the check has to live outside the model being checked.
 
 **Escalation policy.** When the agent cannot meet its confidence threshold within its budget, it escalates rather than guesses. This is the difference between a system that fails gracefully and one that fails silently. Escalation means the system says: "I was unable to answer this confidently. Here is what I found, and here is what is missing." This is vastly more useful than a confident wrong answer, which the downstream consumer has no reason to question.
 
-The interplay between these bounds matters. The budget prevents runaway execution. The action space prevents unexpected behavior. Stop conditions prevent premature or late termination. Escalation handles the cases that fall outside the system's capability. Together, they create a bounded region of autonomous operation that is predictable enough to trust and capable enough to be useful.
-
-These bounds are not restrictions on intelligence. They are the engineering controls that make intelligence useful. A system without bounds is not more capable -- it is less trustworthy. The engineering challenge is calibrating the bounds: tight enough to prevent waste, loose enough to let the agent do its job.
+The interplay matters: budget prevents runaway execution, action space prevents unexpected behavior, stop conditions prevent premature or late termination, and escalation handles what falls outside the system's capability. Together, they form a bounded, trustworthy, useful region of autonomy -- not a restriction on intelligence but the engineering control that makes it usable. Calibrating the bounds is the real challenge: tight enough to prevent waste, loose enough to let the agent do its job.
 
 ## What is not an agent
 
@@ -203,11 +208,9 @@ The key phrase is "not known in advance." If you can write an if/else chain that
 - The coordination overhead is justified by the specialization benefit
 - Example: large-scale research with synthesis, systems with distinct review/approval stages
 
-Multi-agent systems are the most complex and least predictable option. Before choosing this pattern, ask: can I achieve the same decomposition with multiple tools inside a single agent? Usually the answer is yes. Multi-agent systems are justified only when the subtasks require truly different system prompts, different model configurations, or parallel execution with independent state.
+Multi-agent systems are the most complex and least predictable option. Before choosing this pattern, ask: can I achieve the same decomposition with multiple tools inside a single agent? Usually the answer is yes. On a 100-query customer-support benchmark filtered to tasks resolvable in under five turns, a workflow router beat a three-agent hierarchy 87% to 74% on accuracy, at less than half the cost and latency ([Lab-001](/labs/multi-agent-vs-router-100-queries/); the decision rule behind the number is in [SG-003](/signal/003-multi-agent-decision-variable/)). Multi-agent systems are justified only when the subtasks require truly different system prompts, different model configurations, or parallel execution with independent state -- when the work genuinely does not decompose into tools one agent can call.
 
-At each step to the right, you gain capability and lose predictability. The engineering question is always: does the next level of autonomy buy me enough capability to justify what I lose in control?
-
-For most production systems today, the answer lands on "workflow" or "tool-using system." Agents are appropriate less often than the current discourse suggests. Multi-agent systems are appropriate rarely. This is not a criticism of the technology. It is a recognition that simpler architectures are easier to build, test, operate, and trust.
+For most production systems today, the answer lands on "workflow" or "tool-using system." Agents are appropriate less often than the June 2026 loop-engineering discourse suggests ([FN-004](/field-notes/004-loop-engineering-30-year-old-loop/) traces where that discourse overreaches). Multi-agent systems are appropriate rarely. This is not a criticism of the technology. It is a recognition that simpler architectures are easier to build, test, operate, and trust.
 
 ## Core concepts: a precise vocabulary
 
@@ -216,6 +219,8 @@ Before we move to building, a few terms that will recur throughout the book.
 **Action space.** The set of actions available to an agent at any given step. In our system, this is the set of registered tools plus the action of producing a final answer. A smaller action space is almost always better -- it reduces the model's decision burden and the system's failure surface.
 
 **Observation.** The information available to the agent at the start of a step. This includes the original query, retrieved evidence, tool results from previous steps, and any state the system maintains. What you include in the observation is a design decision with direct impact on quality and cost.
+
+**State.** What the loop carries forward between steps: results already retrieved, decisions already made, tools already called. State is what makes step three different from a fresh start -- the agent remembers what came before, and how much of that memory feeds back into the next observation is itself a design decision.
 
 **Step.** One iteration of the observe-think-act loop. The agent observes the current state, decides on an action, and executes it. Each step consumes tokens and adds latency. Steps are the unit of budget.
 
@@ -250,3 +255,12 @@ You now have a vocabulary and a decision framework. You know what an agent is, w
 But understanding the taxonomy is not enough to build anything. The next step is concrete: what does an LLM actually need to know and do to become useful inside a system? How do you give it tools, assemble its context, and structure the loop that turns a language model into a component that can reason and act?
 
 Chapter 2 answers these questions with working code.
+
+## Further reading
+
+- **["BDI Agents: From Theory to Practice"](https://cdn.aaai.org/ICMAS/1995/ICMAS95-042.pdf)** -- Rao and Georgeff, 1995. The observe-decide-execute loop behind this chapter's agent definition, three decades before "agent loop" was a term anyone used.
+- **[FN-003: Anthropic just told you the harness is the product](/field-notes/003-anthropic-told-you-harness-is-product/)** -- Why crediting a model for what its harness did is the same category error as calling a workflow an agent.
+- **[FN-004: Loop engineering is a 30-year-old loop with a new hashtag](/field-notes/004-loop-engineering-30-year-old-loop/)** -- Why the stop condition this chapter treats as a design requirement is still an open problem, and what an enforced gate looks like against a real agent.
+- **[SG-002: Long context did not kill RAG. It changed what retrieval is for.](/signal/002-when-long-context-replaces-rag/)** -- The routing rule for when a RAG workflow can be replaced by a long context window, and when it cannot.
+- **[SG-003: Multi-agent is not an architecture decision. It is a workload decision.](/signal/003-multi-agent-decision-variable/)** -- The decision rule behind this chapter's multi-agent guidance: decomposability, not maturity, decides.
+- **[Lab-001: Multi-agent vs router on 100 customer-support queries](/labs/multi-agent-vs-router-100-queries/)** -- The experiment behind the 87% vs 74% figure in the decision map above.


### PR DESCRIPTION
Chapter 1 (What Agentic Actually Means) is the book's free sample chapter, and after the Foundations refresh it read as the visible quality drop: zero links in 3,700 words, an opening hook built on invented-precision numbers with no composite label, and it asserted unsourced the exact stop-condition claim FN-004 now proves with sources. This closes that gap. It has no code and no model-name staleness (the chapter is deliberately model-agnostic, which held up).

Content:
- Both anecdotes composite-labeled (matching the 00b/00c convention), invented precision removed.
- Six cross-links added where the chapter was reinventing newer, sourced pieces: FN-004 and the Loop Lab at the stop-condition claim, FN-003 at the opening workflow-in-costume anecdote, SG-003 and LAB-001 at the multi-agent decision (the 'usually the answer is yes' call now carries LAB-001's real 87% vs 74% numbers), SG-002 at the RAG example. Further Reading section added in the house style.
- Fixed a diagram alt-text bug (it named a box that was not in the figure) and added the missing glossary entry.

Diagrams (both redrawn in the Gallery paper/ink/brick register):
- agent-anatomy: the observe/reason/act/state loop with the brick accent on the decision point.
- system-types-spectrum: fixed the real bug where Agent and Multi-Agent were distinguished only by a 2px vs 1.5px stroke (invisible) - Multi-Agent is now a stacked-cards motif - and corrected a mislabeled property row.

Verification: vitest 11/11, pytest 142/142, clean build, all six links resolve with reverse-index backlinks, LAB-001 figures verified against the lab page, screenshots at desktop and 400px, both figures cross-checked against the chapter's own table in review.

Merging deploys via Actions. Note: the chapter's 6-column comparison table overflows at 400px - pre-existing, structural, flagged for the follow-up bundle rather than fixed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the differences between workflows, agents, and multi-agent systems with updated examples and terminology.
  * Added guidance on bounded autonomy, including clearer stop-condition and retry behavior explanations.
  * Updated decision guidance on when to use single-agent, workflow, or multi-agent approaches, with benchmark-backed recommendations.
  * Expanded the chapter’s glossary and added a new further-reading section for related concepts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->