### PR TITLE
Lab-002: the durable, human-gated agent (ADK 2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ recipes/R-001/rec001/
 .astro/
 *.log
 .env.production
+
+# Lab-002 isolated venv (never commit) and local db
+.venv-lab002/
+labs/lab_002/runs/durability.db

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint eval run clean serve build-site deploy compare-multiagent foundations foundations-compare
+.PHONY: install test lint eval run clean serve build-site deploy compare-multiagent foundations foundations-compare lab-002-data lab-002-run lab-002-eval
 
 install:
 	pip install -e ".[dev]"
@@ -56,3 +56,12 @@ foundations:
 
 foundations-compare:
 	python src/ch00/eval_compare.py
+
+lab-002-data:
+	python -m labs.lab_002.dataset 30
+
+lab-002-run:
+	python -m labs.lab_002.run
+
+lab-002-eval:
+	python -m labs.lab_002.evaluate

--- a/labs/lab_002/README.md
+++ b/labs/lab_002/README.md
@@ -1,0 +1,115 @@
+# Lab-002: static baseline vs durable contender (local, reproducible)
+
+A free, fully local run comparing a single static ADK agent (**baseline**) against
+a dynamic investigator/verifier workflow with a human-approval gate before any
+irreversible action (**contender**), on the same synthetic incident set, tools,
+and model. A separate durability harness "crashes" the contender mid-run at the
+approval gate and resumes it from disk in a fresh process, to measure what a
+persisted session actually saves on resume.
+
+## Read this first (honesty caveats)
+
+1. **Local floor only, no Gemini comparison yet.** This run uses local open
+   models via Ollama (`llama3.2:3b` for the agents, `qwen2.5:14b` for the
+   judge). `run.py` has a `LAB002_MODEL=gemini-2.0-flash` path that switches to
+   native Gemini (no `LiteLlm` wrapper), but no Gemini API key is configured in
+   this environment, so that path is untested here. Treat any local-vs-Gemini
+   comparison as future work, not a claim in the committed numbers.
+2. **No dollar cost.** Local inference is free, so the cost axis is tokens and
+   model calls per incident, not dollars.
+3. **Synthetic incidents.** `incidents.json` is deterministically generated
+   (four fault families, seeded), not a real incident corpus. It exercises the
+   architecture difference (static single pass vs dynamic fan-out with a gate),
+   not real-world incident diversity.
+4. **Two scoring passes.** `run.py` computes a cheap heuristic success rate
+   (keyword overlap against ground truth). `evaluate.py` is a separate, slower
+   pass that re-scores the same recorded findings with an LLM judge, as a
+   cross-check on the heuristic. Both numbers are in RESULTS.md.
+
+## Reproduce
+
+Requires [Ollama](https://ollama.com) running locally and the `lab002` extra
+(`google-adk>=2.3.0`, `litellm>=1.40`) installed in a dedicated virtualenv --
+the project's default environment pins an older ADK and must not be used here.
+
+```bash
+# 1. Pull the models (agents = small, judge = mid).
+ollama pull llama3.2:3b
+ollama pull qwen2.5:14b
+
+# 2. Set up the ADK-2.3.0 virtualenv (once).
+python3.12 -m venv .venv-lab002
+.venv-lab002/bin/pip install -e ".[lab002]"
+
+# 3. Generate the incident set (deterministic, seed 42).
+make lab-002-data          # python -m labs.lab_002.dataset 30
+
+# 4. Run both systems + the durability harness, record transcripts.
+GOOGLE_GENAI_USE_VERTEXAI=0 make lab-002-run     # python -m labs.lab_002.run
+
+# 5. Score the recorded findings with the LLM judge and write RESULTS.md.
+GOOGLE_GENAI_USE_VERTEXAI=0 make lab-002-eval    # python -m labs.lab_002.evaluate
+```
+
+Run from the repository root so `labs` and `src` import correctly, and use
+`.venv-lab002/bin/python` (or activate that venv) for steps 3-5, not the
+project's default Python.
+
+To smoke-test the pipeline cheaply before a full run, set `LAB002_LIMIT` to
+process only the first N incidents:
+
+```bash
+GOOGLE_GENAI_USE_VERTEXAI=0 LAB002_LIMIT=2 .venv-lab002/bin/python -m labs.lab_002.run
+GOOGLE_GENAI_USE_VERTEXAI=0 LAB002_LIMIT=2 .venv-lab002/bin/python -m labs.lab_002.evaluate
+```
+
+## What the repo contains vs what you generate
+
+Committed (the reusable harness): `dataset.py`, `schema.py`, `tools.py`,
+`gate.py`, `systems.py`, `durability.py`, `metrics.py`, `run.py`,
+`evaluate.py`, `rubric.yaml`, `incidents.json` (the deterministic sample), and
+this README.
+
+Generated locally when you run it: `runs/<system>/<id>.json` transcripts (plus
+`runs/durability/<id>.json` for the crash-tested subset), `results.json`, and
+`RESULTS.md`. These are reproducible from the recipe above; re-running
+overwrites them.
+
+## Design
+
+- `dataset.py` -- deterministic, family-balanced synthetic incidents (bad
+  deploy, config drift, dependency failure, data issue), seed 42.
+- `schema.py` -- the shared Pydantic contracts: `Incident`, `Hypothesis`,
+  `Verdict`, `Finding`, `RemediationDecision`, `RunRecord`.
+- `tools.py` / `gate.py` -- deterministic mock tools (log search, metric
+  query, config/diff read) and the out-of-band approval-token check that
+  gates the one irreversible action.
+- `systems.py` -- the **baseline** (single static `Agent`, one pass, fixed
+  gate on an exact-action match) and the **contender** (an ADK `Workflow`:
+  a dynamic investigator/verifier fan-out across four branches, synthesized
+  into one `Finding`, paused at a `RequestInput` human-approval gate before
+  the remediation node runs).
+- `durability.py` -- crashes the contender at the approval gate (drops the
+  runner and session service) and resumes it from a fresh
+  `SqliteSessionService` over the same on-disk file, proving ADK's dedup
+  skips the pre-interrupt work instead of re-running it.
+- `metrics.py` -- the heuristic success-rate scorer (keyword overlap against
+  ground truth) and the durability-savings calculation.
+- `run.py` -- runs baseline and contender over every incident, plus the
+  durability harness over a fixed 5-incident subset; writes transcripts,
+  `results.json`, and `RESULTS.md`. Guards a bad incident (exception, or the
+  gate never reached) so it is skipped rather than aborting the batch --
+  this closes a gap flagged in Task 9 review, where the durability harness
+  had no such guard.
+- `evaluate.py` -- LLM-judge re-scoring of `root_cause_match` and
+  `remediation_match` (judge-scored 0..1) plus a deterministic
+  `action_correct` check, against `rubric.yaml` (weights 0.5/0.3/0.2, pass at
+  0.6, matching `metrics._PASS`), N judge passes to bound variance. Folds the
+  result back into `results.json` and regenerates `RESULTS.md`.
+
+## Determinism
+
+Models run at temperature 0, but local-model output is not perfectly
+deterministic across hardware and quantization. The committed transcripts and
+per-run judge scores make the reported numbers inspectable; re-running may
+vary slightly.

--- a/labs/lab_002/RESULTS.md
+++ b/labs/lab_002/RESULTS.md
@@ -1,0 +1,43 @@
+# Lab-002 (local reproduction): static baseline vs durable contender
+
+Agent model: `ollama_chat/llama3.2:3b`. 30 incidents, 0 errors during the main run.
+
+## Results
+
+| Metric | Baseline | Contender |
+|--------|----------|-----------|
+| Success rate (heuristic keyword overlap) | 20.0% | 10.0% |
+| Success rate (LLM judge, `qwen2.5:14b`) | 16.7% | 10.0% |
+| Avg judge weighted score | 0.273 | 0.326 |
+| Judge variance (mean stdev) | 0.000 | 0.000 |
+| Avg total tokens / incident | 290.2 | 6256 |
+| Avg model calls | 1 | 16.93 |
+| p50 latency (ms) | 2552.4 | 48106.0 |
+| Remediation applied rate | 3.3% | 100.0% |
+
+**Cost multiple (contender / baseline avg tokens):** 21.56x. **Latency multiple (contender / baseline p50):** 18.85x.
+
+## Durability (crash + resume over a fixed subset)
+
+5 of 5 incidents in the subset reached the human gate and were crash-tested (0 skipped: no finding reached the gate, or the resume errored).
+
+| Metric | Value |
+|--------|-------|
+| Avg tokens saved on resume | 6265.0 |
+| Avg model calls saved on resume | 17.0 |
+| Avg latency (ms) saved on resume | 48590.3 |
+| Avg frontier-only calls after resume | 0.0 |
+
+## LLM judge cross-check
+
+Judge: `qwen2.5:14b`, 3 passes per finding, weights {'root_cause_match': 0.5, 'remediation_match': 0.3, 'action_correct': 0.2}, pass threshold 0.6. `root_cause_match` and `remediation_match` are judge-scored 0..1; `action_correct` is a deterministic exact match against the incident's sanctioned action (no judge call needed for that one).
+
+This is the honesty check on the cheap heuristic above: keyword overlap can both over- and under-credit a finding relative to what an independent reader would say root-caused the incident.
+
+## Read this before quoting the numbers
+
+1. Local open models only (agent above, judge above). No Gemini key is configured in this environment, so `LAB002_MODEL=gemini-2.0-flash` is an untested path here, not a claim made by this run.
+2. Local inference has no dollar cost. The cost axis is tokens and model calls per incident, not dollars.
+3. Judge scoring carries local-model nondeterminism even at temperature 0; per-pass scores are in results.json so the reported averages are inspectable.
+
+Run duration (main): 4830.7s. Run duration (judging): 294.9s. Per-incident transcripts are under `runs/`; full per-incident detail, including every judge pass, is in results.json.

--- a/labs/lab_002/__init__.py
+++ b/labs/lab_002/__init__.py
@@ -1,0 +1,1 @@
+"""Lab-002: the durable, human-gated agent (ADK 2.0)."""

--- a/labs/lab_002/dataset.py
+++ b/labs/lab_002/dataset.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import random
+import sys
+from pathlib import Path
+
+from labs.lab_002.schema import FaultFamily, Incident, IncidentBundle
+
+_PATH = Path(__file__).parent / "incidents.json"
+
+# Per-family templates: (root_cause, remediation, action_prefix, service pool)
+_TEMPLATES = {
+    FaultFamily.BAD_DEPLOY: (
+        "bad deploy of {svc} {ver}", "rollback {svc} to previous version",
+        "rollback_deploy", ["svc-checkout", "svc-payments", "svc-search"]),
+    FaultFamily.CONFIG_DRIFT: (
+        "config drift on {svc}: {key} changed", "revert {key} on {svc}",
+        "revert_config", ["svc-auth", "svc-orders", "svc-inventory"]),
+    FaultFamily.DEPENDENCY_FAILURE: (
+        "{svc} dependency {dep} timing out", "restart {svc} and fail over {dep}",
+        "restart_service", ["svc-notify", "svc-ledger", "svc-catalog"]),
+    FaultFamily.DATA_ISSUE: (
+        "stale cache serving bad data on {svc}", "purge cache for {svc}",
+        "purge_cache", ["svc-profile", "svc-pricing", "svc-feed"]),
+}
+
+
+def _make(idx: int, family: FaultFamily, rng: random.Random) -> Incident:
+    root, remed, prefix, svcs = _TEMPLATES[family]
+    svc = rng.choice(svcs)
+    ver = f"v1.{rng.randint(0, 9)}.{rng.randint(0, 9)}"
+    key = rng.choice(["replicas", "timeout_ms", "max_conns"])
+    dep = rng.choice(["redis", "postgres", "kafka"])
+    err = round(rng.uniform(0.3, 0.95), 2)
+    root_cause = root.format(svc=svc, ver=ver, key=key, dep=dep)
+    return Incident(
+        id=f"inc-{idx:03d}",
+        fault_family=family,
+        bundle=IncidentBundle(
+            logs=[f"[error] {svc} 5xx spike", f"[warn] {dep} latency high"],
+            metrics={"err_rate": err, "p99_ms": round(rng.uniform(200, 4000), 1)},
+            config={key: str(rng.randint(1, 9)), "region": rng.choice(["eu", "us"])},
+            diff=f"- {svc}:{ver}\n+ {svc}:v1.{rng.randint(0, 9)}.{rng.randint(0, 9)}",
+        ),
+        ground_truth_root_cause=root_cause,
+        ground_truth_remediation=remed.format(svc=svc, key=key, dep=dep),
+        irreversible_action=f"{prefix}:{svc}@{ver}",
+    )
+
+
+def generate(n: int, seed: int = 42) -> list[Incident]:
+    """Deterministic, family-balanced synthetic incidents."""
+    rng = random.Random(seed)
+    families = list(FaultFamily)
+    out: list[Incident] = []
+    for idx in range(n):
+        family = families[idx % len(families)]
+        out.append(_make(idx, family, rng))
+    return out
+
+
+def load(path: str | Path = _PATH) -> list[Incident]:
+    data = json.loads(Path(path).read_text())
+    return [Incident.model_validate(d) for d in data]
+
+
+if __name__ == "__main__":
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 30
+    items = generate(n, seed=42)
+    _PATH.write_text(json.dumps([i.model_dump() for i in items], indent=2) + "\n")
+    print(f"wrote {len(items)} incidents to {_PATH}")

--- a/labs/lab_002/durability.py
+++ b/labs/lab_002/durability.py
@@ -1,0 +1,79 @@
+"""Lab-002 durability harness: kill the contender at the gate, resume from
+SQLite in a fresh process, and prove ADK's dedup skips completed work.
+
+Two `SqliteSessionService` instances point at the same on-disk file across
+the two phases. The second one has zero in-memory state and rehydrates
+purely from the persisted event log -- that is the crash boundary this
+harness measures.
+"""
+
+from __future__ import annotations
+
+import time
+
+from google.adk.runners import Runner
+from google.adk.sessions.sqlite_session_service import SqliteSessionService
+from google.genai import types
+
+from labs.lab_002.schema import Incident, RemediationDecision, RunRecord
+from labs.lab_002.systems import (
+    _APP,
+    _USER,
+    _context_blob,
+    _extract_finding,
+    _resume,
+    _tally,
+    build_contender,
+)
+
+
+async def run_with_crash(
+    incident: Incident, model, db_path: str
+) -> tuple[RunRecord, RunRecord]:
+    """Run the contender to the human gate, "crash" it, then resume from a
+    fresh SqliteSessionService over the same db file.
+
+    Returns (pre_interrupt, post_resume) RunRecords.
+    """
+    session_id = f"crash-{incident.id}"
+
+    # --- Phase 1: run to the human gate, then "crash" (drop the runner) ---
+    svc1 = SqliteSessionService(db_path=db_path)
+    await svc1.create_session(app_name=_APP, user_id=_USER, session_id=session_id)
+    wf1 = build_contender(model)
+    runner1 = Runner(agent=wf1, app_name=_APP, session_service=svc1)
+    content = types.Content(role="user", parts=[types.Part(text=_context_blob(incident))])
+    pre = RunRecord(system="contender", incident_id=incident.id)
+    interrupt_id: str | None = None
+    start = time.monotonic()
+    async for event in runner1.run_async(
+        session_id=session_id, user_id=_USER, new_message=content
+    ):
+        _tally(pre, event)
+        finding = _extract_finding(event)
+        if finding is not None:
+            pre.finding = finding
+        if event.long_running_tool_ids:
+            interrupt_id = next(iter(event.long_running_tool_ids))
+    pre.latency_ms = (time.monotonic() - start) * 1000
+    del runner1, svc1, wf1  # simulated process death
+
+    # --- Phase 2: fresh process, fresh service over the same db, resume ---
+    svc2 = SqliteSessionService(db_path=db_path)
+    reloaded = await svc2.get_session(app_name=_APP, user_id=_USER, session_id=session_id)
+    wf2 = build_contender(model)
+    runner2 = Runner(agent=wf2, app_name=_APP, session_service=svc2)
+    post = RunRecord(
+        system="contender", incident_id=incident.id, finding=pre.finding, resumed=True
+    )
+    decision = RemediationDecision(approved=True, approver="sre-oncall")
+    start = time.monotonic()
+    async for event in _resume(runner2, reloaded, interrupt_id, decision):
+        _tally(post, event)
+        if event.content and event.content.parts and any(
+            "applied" in (part.text or "") for part in event.content.parts
+        ):
+            post.remediation_applied = True
+    post.latency_ms = (time.monotonic() - start) * 1000
+    post.approved = True
+    return pre, post

--- a/labs/lab_002/evaluate.py
+++ b/labs/lab_002/evaluate.py
@@ -1,0 +1,292 @@
+"""Re-score recorded findings with an LLM judge and fold the result into
+results.json + RESULTS.md.
+
+Usage:
+    python -m labs.lab_002.evaluate                  # 3 judge passes, qwen2.5:14b
+    python -m labs.lab_002.evaluate --runs 1         # quick pass
+    python -m labs.lab_002.evaluate --judge-model qwen2.5:14b
+
+Reads results.json (written by run.py), which already carries a cheap
+heuristic success rate (keyword overlap, metrics.score_finding). This stage
+re-scores each recorded finding's root cause and remediation against the
+incident's ground truth with an LLM judge, averaging over repeated passes to
+bound judge variance, exactly mirroring Lab-001's judge-prompt shape. The
+third rubric criterion, action_correct, is a deterministic exact-match check
+(no judge call needed: it either names the sanctioned action or it doesn't).
+The numeric pass threshold matches `metrics._PASS` (0.6).
+
+Writes the judge scores back into results.json under a new "judge" key and
+regenerates RESULTS.md so it reflects both the run.py operational numbers
+(success rate, cost/latency multiples, durability savings) and this judge
+cross-check side by side.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import statistics
+import time
+from pathlib import Path
+
+import yaml
+
+from labs.lab_002 import dataset
+from labs.lab_002 import metrics as lab_metrics
+from src.shared.model_client import create_client
+from src.shared.types import CompletionRequest, Message, Role
+
+HERE = Path(__file__).parent
+SYSTEMS = ["baseline", "contender"]
+
+_JUDGE_SYSTEM = (
+    "You are a strict evaluation judge for incident-response findings. Score the "
+    "finding on two criteria, each from 0.0 to 1.0:\n"
+    "- root_cause_match: does the stated root cause correctly identify the actual "
+    "ground-truth root cause?\n"
+    "- remediation_match: does the proposed remediation correctly address the "
+    "ground-truth remediation?\n"
+    'Reply with strict JSON only: {"root_cause_match": x, "remediation_match": x}.'
+)
+
+
+def _clamp(x: float) -> float:
+    try:
+        return max(0.0, min(1.0, float(x)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _parse_scores(content: str) -> dict[str, float]:
+    match = re.search(r"\{.*\}", content or "", re.DOTALL)
+    if not match:
+        return {"root_cause_match": 0.0, "remediation_match": 0.0}
+    try:
+        raw = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return {"root_cause_match": 0.0, "remediation_match": 0.0}
+    return {k: _clamp(raw.get(k, 0.0)) for k in ("root_cause_match", "remediation_match")}
+
+
+async def _judge_once(client, incident, finding: dict) -> dict[str, float]:
+    user = (
+        f"Ground truth root cause: {incident.ground_truth_root_cause}\n"
+        f"Ground truth remediation: {incident.ground_truth_remediation}\n\n"
+        f"Finding root cause: {finding.get('root_cause', '') or '(empty)'}\n"
+        f"Finding remediation: {finding.get('proposed_remediation', '') or '(empty)'}"
+    )
+    resp = await client.complete(
+        CompletionRequest(
+            messages=[
+                Message(role=Role.SYSTEM, content=_JUDGE_SYSTEM),
+                Message(role=Role.USER, content=user),
+            ],
+            temperature=0.0,
+            max_tokens=100,
+            response_format={"type": "json_object"},
+        )
+    )
+    return _parse_scores(resp.content or "")
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Lab-002 evaluate: LLM-judge scoring")
+    parser.add_argument("--judge-model", default=None)
+    parser.add_argument("--runs", type=int, default=3, help="judge passes per finding")
+    parser.add_argument("--base-url", default="http://localhost:11434/v1")
+    args = parser.parse_args()
+
+    rubric = yaml.safe_load((HERE / "rubric.yaml").read_text())
+    weights = rubric["weights"]
+    threshold = rubric.get("pass_threshold", lab_metrics._PASS)
+    judge_cfg = rubric.get("judge", {})
+    judge_model = args.judge_model or judge_cfg.get("model", "qwen2.5:14b")
+    judge_provider = judge_cfg.get("provider", "local")
+
+    results_path = HERE / "results.json"
+    if not results_path.exists():
+        raise SystemExit(
+            "results.json not found -- run `python -m labs.lab_002.run` first"
+        )
+    results = json.loads(results_path.read_text())
+
+    incidents_by_id = {i.id: i for i in dataset.load()}
+    judge = create_client(judge_provider, model_name=judge_model, base_url=args.base_url)
+
+    started = time.time()
+    judge_summary: dict[str, dict] = {}
+
+    for system in SYSTEMS:
+        sys_records = results["systems"][system]["records"]
+        scored = []
+        for rec in sys_records:
+            finding = rec.get("finding")
+            incident = incidents_by_id.get(rec["incident_id"])
+            if finding is None or incident is None:
+                scored.append(
+                    {
+                        "incident_id": rec["incident_id"],
+                        "judge_passed": False,
+                        "judge_weighted": 0.0,
+                        "judge_scores": {
+                            "root_cause_match": 0.0,
+                            "remediation_match": 0.0,
+                            "action_correct": 0.0,
+                        },
+                        "run_weighted": [],
+                    }
+                )
+                continue
+
+            action_correct = (
+                1.0 if finding.get("proposed_action") == incident.irreversible_action else 0.0
+            )
+            run_scores = []
+            run_weighted = []
+            for _ in range(args.runs):
+                s = await _judge_once(judge, incident, finding)
+                s["action_correct"] = action_correct
+                run_scores.append(s)
+                run_weighted.append(sum(s[k] * weights[k] for k in weights))
+            avg_scores = {
+                k: statistics.mean(rs[k] for rs in run_scores)
+                for k in ("root_cause_match", "remediation_match", "action_correct")
+            }
+            mean_weighted = statistics.mean(run_weighted)
+            scored.append(
+                {
+                    "incident_id": rec["incident_id"],
+                    "judge_passed": mean_weighted >= threshold,
+                    "judge_weighted": round(mean_weighted, 4),
+                    "judge_scores": {k: round(v, 4) for k, v in avg_scores.items()},
+                    "run_weighted": [round(x, 4) for x in run_weighted],
+                }
+            )
+            print(
+                f"  [{system}] {rec['incident_id']} judge_weighted={mean_weighted:.2f} "
+                f"pass={mean_weighted >= threshold}"
+            )
+
+        n = len(scored)
+        passed = sum(1 for s in scored if s["judge_passed"])
+        variance = (
+            statistics.mean(
+                statistics.pstdev(s["run_weighted"]) if len(s["run_weighted"]) > 1 else 0.0
+                for s in scored
+            )
+            if scored
+            else 0.0
+        )
+        judge_summary[system] = {
+            "n": n,
+            "accuracy": round(passed / n, 4) if n else 0.0,
+            "avg_weighted": round(statistics.mean(s["judge_weighted"] for s in scored), 4)
+            if n
+            else 0.0,
+            "judge_variance": round(variance, 4),
+            "records": scored,
+        }
+
+    results["judge"] = {
+        "model": judge_model,
+        "runs": args.runs,
+        "pass_threshold": threshold,
+        "weights": weights,
+        "duration_s": round(time.time() - started, 1),
+        "systems": judge_summary,
+    }
+    results_path.write_text(json.dumps(results, indent=2))
+    (HERE / "RESULTS.md").write_text(_render_markdown(results))
+    print(
+        f"[evaluate] wrote results.json (judge section) and RESULTS.md "
+        f"({results['judge']['duration_s']}s)"
+    )
+
+
+def _render_markdown(r: dict) -> str:
+    base = r["systems"]["baseline"]
+    cont = r["systems"]["contender"]
+    dur = r["durability"]
+    judge = r["judge"]
+    jbase = judge["systems"]["baseline"]
+    jcont = judge["systems"]["contender"]
+    limit_note = f" (limited to first {r['limit']})" if r.get("limit") else ""
+
+    lines = [
+        "# Lab-002 (local reproduction): static baseline vs durable contender",
+        "",
+        f"Agent model: `{r['agent_model']}`. {r['n_incidents']} incidents{limit_note}, "
+        f"{r['errors']} errors during the main run.",
+        "",
+        "## Results",
+        "",
+        "| Metric | Baseline | Contender |",
+        "|--------|----------|-----------|",
+        f"| Success rate (heuristic keyword overlap) | {base['success_rate']:.1%} | {cont['success_rate']:.1%} |",
+        f"| Success rate (LLM judge, `{judge['model']}`) | {jbase['accuracy']:.1%} | {jcont['accuracy']:.1%} |",
+        f"| Avg judge weighted score | {jbase['avg_weighted']:.3f} | {jcont['avg_weighted']:.3f} |",
+        f"| Judge variance (mean stdev) | {jbase['judge_variance']:.3f} | {jcont['judge_variance']:.3f} |",
+        f"| Avg total tokens / incident | {base['avg_total_tokens']} | {cont['avg_total_tokens']} |",
+        f"| Avg model calls | {base['avg_model_calls']} | {cont['avg_model_calls']} |",
+        f"| p50 latency (ms) | {base['p50_latency_ms']} | {cont['p50_latency_ms']} |",
+        f"| Remediation applied rate | {base['remediation_rate']:.1%} | {cont['remediation_rate']:.1%} |",
+        "",
+        f"**Cost multiple (contender / baseline avg tokens):** {r['cost_multiple']}x. "
+        f"**Latency multiple (contender / baseline p50):** {r['latency_multiple']}x.",
+        "",
+        "## Durability (crash + resume over a fixed subset)",
+        "",
+        f"{dur['n']} of {len(r['durability_subset'])} incidents in the subset reached "
+        f"the human gate and were crash-tested ({r['durability_skipped']} skipped: no "
+        "finding reached the gate, or the resume errored).",
+        "",
+    ]
+    if dur["n"]:
+        lines += [
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Avg tokens saved on resume | {dur['avg_tokens_saved']} |",
+            f"| Avg model calls saved on resume | {dur['avg_model_calls_saved']} |",
+            f"| Avg latency (ms) saved on resume | {dur['avg_latency_ms_saved']} |",
+            f"| Avg frontier-only calls after resume | {dur['avg_frontier_calls']} |",
+            "",
+        ]
+    else:
+        lines += [
+            "No incidents in the durability subset reached the gate; no savings computed.",
+            "",
+        ]
+    lines += [
+        "## LLM judge cross-check",
+        "",
+        f"Judge: `{judge['model']}`, {judge['runs']} passes per finding, weights "
+        f"{judge['weights']}, pass threshold {judge['pass_threshold']}. "
+        "`root_cause_match` and `remediation_match` are judge-scored 0..1; "
+        "`action_correct` is a deterministic exact match against the incident's "
+        "sanctioned action (no judge call needed for that one).",
+        "",
+        "This is the honesty check on the cheap heuristic above: keyword overlap can "
+        "both over- and under-credit a finding relative to what an independent reader "
+        "would say root-caused the incident.",
+        "",
+        "## Read this before quoting the numbers",
+        "",
+        "1. Local open models only (agent above, judge above). No Gemini key is "
+        "configured in this environment, so `LAB002_MODEL=gemini-2.0-flash` is an "
+        "untested path here, not a claim made by this run.",
+        "2. Local inference has no dollar cost. The cost axis is tokens and model "
+        "calls per incident, not dollars.",
+        "3. Judge scoring carries local-model nondeterminism even at temperature 0; "
+        "per-pass scores are in results.json so the reported averages are inspectable.",
+        "",
+        f"Run duration (main): {r['duration_s']}s. Run duration (judging): "
+        f"{judge['duration_s']}s. Per-incident transcripts are under `runs/`; full "
+        "per-incident detail, including every judge pass, is in results.json.",
+    ]
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/labs/lab_002/gate.py
+++ b/labs/lab_002/gate.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class ApprovalError(RuntimeError):
+    """Raised when an irreversible action is attempted without valid approval."""
+
+
+@dataclass(frozen=True)
+class ApprovalToken:
+    action: str
+    approver: str
+
+
+def require_approval(action: str, token: ApprovalToken | None) -> None:
+    """Raise unless `token` authorizes exactly `action`.
+
+    This is the enforced stop from FN-004: the gate is a capability check
+    outside the model, not a prompt the model can talk past.
+    """
+    if token is None:
+        raise ApprovalError(f"no approval token for irreversible action: {action}")
+    if token.action != action:
+        raise ApprovalError(f"token authorizes '{token.action}', not '{action}'")

--- a/labs/lab_002/incidents.json
+++ b/labs/lab_002/incidents.json
@@ -1,0 +1,662 @@
+[
+  {
+    "id": "inc-000",
+    "fault_family": "bad_deploy",
+    "bundle": {
+      "logs": [
+        "[error] svc-search 5xx spike",
+        "[warn] postgres latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.46,
+        "p99_ms": 730.2
+      },
+      "config": {
+        "max_conns": "2",
+        "region": "eu"
+      },
+      "diff": "- svc-search:v1.1.0\n+ svc-search:v1.9.6"
+    },
+    "ground_truth_root_cause": "bad deploy of svc-search v1.1.0",
+    "ground_truth_remediation": "rollback svc-search to previous version",
+    "irreversible_action": "rollback_deploy:svc-search@v1.1.0"
+  },
+  {
+    "id": "inc-001",
+    "fault_family": "config_drift",
+    "bundle": {
+      "logs": [
+        "[error] svc-auth 5xx spike",
+        "[warn] redis latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.63,
+        "p99_ms": 300.8
+      },
+      "config": {
+        "replicas": "4",
+        "region": "us"
+      },
+      "diff": "- svc-auth:v1.0.1\n+ svc-auth:v1.3.7"
+    },
+    "ground_truth_root_cause": "config drift on svc-auth: replicas changed",
+    "ground_truth_remediation": "revert replicas on svc-auth",
+    "irreversible_action": "revert_config:svc-auth@v1.0.1"
+  },
+  {
+    "id": "inc-002",
+    "fault_family": "dependency_failure",
+    "bundle": {
+      "logs": [
+        "[error] svc-catalog 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.57,
+        "p99_ms": 1255.9
+      },
+      "config": {
+        "replicas": "4",
+        "region": "us"
+      },
+      "diff": "- svc-catalog:v1.4.0\n+ svc-catalog:v1.1.1"
+    },
+    "ground_truth_root_cause": "svc-catalog dependency kafka timing out",
+    "ground_truth_remediation": "restart svc-catalog and fail over kafka",
+    "irreversible_action": "restart_service:svc-catalog@v1.4.0"
+  },
+  {
+    "id": "inc-003",
+    "fault_family": "data_issue",
+    "bundle": {
+      "logs": [
+        "[error] svc-pricing 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.47,
+        "p99_ms": 365.1
+      },
+      "config": {
+        "timeout_ms": "8",
+        "region": "eu"
+      },
+      "diff": "- svc-pricing:v1.1.5\n+ svc-pricing:v1.6.1"
+    },
+    "ground_truth_root_cause": "stale cache serving bad data on svc-pricing",
+    "ground_truth_remediation": "purge cache for svc-pricing",
+    "irreversible_action": "purge_cache:svc-pricing@v1.1.5"
+  },
+  {
+    "id": "inc-004",
+    "fault_family": "bad_deploy",
+    "bundle": {
+      "logs": [
+        "[error] svc-search 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.42,
+        "p99_ms": 464.3
+      },
+      "config": {
+        "timeout_ms": "4",
+        "region": "us"
+      },
+      "diff": "- svc-search:v1.4.9\n+ svc-search:v1.1.3"
+    },
+    "ground_truth_root_cause": "bad deploy of svc-search v1.4.9",
+    "ground_truth_remediation": "rollback svc-search to previous version",
+    "irreversible_action": "rollback_deploy:svc-search@v1.4.9"
+  },
+  {
+    "id": "inc-005",
+    "fault_family": "config_drift",
+    "bundle": {
+      "logs": [
+        "[error] svc-auth 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.84,
+        "p99_ms": 818.1
+      },
+      "config": {
+        "timeout_ms": "6",
+        "region": "eu"
+      },
+      "diff": "- svc-auth:v1.6.4\n+ svc-auth:v1.4.1"
+    },
+    "ground_truth_root_cause": "config drift on svc-auth: timeout_ms changed",
+    "ground_truth_remediation": "revert timeout_ms on svc-auth",
+    "irreversible_action": "revert_config:svc-auth@v1.6.4"
+  },
+  {
+    "id": "inc-006",
+    "fault_family": "dependency_failure",
+    "bundle": {
+      "logs": [
+        "[error] svc-catalog 5xx spike",
+        "[warn] redis latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.41,
+        "p99_ms": 1641.9
+      },
+      "config": {
+        "max_conns": "9",
+        "region": "eu"
+      },
+      "diff": "- svc-catalog:v1.2.8\n+ svc-catalog:v1.5.0"
+    },
+    "ground_truth_root_cause": "svc-catalog dependency redis timing out",
+    "ground_truth_remediation": "restart svc-catalog and fail over redis",
+    "irreversible_action": "restart_service:svc-catalog@v1.2.8"
+  },
+  {
+    "id": "inc-007",
+    "fault_family": "data_issue",
+    "bundle": {
+      "logs": [
+        "[error] svc-profile 5xx spike",
+        "[warn] postgres latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.34,
+        "p99_ms": 3669.9
+      },
+      "config": {
+        "timeout_ms": "6",
+        "region": "eu"
+      },
+      "diff": "- svc-profile:v1.0.5\n+ svc-profile:v1.7.6"
+    },
+    "ground_truth_root_cause": "stale cache serving bad data on svc-profile",
+    "ground_truth_remediation": "purge cache for svc-profile",
+    "irreversible_action": "purge_cache:svc-profile@v1.0.5"
+  },
+  {
+    "id": "inc-008",
+    "fault_family": "bad_deploy",
+    "bundle": {
+      "logs": [
+        "[error] svc-search 5xx spike",
+        "[warn] redis latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.46,
+        "p99_ms": 2333.2
+      },
+      "config": {
+        "timeout_ms": "5",
+        "region": "us"
+      },
+      "diff": "- svc-search:v1.7.2\n+ svc-search:v1.9.6"
+    },
+    "ground_truth_root_cause": "bad deploy of svc-search v1.7.2",
+    "ground_truth_remediation": "rollback svc-search to previous version",
+    "irreversible_action": "rollback_deploy:svc-search@v1.7.2"
+  },
+  {
+    "id": "inc-009",
+    "fault_family": "config_drift",
+    "bundle": {
+      "logs": [
+        "[error] svc-orders 5xx spike",
+        "[warn] postgres latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.36,
+        "p99_ms": 379.0
+      },
+      "config": {
+        "max_conns": "2",
+        "region": "eu"
+      },
+      "diff": "- svc-orders:v1.3.2\n+ svc-orders:v1.2.6"
+    },
+    "ground_truth_root_cause": "config drift on svc-orders: max_conns changed",
+    "ground_truth_remediation": "revert max_conns on svc-orders",
+    "irreversible_action": "revert_config:svc-orders@v1.3.2"
+  },
+  {
+    "id": "inc-010",
+    "fault_family": "dependency_failure",
+    "bundle": {
+      "logs": [
+        "[error] svc-catalog 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.95,
+        "p99_ms": 2210.6
+      },
+      "config": {
+        "timeout_ms": "9",
+        "region": "eu"
+      },
+      "diff": "- svc-catalog:v1.1.6\n+ svc-catalog:v1.1.8"
+    },
+    "ground_truth_root_cause": "svc-catalog dependency kafka timing out",
+    "ground_truth_remediation": "restart svc-catalog and fail over kafka",
+    "irreversible_action": "restart_service:svc-catalog@v1.1.6"
+  },
+  {
+    "id": "inc-011",
+    "fault_family": "data_issue",
+    "bundle": {
+      "logs": [
+        "[error] svc-pricing 5xx spike",
+        "[warn] postgres latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.4,
+        "p99_ms": 212.3
+      },
+      "config": {
+        "timeout_ms": "5",
+        "region": "eu"
+      },
+      "diff": "- svc-pricing:v1.5.1\n+ svc-pricing:v1.8.1"
+    },
+    "ground_truth_root_cause": "stale cache serving bad data on svc-pricing",
+    "ground_truth_remediation": "purge cache for svc-pricing",
+    "irreversible_action": "purge_cache:svc-pricing@v1.5.1"
+  },
+  {
+    "id": "inc-012",
+    "fault_family": "bad_deploy",
+    "bundle": {
+      "logs": [
+        "[error] svc-search 5xx spike",
+        "[warn] redis latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.4,
+        "p99_ms": 3097.5
+      },
+      "config": {
+        "max_conns": "9",
+        "region": "eu"
+      },
+      "diff": "- svc-search:v1.4.8\n+ svc-search:v1.9.5"
+    },
+    "ground_truth_root_cause": "bad deploy of svc-search v1.4.8",
+    "ground_truth_remediation": "rollback svc-search to previous version",
+    "irreversible_action": "rollback_deploy:svc-search@v1.4.8"
+  },
+  {
+    "id": "inc-013",
+    "fault_family": "config_drift",
+    "bundle": {
+      "logs": [
+        "[error] svc-orders 5xx spike",
+        "[warn] postgres latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.46,
+        "p99_ms": 1115.3
+      },
+      "config": {
+        "timeout_ms": "2",
+        "region": "eu"
+      },
+      "diff": "- svc-orders:v1.0.1\n+ svc-orders:v1.7.1"
+    },
+    "ground_truth_root_cause": "config drift on svc-orders: timeout_ms changed",
+    "ground_truth_remediation": "revert timeout_ms on svc-orders",
+    "irreversible_action": "revert_config:svc-orders@v1.0.1"
+  },
+  {
+    "id": "inc-014",
+    "fault_family": "dependency_failure",
+    "bundle": {
+      "logs": [
+        "[error] svc-catalog 5xx spike",
+        "[warn] postgres latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.92,
+        "p99_ms": 827.5
+      },
+      "config": {
+        "max_conns": "9",
+        "region": "us"
+      },
+      "diff": "- svc-catalog:v1.2.2\n+ svc-catalog:v1.3.8"
+    },
+    "ground_truth_root_cause": "svc-catalog dependency postgres timing out",
+    "ground_truth_remediation": "restart svc-catalog and fail over postgres",
+    "irreversible_action": "restart_service:svc-catalog@v1.2.2"
+  },
+  {
+    "id": "inc-015",
+    "fault_family": "data_issue",
+    "bundle": {
+      "logs": [
+        "[error] svc-feed 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.72,
+        "p99_ms": 1864.8
+      },
+      "config": {
+        "timeout_ms": "9",
+        "region": "us"
+      },
+      "diff": "- svc-feed:v1.3.4\n+ svc-feed:v1.1.3"
+    },
+    "ground_truth_root_cause": "stale cache serving bad data on svc-feed",
+    "ground_truth_remediation": "purge cache for svc-feed",
+    "irreversible_action": "purge_cache:svc-feed@v1.3.4"
+  },
+  {
+    "id": "inc-016",
+    "fault_family": "bad_deploy",
+    "bundle": {
+      "logs": [
+        "[error] svc-checkout 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.66,
+        "p99_ms": 2436.1
+      },
+      "config": {
+        "replicas": "1",
+        "region": "eu"
+      },
+      "diff": "- svc-checkout:v1.1.5\n+ svc-checkout:v1.0.3"
+    },
+    "ground_truth_root_cause": "bad deploy of svc-checkout v1.1.5",
+    "ground_truth_remediation": "rollback svc-checkout to previous version",
+    "irreversible_action": "rollback_deploy:svc-checkout@v1.1.5"
+  },
+  {
+    "id": "inc-017",
+    "fault_family": "config_drift",
+    "bundle": {
+      "logs": [
+        "[error] svc-auth 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.45,
+        "p99_ms": 2742.1
+      },
+      "config": {
+        "replicas": "4",
+        "region": "eu"
+      },
+      "diff": "- svc-auth:v1.0.5\n+ svc-auth:v1.9.9"
+    },
+    "ground_truth_root_cause": "config drift on svc-auth: replicas changed",
+    "ground_truth_remediation": "revert replicas on svc-auth",
+    "irreversible_action": "revert_config:svc-auth@v1.0.5"
+  },
+  {
+    "id": "inc-018",
+    "fault_family": "dependency_failure",
+    "bundle": {
+      "logs": [
+        "[error] svc-ledger 5xx spike",
+        "[warn] redis latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.36,
+        "p99_ms": 2704.1
+      },
+      "config": {
+        "timeout_ms": "6",
+        "region": "us"
+      },
+      "diff": "- svc-ledger:v1.3.7\n+ svc-ledger:v1.6.7"
+    },
+    "ground_truth_root_cause": "svc-ledger dependency redis timing out",
+    "ground_truth_remediation": "restart svc-ledger and fail over redis",
+    "irreversible_action": "restart_service:svc-ledger@v1.3.7"
+  },
+  {
+    "id": "inc-019",
+    "fault_family": "data_issue",
+    "bundle": {
+      "logs": [
+        "[error] svc-feed 5xx spike",
+        "[warn] postgres latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.77,
+        "p99_ms": 3242.3
+      },
+      "config": {
+        "replicas": "2",
+        "region": "eu"
+      },
+      "diff": "- svc-feed:v1.0.1\n+ svc-feed:v1.3.3"
+    },
+    "ground_truth_root_cause": "stale cache serving bad data on svc-feed",
+    "ground_truth_remediation": "purge cache for svc-feed",
+    "irreversible_action": "purge_cache:svc-feed@v1.0.1"
+  },
+  {
+    "id": "inc-020",
+    "fault_family": "bad_deploy",
+    "bundle": {
+      "logs": [
+        "[error] svc-search 5xx spike",
+        "[warn] redis latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.48,
+        "p99_ms": 1149.3
+      },
+      "config": {
+        "timeout_ms": "2",
+        "region": "us"
+      },
+      "diff": "- svc-search:v1.7.2\n+ svc-search:v1.8.1"
+    },
+    "ground_truth_root_cause": "bad deploy of svc-search v1.7.2",
+    "ground_truth_remediation": "rollback svc-search to previous version",
+    "irreversible_action": "rollback_deploy:svc-search@v1.7.2"
+  },
+  {
+    "id": "inc-021",
+    "fault_family": "config_drift",
+    "bundle": {
+      "logs": [
+        "[error] svc-auth 5xx spike",
+        "[warn] redis latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.41,
+        "p99_ms": 2045.4
+      },
+      "config": {
+        "replicas": "4",
+        "region": "us"
+      },
+      "diff": "- svc-auth:v1.8.0\n+ svc-auth:v1.0.2"
+    },
+    "ground_truth_root_cause": "config drift on svc-auth: replicas changed",
+    "ground_truth_remediation": "revert replicas on svc-auth",
+    "irreversible_action": "revert_config:svc-auth@v1.8.0"
+  },
+  {
+    "id": "inc-022",
+    "fault_family": "dependency_failure",
+    "bundle": {
+      "logs": [
+        "[error] svc-ledger 5xx spike",
+        "[warn] postgres latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.49,
+        "p99_ms": 2847.0
+      },
+      "config": {
+        "timeout_ms": "9",
+        "region": "us"
+      },
+      "diff": "- svc-ledger:v1.0.6\n+ svc-ledger:v1.2.3"
+    },
+    "ground_truth_root_cause": "svc-ledger dependency postgres timing out",
+    "ground_truth_remediation": "restart svc-ledger and fail over postgres",
+    "irreversible_action": "restart_service:svc-ledger@v1.0.6"
+  },
+  {
+    "id": "inc-023",
+    "fault_family": "data_issue",
+    "bundle": {
+      "logs": [
+        "[error] svc-pricing 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.65,
+        "p99_ms": 3042.3
+      },
+      "config": {
+        "max_conns": "1",
+        "region": "eu"
+      },
+      "diff": "- svc-pricing:v1.3.0\n+ svc-pricing:v1.9.7"
+    },
+    "ground_truth_root_cause": "stale cache serving bad data on svc-pricing",
+    "ground_truth_remediation": "purge cache for svc-pricing",
+    "irreversible_action": "purge_cache:svc-pricing@v1.3.0"
+  },
+  {
+    "id": "inc-024",
+    "fault_family": "bad_deploy",
+    "bundle": {
+      "logs": [
+        "[error] svc-search 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.35,
+        "p99_ms": 906.1
+      },
+      "config": {
+        "replicas": "2",
+        "region": "eu"
+      },
+      "diff": "- svc-search:v1.8.2\n+ svc-search:v1.6.1"
+    },
+    "ground_truth_root_cause": "bad deploy of svc-search v1.8.2",
+    "ground_truth_remediation": "rollback svc-search to previous version",
+    "irreversible_action": "rollback_deploy:svc-search@v1.8.2"
+  },
+  {
+    "id": "inc-025",
+    "fault_family": "config_drift",
+    "bundle": {
+      "logs": [
+        "[error] svc-inventory 5xx spike",
+        "[warn] redis latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.7,
+        "p99_ms": 1793.1
+      },
+      "config": {
+        "max_conns": "9",
+        "region": "us"
+      },
+      "diff": "- svc-inventory:v1.3.9\n+ svc-inventory:v1.4.3"
+    },
+    "ground_truth_root_cause": "config drift on svc-inventory: max_conns changed",
+    "ground_truth_remediation": "revert max_conns on svc-inventory",
+    "irreversible_action": "revert_config:svc-inventory@v1.3.9"
+  },
+  {
+    "id": "inc-026",
+    "fault_family": "dependency_failure",
+    "bundle": {
+      "logs": [
+        "[error] svc-catalog 5xx spike",
+        "[warn] postgres latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.39,
+        "p99_ms": 2652.9
+      },
+      "config": {
+        "timeout_ms": "8",
+        "region": "us"
+      },
+      "diff": "- svc-catalog:v1.5.3\n+ svc-catalog:v1.1.0"
+    },
+    "ground_truth_root_cause": "svc-catalog dependency postgres timing out",
+    "ground_truth_remediation": "restart svc-catalog and fail over postgres",
+    "irreversible_action": "restart_service:svc-catalog@v1.5.3"
+  },
+  {
+    "id": "inc-027",
+    "fault_family": "data_issue",
+    "bundle": {
+      "logs": [
+        "[error] svc-pricing 5xx spike",
+        "[warn] redis latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.65,
+        "p99_ms": 2122.4
+      },
+      "config": {
+        "replicas": "3",
+        "region": "us"
+      },
+      "diff": "- svc-pricing:v1.9.9\n+ svc-pricing:v1.1.3"
+    },
+    "ground_truth_root_cause": "stale cache serving bad data on svc-pricing",
+    "ground_truth_remediation": "purge cache for svc-pricing",
+    "irreversible_action": "purge_cache:svc-pricing@v1.9.9"
+  },
+  {
+    "id": "inc-028",
+    "fault_family": "bad_deploy",
+    "bundle": {
+      "logs": [
+        "[error] svc-payments 5xx spike",
+        "[warn] kafka latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.76,
+        "p99_ms": 2524.4
+      },
+      "config": {
+        "timeout_ms": "9",
+        "region": "eu"
+      },
+      "diff": "- svc-payments:v1.4.2\n+ svc-payments:v1.8.4"
+    },
+    "ground_truth_root_cause": "bad deploy of svc-payments v1.4.2",
+    "ground_truth_remediation": "rollback svc-payments to previous version",
+    "irreversible_action": "rollback_deploy:svc-payments@v1.4.2"
+  },
+  {
+    "id": "inc-029",
+    "fault_family": "config_drift",
+    "bundle": {
+      "logs": [
+        "[error] svc-inventory 5xx spike",
+        "[warn] redis latency high"
+      ],
+      "metrics": {
+        "err_rate": 0.88,
+        "p99_ms": 3021.2
+      },
+      "config": {
+        "timeout_ms": "3",
+        "region": "us"
+      },
+      "diff": "- svc-inventory:v1.1.2\n+ svc-inventory:v1.4.9"
+    },
+    "ground_truth_root_cause": "config drift on svc-inventory: timeout_ms changed",
+    "ground_truth_remediation": "revert timeout_ms on svc-inventory",
+    "irreversible_action": "revert_config:svc-inventory@v1.1.2"
+  }
+]

--- a/labs/lab_002/metrics.py
+++ b/labs/lab_002/metrics.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+
+from labs.lab_002.schema import Finding, Incident, RunRecord
+
+_PASS = 0.6
+
+
+def _tokens(text: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9.@]+", text.lower()))
+
+
+def score_finding(finding: Finding | None, incident: Incident) -> float:
+    """Keyword-overlap match of root cause + remediation against ground truth."""
+    if finding is None:
+        return 0.0
+    truth = _tokens(incident.ground_truth_root_cause) | _tokens(
+        incident.ground_truth_remediation)
+    got = _tokens(finding.root_cause) | _tokens(finding.proposed_remediation)
+    if not truth:
+        return 0.0
+    return len(truth & got) / len(truth)
+
+
+def success_rate(records: list[RunRecord], incidents: dict[str, Incident]) -> float:
+    if not records:
+        return 0.0
+    passed = sum(
+        1 for r in records
+        if score_finding(r.finding, incidents[r.incident_id]) >= _PASS
+    )
+    return passed / len(records)
+
+
+def durability_savings(
+    pre_interrupt: RunRecord, post_resume: RunRecord
+) -> dict[str, float]:
+    """Work a naive re-run repeats but ADK's dedup skips on resume.
+
+    Under a naive harness a crash at the gate forces re-running all
+    pre-interrupt work; ADK replays it from the event log for free and runs
+    only the post-resume frontier. So the saved work equals the pre-interrupt
+    totals, and `frontier_calls` reports how little actually re-ran, which is
+    the evidence dedup worked.
+    """
+    return {
+        "tokens_saved": float(
+            pre_interrupt.prompt_tokens + pre_interrupt.completion_tokens
+        ),
+        "model_calls_saved": float(pre_interrupt.model_calls),
+        "latency_ms_saved": float(pre_interrupt.latency_ms),
+        "frontier_calls": float(post_resume.model_calls),
+    }

--- a/labs/lab_002/results.json
+++ b/labs/lab_002/results.json
@@ -1,0 +1,2048 @@
+{
+  "agent_model": "ollama_chat/llama3.2:3b",
+  "n_incidents": 30,
+  "limit": null,
+  "errors": 0,
+  "durability_subset": [
+    "inc-000",
+    "inc-001",
+    "inc-002",
+    "inc-003",
+    "inc-004"
+  ],
+  "durability_skipped": 0,
+  "started": 1783079773.445128,
+  "finished": 1783084604.1704352,
+  "duration_s": 4830.7,
+  "systems": {
+    "baseline": {
+      "n": 30,
+      "success_rate": 0.2,
+      "avg_prompt_tokens": 178.9,
+      "avg_completion_tokens": 111.3,
+      "avg_total_tokens": 290.2,
+      "avg_model_calls": 1,
+      "p50_latency_ms": 2552.4,
+      "remediation_rate": 0.0333,
+      "records": [
+        {
+          "incident_id": "inc-000",
+          "finding": {
+            "incident_id": "inc-000",
+            "root_cause": "Incompatible version of `svc-search` causing high latency and errors due to spike in service usage.",
+            "proposed_remediation": "Upgrade `svc-search` to the latest available version (v1.9.6) and verify its functionality.",
+            "proposed_action": "Rollback deploy of `svc-search` to v1.1.0 and wait for further analysis."
+          },
+          "prompt_tokens": 177,
+          "completion_tokens": 100,
+          "model_calls": 1,
+          "latency_ms": 3569.6,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.5
+        },
+        {
+          "incident_id": "inc-001",
+          "finding": {
+            "incident_id": "inc-001",
+            "root_cause": "Incompatible service version change",
+            "proposed_remediation": "Roll back the svc-auth service to a known good version (v1.0.1) and verify the application functionality.",
+            "proposed_action": "Revert config:svc-auth@v1.3.7"
+          },
+          "prompt_tokens": 176,
+          "completion_tokens": 81,
+          "model_calls": 1,
+          "latency_ms": 1789.5,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.25
+        },
+        {
+          "incident_id": "inc-002",
+          "finding": {
+            "incident_id": "inc-002",
+            "root_cause": "Inconsistent service version update causing data consistency issues and high latency",
+            "proposed_remediation": "Immediately roll back the update to svc-catalog:v1.4.0 using a previous backup or snapshot",
+            "proposed_action": "Rollback update: svc-catalog service reverted to v1.4.0 using most recent available backup, as of 10 minutes ago"
+          },
+          "prompt_tokens": 181,
+          "completion_tokens": 101,
+          "model_calls": 1,
+          "latency_ms": 2220.6,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-003",
+          "finding": {
+            "incident_id": "inc-003",
+            "root_cause": "Inconsistent configuration between service version and cached versions",
+            "proposed_remediation": "Verify and update the configuration to match the latest version of svc-pricing (v1.6.1) and consider rebuilding or purging caches for the old version (v1.1.5)",
+            "proposed_action": "Rebuild service cache with latest version (v1.6.1)"
+          },
+          "prompt_tokens": 180,
+          "completion_tokens": 102,
+          "model_calls": 1,
+          "latency_ms": 2235.5,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-004",
+          "finding": {
+            "incident_id": "inc-004",
+            "root_cause": "Incompatible version of the service search component leading to unexpected behavior",
+            "proposed_remediation": "Rollback the deployment to the previously deployed stable version (v1.4.9) of the service search component",
+            "proposed_action": "Irreversible action: Immediately cancel any pending deployment of the new service search version (v1.1.3)"
+          },
+          "prompt_tokens": 176,
+          "completion_tokens": 97,
+          "model_calls": 1,
+          "latency_ms": 2133.5,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.6
+        },
+        {
+          "incident_id": "inc-005",
+          "finding": {
+            "incident_id": "inc-005",
+            "root_cause": "The root cause of the incident is likely due to a change in the service auth version, which has caused inconsistencies and errors leading to the spike in errors.",
+            "proposed_remediation": "Revert the service auth configuration to its previous version (v1.6.4) to restore stability and fix the error spike.",
+            "proposed_action": "Revert config:svc-auth@v1.6.4"
+          },
+          "prompt_tokens": 176,
+          "completion_tokens": 108,
+          "model_calls": 1,
+          "latency_ms": 2701.8,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.2222
+        },
+        {
+          "incident_id": "inc-006",
+          "finding": {
+            "incident_id": "inc-006",
+            "root_cause": "Incompatible service version update leading to service unavailability and latency issues",
+            "proposed_remediation": "Roll back the service catalog to its previous stable version (v1.2.8) and investigate the cause of the incompatible version update.",
+            "proposed_action": "Run `baseline_responder restart_service:svc-catalog@v1.5.0`"
+          },
+          "prompt_tokens": 182,
+          "completion_tokens": 99,
+          "model_calls": 1,
+          "latency_ms": 2366.9,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.2
+        },
+        {
+          "incident_id": "inc-007",
+          "finding": {
+            "incident_id": "inc-007",
+            "root_cause": "Inconsistent service profile version",
+            "proposed_remediation": "Update the service profile to v1.7.6 using a canonical deployment process",
+            "proposed_action": "Purge cache for svc-profile@v1.0.5"
+          },
+          "prompt_tokens": 177,
+          "completion_tokens": 73,
+          "model_calls": 1,
+          "latency_ms": 1675.2,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.1
+        },
+        {
+          "incident_id": "inc-008",
+          "finding": {
+            "incident_id": "inc-008",
+            "root_cause": "Incompatible service version upgrade causing spike in errors and latency",
+            "proposed_remediation": "Upgrade the service to a compatible version, such as v1.8.0, or roll back to the previous stable version (v1.7.2)",
+            "proposed_action": "rollback_deploy:svc-search@v1.7.2"
+          },
+          "prompt_tokens": 177,
+          "completion_tokens": 94,
+          "model_calls": 1,
+          "latency_ms": 2071.9,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": false,
+          "heuristic_score": 0.4
+        },
+        {
+          "incident_id": "inc-009",
+          "finding": {
+            "incident_id": "inc-009",
+            "root_cause": "Inconsistent service version between expected and deployed versions of 'svc-orders', likely causing the 5xx spike.",
+            "proposed_remediation": "Revert to previously deployed version of 'svc-orders' (v1.3.2) using the candidate action ID 'revert_config:svc-orders@v1.3.2'.",
+            "proposed_action": "Apply irreversible change by reverting configuration to previous state. This will involve rolling back the deployment to v1.3.2 and re-running any necessary upgrades or configurations."
+          },
+          "prompt_tokens": 177,
+          "completion_tokens": 133,
+          "model_calls": 1,
+          "latency_ms": 2844.5,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.4444
+        },
+        {
+          "incident_id": "inc-010",
+          "finding": {
+            "incident_id": "inc-010",
+            "root_cause": "Upgrade to a newer version of the service catalog may have caused compatibility issues, leading to errors and spikes.",
+            "proposed_remediation": "Rollback the upgrade to svc-catalog:v1.1.6 as soon as possible to prevent further issues.",
+            "proposed_action": "Irreversible Action: Remove the latest patch version of svc-catalog (v1.1.8) from all nodes in the region, leaving only v1.1.6 intact."
+          },
+          "prompt_tokens": 181,
+          "completion_tokens": 120,
+          "model_calls": 1,
+          "latency_ms": 2588.2,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-011",
+          "finding": {
+            "incident_id": "inc-011",
+            "root_cause": "Unexpected upgrade to v1.8.1 of the 'svc-pricing' service, potentially introducing performance regressions.",
+            "proposed_remediation": "Immediately roll back to the previous version (v1.5.1) of the 'svc-pricing' service and monitor for improvements in error rates and latency.",
+            "proposed_action": "Revert to v1.5.1 on svc-pricing: Run `purge_cache:svc-pricing@v1.8.1`"
+          },
+          "prompt_tokens": 180,
+          "completion_tokens": 127,
+          "model_calls": 1,
+          "latency_ms": 2724.0,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-012",
+          "finding": {
+            "incident_id": "inc-012",
+            "root_cause": "Incompatible changes in the service search version from v1.4.8 to v1.9.5 may be causing intermittent 5xx errors.",
+            "proposed_remediation": "Deploy the latest version of service search (v1.9.5) and monitor for error rates to ensure they are within a healthy threshold.",
+            "proposed_action": "Perform an irreversible action: Remove all existing deployments of v1.4.8 from the system, including any related configuration files or database schema changes."
+          },
+          "prompt_tokens": 178,
+          "completion_tokens": 126,
+          "model_calls": 1,
+          "latency_ms": 2712.9,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.6
+        },
+        {
+          "incident_id": "inc-013",
+          "finding": {
+            "incident_id": "inc-013",
+            "root_cause": "Incompatible version upgrade of service 'svc-orders' from v1.0.1 to v1.7.1, causing latency issues and 5xx errors.",
+            "proposed_remediation": "Update the service 'svc-orders' to a compatible version, such as v1.6.2 or earlier",
+            "proposed_action": "Revert configuration of service 'svc-orders' to v1.0.1 using the candidate action 'revert_config:svc-orders@v1.0.1'"
+          },
+          "prompt_tokens": 177,
+          "completion_tokens": 128,
+          "model_calls": 1,
+          "latency_ms": 2760.2,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.2222
+        },
+        {
+          "incident_id": "inc-014",
+          "finding": {
+            "incident_id": "inc-014",
+            "root_cause": "Incompatible service catalog version update causing latency and errors",
+            "proposed_remediation": "Apply the latest stable version of service catalog (version v1.3.8) to minimize latency and errors.",
+            "proposed_action": "Apply the latest stable version of service catalog (version v1.3.0, not v1.3.8), then restart the service catalog. Note: this is an irreversible action as it will update the configuration and restart the service without reverting to the previous version."
+          },
+          "prompt_tokens": 181,
+          "completion_tokens": 126,
+          "model_calls": 1,
+          "latency_ms": 2708.6,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.2
+        },
+        {
+          "incident_id": "inc-015",
+          "finding": {
+            "incident_id": "inc-015",
+            "root_cause": "Inconsistent service version in the configuration and codebase, leading to a cache mismatch that caused the 5xx spike.",
+            "proposed_remediation": "Update the service feed version in the configuration to match the version in the codebase.",
+            "proposed_action": "Purge cache for svc-feed@v1.3.4"
+          },
+          "prompt_tokens": 177,
+          "completion_tokens": 91,
+          "model_calls": 1,
+          "latency_ms": 1975.1,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.2
+        },
+        {
+          "incident_id": "inc-016",
+          "finding": {
+            "incident_id": "inc-016",
+            "root_cause": "Service level agreement (SLA) breach due to high error rate and latency in Kafka cluster.",
+            "proposed_remediation": "Perform a full rollback of the svc-checkout deployment from v1.1.5 to v1.0.3",
+            "proposed_action": "Execute the candidate action 'rollback_deploy:svc-checkout@v1.1.5' with caution and monitoring to ensure successful roll back"
+          },
+          "prompt_tokens": 181,
+          "completion_tokens": 109,
+          "model_calls": 1,
+          "latency_ms": 2356.6,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.6
+        },
+        {
+          "incident_id": "inc-017",
+          "finding": {
+            "incident_id": "inc-017",
+            "root_cause": "Incompatible version of the `svc-auth` service between the current configuration and the previously deployed version (v1.0.5). The new version (v1.9.9) is not backwards compatible.",
+            "proposed_remediation": "Revert the configuration to use the previous version of the `svc-auth` service (v1.0.5) until a more compatible version can be found and implemented.",
+            "proposed_action": "Revert the `svc-auth` configuration to v1.0.5, which is the previously deployed version."
+          },
+          "prompt_tokens": 177,
+          "completion_tokens": 137,
+          "model_calls": 1,
+          "latency_ms": 2950.6,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.375
+        },
+        {
+          "incident_id": "inc-018",
+          "finding": {
+            "incident_id": "inc-018",
+            "root_cause": "Incompatible version change in 'svc-ledger': Upgrade from v1.3.7 to v1.6.7 may have introduced new or changed configurations that are causing the observed errors.",
+            "proposed_remediation": "Manually inspect the application code and configuration files for any changes related to the 'svc-ledger' service and verify that all updates were properly tested and validated before deployment.",
+            "proposed_action": "irreversible-action: Run a recovery rollbacks of the container group for 'svc-ledger', and then initiate a partial upgrade to v1.6.7, ensuring to update dependent services and applications accordingly."
+          },
+          "prompt_tokens": 181,
+          "completion_tokens": 152,
+          "model_calls": 1,
+          "latency_ms": 3264.8,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-019",
+          "finding": {
+            "incident_id": "inc-019",
+            "root_cause": "Upgrade to new version of service (svc-feed) without proper testing or validation, leading to a spike in errors and latency.",
+            "proposed_remediation": "Immediately roll back the upgrade to svc-feed v1.0.1 using the 'purge_cache:svc-feed@v1.0.1' action",
+            "proposed_action": "Revert service to previous version (v1.0.1) by purging cache and restarting the service"
+          },
+          "prompt_tokens": 177,
+          "completion_tokens": 117,
+          "model_calls": 1,
+          "latency_ms": 2535.7,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.4
+        },
+        {
+          "incident_id": "inc-020",
+          "finding": {
+            "incident_id": "inc-020",
+            "root_cause": "Recently deployed version of `svc-search` (v1.8.1) may be causing the 5xx spike and high latency issues.",
+            "proposed_remediation": "Rollback to the previous known good version (`v1.7.2`) and re-deploy",
+            "proposed_action": "{'type': 'rollBack', 'resourceId': '/services/v1/search', 'revision': 'v1.7.2'}"
+          },
+          "prompt_tokens": 177,
+          "completion_tokens": 115,
+          "model_calls": 1,
+          "latency_ms": 2485.4,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.9
+        },
+        {
+          "incident_id": "inc-021",
+          "finding": {
+            "incident_id": "inc-021",
+            "root_cause": "Unexpected changes to the service auth configuration, potentially causing spikes in errors and high latency.",
+            "proposed_remediation": "Revert the service auth configuration to its previous version (v1.8.0) to stabilize the system and reduce errors.",
+            "proposed_action": "Revert config: svc-auth@v1.8.0"
+          },
+          "prompt_tokens": 177,
+          "completion_tokens": 93,
+          "model_calls": 1,
+          "latency_ms": 2027.0,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.25
+        },
+        {
+          "incident_id": "inc-022",
+          "finding": {
+            "incident_id": "inc-022",
+            "root_cause": "Incompatible version upgrade of service 'svc-ledger' to v1.2.3, causing a spike in errors and increased latency.",
+            "proposed_remediation": "Roll back the service to version v1.0.6 immediately to prevent further issues.",
+            "proposed_action": "Irreversible action: Delete the latest patch from the container registry for 'svc-ledger'."
+          },
+          "prompt_tokens": 181,
+          "completion_tokens": 102,
+          "model_calls": 1,
+          "latency_ms": 2224.0,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-023",
+          "finding": {
+            "incident_id": "inc-023",
+            "root_cause": "Inconsistent service version between the current deployment and expected version, potentially causing unexpected behavior or errors.",
+            "proposed_remediation": "Update the service to the latest version (v1.9.7) of svc-pricing to ensure consistency with other components.",
+            "proposed_action": "Revert to a previous known good state by purging the cache for the 'svc-pricing' service at version v1.3.0."
+          },
+          "prompt_tokens": 182,
+          "completion_tokens": 112,
+          "model_calls": 1,
+          "latency_ms": 2429.3,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.2
+        },
+        {
+          "incident_id": "inc-024",
+          "finding": {
+            "incident_id": "inc-024",
+            "root_cause": "The incorrect deployment of service 'svc-search' at version 'v1.6.1' likely caused a spike in errors and increased latency, as the newer version may have introduced bugs or compatibility issues.",
+            "proposed_remediation": "Redeploy service 'svc-search' to version 'v1.8.2' using the most recent available version.",
+            "proposed_action": "Roll back deployment of 'svc-search' to its previous version ('v1.8.2') immediately."
+          },
+          "prompt_tokens": 176,
+          "completion_tokens": 123,
+          "model_calls": 1,
+          "latency_ms": 2944.3,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.6
+        },
+        {
+          "incident_id": "inc-025",
+          "finding": {
+            "incident_id": "inc-025",
+            "root_cause": "Upgrade to a newer version of the service inventory component may have introduced an unexpected change that is causing high latency and spike in errors.",
+            "proposed_remediation": "Roll back to the previous version of the service inventory component to revert to known good configuration.",
+            "proposed_action": "Revert config:svc-inventory@v1.3.9"
+          },
+          "prompt_tokens": 182,
+          "completion_tokens": 95,
+          "model_calls": 1,
+          "latency_ms": 3707.2,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.2222
+        },
+        {
+          "incident_id": "inc-026",
+          "finding": {
+            "incident_id": "inc-026",
+            "root_cause": "Inconsistent service version mismatch between expected and actual versions of the 'svc-catalog' service, leading to unexpected behavior.",
+            "proposed_remediation": "Update the service version in the configuration to match the expected version (v1.5.3) of the 'svc-catalog' service.",
+            "proposed_action": "Revert changes made to the 'svc-catalog' service from v1.1.0 to v1.5.3 and restore to the latest stable version."
+          },
+          "prompt_tokens": 181,
+          "completion_tokens": 123,
+          "model_calls": 1,
+          "latency_ms": 2641.3,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-027",
+          "finding": {
+            "incident_id": "inc-027",
+            "root_cause": "Inconsistent or outdated cache causing a spike in errors for the svc-pricing service.",
+            "proposed_remediation": "Clear the cache for the svc-pricing service to resolve the issue, and verify the new version (v1.1.3) is being used.",
+            "proposed_action": "Clear the svc-pricing service cache using the candidate action 'purge_cache:svc-pricing@v1.9.9' in place of the proposed action."
+          },
+          "prompt_tokens": 181,
+          "completion_tokens": 119,
+          "model_calls": 1,
+          "latency_ms": 2569.1,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.4
+        },
+        {
+          "incident_id": "inc-028",
+          "finding": {
+            "incident_id": "inc-028",
+            "root_cause": "Unintended changes to the `svc-payments` service, causing a spike in errors and high latency on Kafka.",
+            "proposed_remediation": "Roll back the deployment of `svc-payments` to version v1.4.2 from v1.8.4 using the candidate action: rollback_deploy:svc-payments@v1.4.2",
+            "proposed_action": "Rollback the `svc-payments` service to version v1.4.2"
+          },
+          "prompt_tokens": 181,
+          "completion_tokens": 122,
+          "model_calls": 1,
+          "latency_ms": 2642.4,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.8
+        },
+        {
+          "incident_id": "inc-029",
+          "finding": {
+            "incident_id": "inc-029",
+            "root_cause": "Unexpected spike in service inventory error rate and latency, potentially due to incompatible configuration update.",
+            "proposed_remediation": "Review the changelog for svc-inventory v1.4.9 to identify the cause of the issues and revert the configuration to a known good version (v1.1.2) as indicated by the candidate action.",
+            "proposed_action": "Revert configuration to svc-inventory: v1.1.2"
+          },
+          "prompt_tokens": 181,
+          "completion_tokens": 113,
+          "model_calls": 1,
+          "latency_ms": 2450.2,
+          "remediation_applied": false,
+          "approved": false,
+          "resumed": false,
+          "heuristic_score": 0.3333
+        }
+      ]
+    },
+    "contender": {
+      "n": 30,
+      "success_rate": 0.1,
+      "avg_prompt_tokens": 4139.0,
+      "avg_completion_tokens": 2117.0,
+      "avg_total_tokens": 6256,
+      "avg_model_calls": 16.93,
+      "p50_latency_ms": 48106.0,
+      "remediation_rate": 1.0,
+      "records": [
+        {
+          "incident_id": "inc-000",
+          "finding": {
+            "incident_id": "inc-000",
+            "root_cause": "A spike in svc-search service errors, high latency on postgres, and increased error rate may be caused by the recent deployment of v1.9.6, which could have introduced compatibility or performance issues.",
+            "proposed_remediation": "Investigate the changes made between v1.1.0 and v1.9.6 in the svc-search service to identify potential causes of the errors and high latency.",
+            "proposed_action": "Roll back the deployment to v1.1.0"
+          },
+          "prompt_tokens": 4079,
+          "completion_tokens": 2168,
+          "model_calls": 17,
+          "latency_ms": 48813.6,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.5
+        },
+        {
+          "incident_id": "inc-001",
+          "finding": {
+            "incident_id": "inc-001",
+            "root_cause": "Inconsistent service version leading to a spike in errors and increased latency.",
+            "proposed_remediation": "Revert the configuration to a known good version (svc-auth:v1.0.1) to mitigate the effects of the service version mismatch.",
+            "proposed_action": "revert_config:svc-auth@v1.0.1"
+          },
+          "prompt_tokens": 4078,
+          "completion_tokens": 2279,
+          "model_calls": 17,
+          "latency_ms": 51194.4,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.375
+        },
+        {
+          "incident_id": "inc-002",
+          "finding": {
+            "incident_id": "inc-002",
+            "root_cause": "A recent configuration change to v1.1.1 may have caused instability leading to the need for restarting the service.",
+            "proposed_remediation": "Restarting the svc-catalog service to address potential instability caused by the version change.",
+            "proposed_action": "restart_service:svc-catalog@v1.4.0"
+          },
+          "prompt_tokens": 4313,
+          "completion_tokens": 1922,
+          "model_calls": 17,
+          "latency_ms": 43622.4,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.2
+        },
+        {
+          "incident_id": "inc-003",
+          "finding": {
+            "incident_id": "inc-003",
+            "root_cause": "Potential upgrade to svc-pricing v1.6.1 caused a spike in errors and high latency.",
+            "proposed_remediation": "Investigate the cause of the spike, gather logs and metrics data to understand the impact of the upgrade.",
+            "proposed_action": "Purge_cache:svc-pricing@v1.1.5"
+          },
+          "prompt_tokens": 4235,
+          "completion_tokens": 2357,
+          "model_calls": 17,
+          "latency_ms": 52478.3,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-004",
+          "finding": {
+            "incident_id": "inc-004",
+            "root_cause": "Spike in error rate for svc-search service, with p99 latency of 464ms, potentially due to changes from v1.4.9 to v1.1.3.",
+            "proposed_remediation": "Investigate and analyze the cause of the spike in error rate and latency, and consider applying a patch or update to restore stability.",
+            "proposed_action": "rollback_deploy:svc-search@v1.4.9"
+          },
+          "prompt_tokens": 3997,
+          "completion_tokens": 1917,
+          "model_calls": 17,
+          "latency_ms": 43934.1,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.5
+        },
+        {
+          "incident_id": "inc-005",
+          "finding": {
+            "incident_id": "inc-005",
+            "root_cause": "The deployment of version 1.6.4 of the svc-auth service likely caused a spike in errors and high latency issues, leading to a temporary disruption in service availability.",
+            "proposed_remediation": "Revert the configuration to use a previous version of the svc-auth service, such as v1.4.1, to address the performance issue and communication problems with other services.",
+            "proposed_action": "revert_config:svc-auth@v1.6.4"
+          },
+          "prompt_tokens": 4177,
+          "completion_tokens": 2391,
+          "model_calls": 17,
+          "latency_ms": 58906.1,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.3333
+        },
+        {
+          "incident_id": "inc-006",
+          "finding": {
+            "incident_id": "inc-006",
+            "root_cause": "The sudden spike in service catalog errors is likely caused by an issue with the redis latency, which may be related to the upgrade from svc-catalog v1.2.8 to v1.5.0.",
+            "proposed_remediation": "Upgrade svc-catalog to a newer version (e.g., v1.4.0) or investigate and address any issues with the redis configuration.",
+            "proposed_action": "restart_service:svc-catalog@v1.2.8"
+          },
+          "prompt_tokens": 4224,
+          "completion_tokens": 2352,
+          "model_calls": 17,
+          "latency_ms": 54990.2,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.4
+        },
+        {
+          "incident_id": "inc-007",
+          "finding": {
+            "incident_id": "inc-007",
+            "root_cause": "The spike in errors and high latency on the service profile is likely due to changes made during the upgrade from v1.0.5 to v1.7.6, which may have introduced compatibility issues or performance regressions.",
+            "proposed_remediation": "Thoroughly review the changelog for version 1.7.6 of the service profile to identify potential causes of the spike and high latency, and apply any necessary fixes or updates.",
+            "proposed_action": "Purge cache:svc-profile@v1.0.5"
+          },
+          "prompt_tokens": 4083,
+          "completion_tokens": 2275,
+          "model_calls": 17,
+          "latency_ms": 52435.2,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-008",
+          "finding": {
+            "incident_id": "inc-008",
+            "root_cause": "A performance spike in the svc-search service, with an error rate of 0.46 and a p99 latency of 2333.2ms, which was caused by a deployment of version v1.9.6, is affecting the application.",
+            "proposed_remediation": "Roll back to a previous version of the svc-search service, such as v1.7.2, to reduce performance issues and stabilize the system.",
+            "proposed_action": "rollback_deploy:svc-search@v1.7.2"
+          },
+          "prompt_tokens": 4200,
+          "completion_tokens": 2258,
+          "model_calls": 17,
+          "latency_ms": 50517.5,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.7
+        },
+        {
+          "incident_id": "inc-009",
+          "finding": {
+            "incident_id": "inc-009",
+            "root_cause": "The root cause of the incident is unclear, but it is likely related to a configuration change or an unexpected spike in service usage.",
+            "proposed_remediation": "Investigate and analyze logs and metrics to identify the root cause of the issue and implement corrective actions.",
+            "proposed_action": "revert_config:svc-orders@v1.3.2"
+          },
+          "prompt_tokens": 4264,
+          "completion_tokens": 2449,
+          "model_calls": 17,
+          "latency_ms": 54406.3,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.0
+        },
+        {
+          "incident_id": "inc-010",
+          "finding": {
+            "incident_id": "inc-010",
+            "root_cause": "The high error rate (95%) and latency spike in the service catalog may be related to a version mismatch between the expected v1.1.6 and the deployed v1.1.8, which could be causing issues with the Kafka latency.",
+            "proposed_remediation": "Try updating the service catalog to the latest version (v1.1.8) to resolve the potential issue.",
+            "proposed_action": "restart_service:svc-catalog@v1.1.6"
+          },
+          "prompt_tokens": 4300,
+          "completion_tokens": 2137,
+          "model_calls": 17,
+          "latency_ms": 47905.1,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-011",
+          "finding": {
+            "incident_id": "inc-011",
+            "root_cause": "A spike in 5xx errors from the svc-pricing service, combined with high latency and poor performance metrics, suggests a potential issue with the new version of svc-pricing (v1.8.1) that was recently deployed.",
+            "proposed_remediation": "Revert to the previous version of svc-pricing (v1.5.1) by running the purge_cache action.",
+            "proposed_action": "Purge cache:svc-pricing@v1.5.1"
+          },
+          "prompt_tokens": 4031,
+          "completion_tokens": 1787,
+          "model_calls": 17,
+          "latency_ms": 40324.8,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.4
+        },
+        {
+          "incident_id": "inc-012",
+          "finding": {
+            "incident_id": "inc-012",
+            "root_cause": "Inconsistent versioning of the svc-search service, with a more recent version (v1.9.5) being deployed while an older version (v1.4.8) is still active.",
+            "proposed_remediation": "Deploy a newer version of the svc-search service to ensure consistent and up-to-date functionality",
+            "proposed_action": "rollback_deploy:svc-search@v1.4.8"
+          },
+          "prompt_tokens": 4068,
+          "completion_tokens": 2036,
+          "model_calls": 17,
+          "latency_ms": 45581.0,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.7
+        },
+        {
+          "incident_id": "inc-013",
+          "finding": {
+            "incident_id": "inc-013",
+            "root_cause": "The spike in errors for the 'svc-orders' service resulted from an upgrade to version v1.7.1, which may have introduced unintended changes that are causing latency issues with the PostgreSQL database.",
+            "proposed_remediation": "Roll back the update to version v1.0.1 of the 'svc-orders' service to address the spike in errors and improve overall performance.",
+            "proposed_action": "revert_config:svc-orders@v1.0.1"
+          },
+          "prompt_tokens": 4048,
+          "completion_tokens": 2157,
+          "model_calls": 17,
+          "latency_ms": 48135.9,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.2222
+        },
+        {
+          "incident_id": "inc-014",
+          "finding": {
+            "incident_id": "inc-014",
+            "root_cause": "The data service experienced high error rates and slow response times potentially due to the version upgrade from v1.2.2 to v1.3.8, which may be causing performance issues.",
+            "proposed_remediation": "Review and refine configuration settings, such as max_conns, to mitigate potential oversubscription leading to performance issues.",
+            "proposed_action": "restart_service:svc-catalog@v1.2.2"
+          },
+          "prompt_tokens": 3934,
+          "completion_tokens": 1940,
+          "model_calls": 15,
+          "latency_ms": 43394.5,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.1
+        },
+        {
+          "incident_id": "inc-015",
+          "finding": {
+            "incident_id": "inc-015",
+            "root_cause": "Potential issue with service feed version upgrade causing increased errors and latency.",
+            "proposed_remediation": "Verify that the new service feed version v1.1.3 is properly deployed and functioning correctly.",
+            "proposed_action": "Purge cache:svc-feed@v1.3.4"
+          },
+          "prompt_tokens": 3942,
+          "completion_tokens": 1899,
+          "model_calls": 17,
+          "latency_ms": 42621.8,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.1
+        },
+        {
+          "incident_id": "inc-016",
+          "finding": {
+            "incident_id": "inc-016",
+            "root_cause": "Potential service discovery issue due to inconsistent configuration",
+            "proposed_remediation": "Verify service discovery configuration and reconcile differences between v1.1.5 and v1.0.3",
+            "proposed_action": "rollback_deploy:svc-checkout@v1.1.5"
+          },
+          "prompt_tokens": 4101,
+          "completion_tokens": 2045,
+          "model_calls": 17,
+          "latency_ms": 45614.6,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.2
+        },
+        {
+          "incident_id": "inc-017",
+          "finding": {
+            "incident_id": "inc-017",
+            "root_cause": "The high latency on the Kafka service may be related to a discrepancy in the replica count, as the new version of svc-auth has increased the number of replicas from 4 to an unspecified amount.",
+            "proposed_remediation": "Verify the current number of replicas and adjust them according to the specified value (4) to reduce latency on the Kafka service.",
+            "proposed_action": "revert_config:svc-auth@v1.0.5"
+          },
+          "prompt_tokens": 4310,
+          "completion_tokens": 2304,
+          "model_calls": 17,
+          "latency_ms": 51209.4,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.5
+        },
+        {
+          "incident_id": "inc-018",
+          "finding": {
+            "incident_id": "inc-018",
+            "root_cause": "Inconsistent service version leading to unexpected behavior and errors in the 'svc-ledger' service.",
+            "proposed_remediation": "Update the service version of 'svc-ledger' to a consistent version, such as v1.6.7, to prevent similar issues in the future.",
+            "proposed_action": "restart_service:svc-ledger@v1.3.7"
+          },
+          "prompt_tokens": 4136,
+          "completion_tokens": 1997,
+          "model_calls": 17,
+          "latency_ms": 44713.6,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-019",
+          "finding": {
+            "incident_id": "inc-019",
+            "root_cause": "A change in the svc-feed service to version v1.3.3 resulted in a high error rate (77%) and latency issues, causing a 5xx spike.",
+            "proposed_remediation": "Investigate and identify the root cause of the issue, and consider rolling back the svc-feed service to a previous stable version if necessary.",
+            "proposed_action": "Purge_cache:svc-feed@v1.0.1"
+          },
+          "prompt_tokens": 4144,
+          "completion_tokens": 2272,
+          "model_calls": 17,
+          "latency_ms": 50509.8,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.2
+        },
+        {
+          "incident_id": "inc-020",
+          "finding": {
+            "incident_id": "inc-020",
+            "root_cause": "Unconfirmed hypotheses, but high error rate (0.48) and long response time (p99_ms=1149.3) suggest issues with the updated svc-search service version v1.8.1.",
+            "proposed_remediation": "Investigate and verify the updates to svc-search, and consider rolling back to a known good version (v1.7.2) if necessary.",
+            "proposed_action": "rollback_deploy:svc-search@v1.7.2"
+          },
+          "prompt_tokens": 4053,
+          "completion_tokens": 1911,
+          "model_calls": 17,
+          "latency_ms": 42796.8,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.5
+        },
+        {
+          "incident_id": "inc-021",
+          "finding": {
+            "incident_id": "inc-021",
+            "root_cause": "Inconsistent configuration and potential version mismatch between the expected v1.8.0 of svc-auth and the deployed v1.0.2, leading to unexpected spike in errors.",
+            "proposed_remediation": "Revert the configuration to a consistent version, for example by reverting to v1.8.0 of svc-auth",
+            "proposed_action": "revert_config:svc-auth@v1.8.0"
+          },
+          "prompt_tokens": 4107,
+          "completion_tokens": 2038,
+          "model_calls": 17,
+          "latency_ms": 46943.7,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.375
+        },
+        {
+          "incident_id": "inc-022",
+          "finding": {
+            "incident_id": "inc-022",
+            "root_cause": "Inconsistent service version upgrade may have introduced instability in the system.",
+            "proposed_remediation": "Verify and validate all service upgrades to prevent future issues.",
+            "proposed_action": "restart_service:svc-ledger@v1.0.6"
+          },
+          "prompt_tokens": 4182,
+          "completion_tokens": 1855,
+          "model_calls": 17,
+          "latency_ms": 43636.0,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.1
+        },
+        {
+          "incident_id": "inc-023",
+          "finding": {
+            "incident_id": "inc-023",
+            "root_cause": "The spike in errors (err_rate=0.65) and latency high warning ([warn] kafka latency high) on svc-pricing suggest a potential issue with the new version v1.9.7, which may be causing errors or performance degradation.",
+            "proposed_remediation": "Investigate the changes between versions v1.3.0 and v1.9.7 of svc-pricing to identify the cause of the issues.",
+            "proposed_action": "Purge_cache:svc-pricing@v1.3.0"
+          },
+          "prompt_tokens": 4345,
+          "completion_tokens": 2258,
+          "model_calls": 17,
+          "latency_ms": 53811.8,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-024",
+          "finding": {
+            "incident_id": "inc-024",
+            "root_cause": "The recent deployment of service search v1.6.1 has resulted in a spike of errors (err_rate=0.35) and high latency issues (p99_ms=906.1), indicating potential performance degradation.",
+            "proposed_remediation": "Revert the affected deployment to the previous version, v1.8.2, to restore expected service performance.",
+            "proposed_action": "rollback_deploy:svc-search@v1.8.2"
+          },
+          "prompt_tokens": 4198,
+          "completion_tokens": 2422,
+          "model_calls": 17,
+          "latency_ms": 71353.3,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.6
+        },
+        {
+          "incident_id": "inc-025",
+          "finding": {
+            "incident_id": "inc-025",
+            "root_cause": "The high performance of the updated version of service inventory (v1.4.3) is causing a spike in errors, leading to a 70% error rate.",
+            "proposed_remediation": "Gradually roll out a version of the service inventory that is closer to the current update to reduce the impact on the system.",
+            "proposed_action": "revert_config:svc-inventory@v1.3.9"
+          },
+          "prompt_tokens": 4065,
+          "completion_tokens": 1874,
+          "model_calls": 17,
+          "latency_ms": 53224.9,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.2222
+        },
+        {
+          "incident_id": "inc-026",
+          "finding": {
+            "incident_id": "inc-026",
+            "root_cause": "The service catalog is experiencing a 5xx spike and high latency issues due to an incompatible update.",
+            "proposed_remediation": "Apply the latest stable version of svc-catalog (v1.1.0) to resolve compatibility issues and improve performance.",
+            "proposed_action": "restart_service:svc-catalog@v1.1.0"
+          },
+          "prompt_tokens": 4092,
+          "completion_tokens": 2208,
+          "model_calls": 17,
+          "latency_ms": 48886.6,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.3
+        },
+        {
+          "incident_id": "inc-027",
+          "finding": {
+            "incident_id": "inc-027",
+            "root_cause": "Unexpected spike in service-level error rate and high latency issues with Redis, likely caused by changes to the svc-pricing service.",
+            "proposed_remediation": "Investigate and address the root cause of the changes to the svc-pricing service that led to the spike in errors and latency issues.",
+            "proposed_action": "Purge_cache:svc-pricing@v1.9.9"
+          },
+          "prompt_tokens": 4177,
+          "completion_tokens": 1937,
+          "model_calls": 17,
+          "latency_ms": 43805.6,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.2
+        },
+        {
+          "incident_id": "inc-028",
+          "finding": {
+            "incident_id": "inc-028",
+            "root_cause": "A spike in errors for the svc-payments service, leading to a high error rate and prolonged latency in the Kafka cluster.",
+            "proposed_remediation": "Investigate the root cause of the issues with the updated svc-payments version v1.8.4.",
+            "proposed_action": "rollback_deploy:svc-payments@v1.4.2"
+          },
+          "prompt_tokens": 4227,
+          "completion_tokens": 2077,
+          "model_calls": 17,
+          "latency_ms": 48076.1,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.5
+        },
+        {
+          "incident_id": "inc-029",
+          "finding": {
+            "incident_id": "inc-029",
+            "root_cause": "Inconsistent version of the service inventory, likely causing a 5xx spike in svc-inventory",
+            "proposed_remediation": "Update the service inventory to a consistent version (v1.1.2) or investigate why v1.4.9 is being used",
+            "proposed_action": "revert_config:svc-inventory@v1.1.2"
+          },
+          "prompt_tokens": 4061,
+          "completion_tokens": 1987,
+          "model_calls": 17,
+          "latency_ms": 45817.8,
+          "remediation_applied": true,
+          "approved": true,
+          "resumed": true,
+          "heuristic_score": 0.2222
+        }
+      ]
+    }
+  },
+  "cost_multiple": 21.56,
+  "latency_multiple": 18.85,
+  "durability": {
+    "n": 5,
+    "avg_tokens_saved": 6265.0,
+    "avg_model_calls_saved": 17.0,
+    "avg_latency_ms_saved": 48590.3,
+    "avg_frontier_calls": 0.0,
+    "records": [
+      {
+        "incident_id": "inc-000",
+        "savings": {
+          "tokens_saved": 6516.0,
+          "model_calls_saved": 17.0,
+          "latency_ms_saved": 51953.365791996475,
+          "frontier_calls": 0.0
+        }
+      },
+      {
+        "incident_id": "inc-001",
+        "savings": {
+          "tokens_saved": 5946.0,
+          "model_calls_saved": 17.0,
+          "latency_ms_saved": 43854.71458299435,
+          "frontier_calls": 0.0
+        }
+      },
+      {
+        "incident_id": "inc-002",
+        "savings": {
+          "tokens_saved": 6654.0,
+          "model_calls_saved": 17.0,
+          "latency_ms_saved": 53183.23570799839,
+          "frontier_calls": 0.0
+        }
+      },
+      {
+        "incident_id": "inc-003",
+        "savings": {
+          "tokens_saved": 6126.0,
+          "model_calls_saved": 17.0,
+          "latency_ms_saved": 46987.40908400214,
+          "frontier_calls": 0.0
+        }
+      },
+      {
+        "incident_id": "inc-004",
+        "savings": {
+          "tokens_saved": 6083.0,
+          "model_calls_saved": 17.0,
+          "latency_ms_saved": 46972.64162500505,
+          "frontier_calls": 0.0
+        }
+      }
+    ]
+  },
+  "judge": {
+    "model": "qwen2.5:14b",
+    "runs": 3,
+    "pass_threshold": 0.6,
+    "weights": {
+      "root_cause_match": 0.5,
+      "remediation_match": 0.3,
+      "action_correct": 0.2
+    },
+    "duration_s": 294.9,
+    "systems": {
+      "baseline": {
+        "n": 30,
+        "accuracy": 0.1667,
+        "avg_weighted": 0.2733,
+        "judge_variance": 0.0,
+        "records": [
+          {
+            "incident_id": "inc-000",
+            "judge_passed": false,
+            "judge_weighted": 0.1,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.1,
+              0.1,
+              0.1
+            ]
+          },
+          {
+            "incident_id": "inc-001",
+            "judge_passed": false,
+            "judge_weighted": 0.34,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.8,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.34,
+              0.34,
+              0.34
+            ]
+          },
+          {
+            "incident_id": "inc-002",
+            "judge_passed": false,
+            "judge_weighted": 0.0,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          {
+            "incident_id": "inc-003",
+            "judge_passed": false,
+            "judge_weighted": 0.31,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.7,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.31,
+              0.31,
+              0.31
+            ]
+          },
+          {
+            "incident_id": "inc-004",
+            "judge_passed": false,
+            "judge_weighted": 0.55,
+            "judge_scores": {
+              "root_cause_match": 0.8,
+              "remediation_match": 0.5,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.55,
+              0.55,
+              0.55
+            ]
+          },
+          {
+            "incident_id": "inc-005",
+            "judge_passed": false,
+            "judge_weighted": 0.49,
+            "judge_scores": {
+              "root_cause_match": 0.5,
+              "remediation_match": 0.8,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.49,
+              0.49,
+              0.49
+            ]
+          },
+          {
+            "incident_id": "inc-006",
+            "judge_passed": false,
+            "judge_weighted": 0.0,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          {
+            "incident_id": "inc-007",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-008",
+            "judge_passed": true,
+            "judge_weighted": 0.95,
+            "judge_scores": {
+              "root_cause_match": 0.9,
+              "remediation_match": 1.0,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.95,
+              0.95,
+              0.95
+            ]
+          },
+          {
+            "incident_id": "inc-009",
+            "judge_passed": false,
+            "judge_weighted": 0.59,
+            "judge_scores": {
+              "root_cause_match": 0.7,
+              "remediation_match": 0.8,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.59,
+              0.59,
+              0.59
+            ]
+          },
+          {
+            "incident_id": "inc-010",
+            "judge_passed": false,
+            "judge_weighted": 0.0,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          {
+            "incident_id": "inc-011",
+            "judge_passed": false,
+            "judge_weighted": 0.0,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          {
+            "incident_id": "inc-012",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-013",
+            "judge_passed": false,
+            "judge_weighted": 0.0,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          {
+            "incident_id": "inc-014",
+            "judge_passed": false,
+            "judge_weighted": 0.0,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          {
+            "incident_id": "inc-015",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-016",
+            "judge_passed": false,
+            "judge_weighted": 0.3,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 1.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.3,
+              0.3,
+              0.3
+            ]
+          },
+          {
+            "incident_id": "inc-017",
+            "judge_passed": false,
+            "judge_weighted": 0.21,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.7,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.21,
+              0.21,
+              0.21
+            ]
+          },
+          {
+            "incident_id": "inc-018",
+            "judge_passed": false,
+            "judge_weighted": 0.0,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          {
+            "incident_id": "inc-019",
+            "judge_passed": false,
+            "judge_weighted": 0.15,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.5,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.15,
+              0.15,
+              0.15
+            ]
+          },
+          {
+            "incident_id": "inc-020",
+            "judge_passed": true,
+            "judge_weighted": 0.69,
+            "judge_scores": {
+              "root_cause_match": 0.9,
+              "remediation_match": 0.8,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.69,
+              0.69,
+              0.69
+            ]
+          },
+          {
+            "incident_id": "inc-021",
+            "judge_passed": true,
+            "judge_weighted": 0.62,
+            "judge_scores": {
+              "root_cause_match": 0.7,
+              "remediation_match": 0.9,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.62,
+              0.62,
+              0.62
+            ]
+          },
+          {
+            "incident_id": "inc-022",
+            "judge_passed": false,
+            "judge_weighted": 0.0,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          {
+            "incident_id": "inc-023",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-024",
+            "judge_passed": false,
+            "judge_weighted": 0.15,
+            "judge_scores": {
+              "root_cause_match": 0.3,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.15,
+              0.15,
+              0.15
+            ]
+          },
+          {
+            "incident_id": "inc-025",
+            "judge_passed": false,
+            "judge_weighted": 0.34,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.8,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.34,
+              0.34,
+              0.34
+            ]
+          },
+          {
+            "incident_id": "inc-026",
+            "judge_passed": false,
+            "judge_weighted": 0.0,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          {
+            "incident_id": "inc-027",
+            "judge_passed": true,
+            "judge_weighted": 0.69,
+            "judge_scores": {
+              "root_cause_match": 0.9,
+              "remediation_match": 0.8,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.69,
+              0.69,
+              0.69
+            ]
+          },
+          {
+            "incident_id": "inc-028",
+            "judge_passed": true,
+            "judge_weighted": 0.66,
+            "judge_scores": {
+              "root_cause_match": 0.9,
+              "remediation_match": 0.7,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.66,
+              0.66,
+              0.66
+            ]
+          },
+          {
+            "incident_id": "inc-029",
+            "judge_passed": false,
+            "judge_weighted": 0.54,
+            "judge_scores": {
+              "root_cause_match": 0.6,
+              "remediation_match": 0.8,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.54,
+              0.54,
+              0.54
+            ]
+          }
+        ]
+      },
+      "contender": {
+        "n": 30,
+        "accuracy": 0.1,
+        "avg_weighted": 0.326,
+        "judge_variance": 0.0,
+        "records": [
+          {
+            "incident_id": "inc-000",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-001",
+            "judge_passed": false,
+            "judge_weighted": 0.48,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.6,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.48,
+              0.48,
+              0.48
+            ]
+          },
+          {
+            "incident_id": "inc-002",
+            "judge_passed": false,
+            "judge_weighted": 0.54,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.8,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.54,
+              0.54,
+              0.54
+            ]
+          },
+          {
+            "incident_id": "inc-003",
+            "judge_passed": false,
+            "judge_weighted": 0.0,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          {
+            "incident_id": "inc-004",
+            "judge_passed": false,
+            "judge_weighted": 0.33,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.33,
+              0.33,
+              0.33
+            ]
+          },
+          {
+            "incident_id": "inc-005",
+            "judge_passed": false,
+            "judge_weighted": 0.48,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.6,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.48,
+              0.48,
+              0.48
+            ]
+          },
+          {
+            "incident_id": "inc-006",
+            "judge_passed": true,
+            "judge_weighted": 0.64,
+            "judge_scores": {
+              "root_cause_match": 0.7,
+              "remediation_match": 0.3,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.64,
+              0.64,
+              0.64
+            ]
+          },
+          {
+            "incident_id": "inc-007",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-008",
+            "judge_passed": true,
+            "judge_weighted": 0.87,
+            "judge_scores": {
+              "root_cause_match": 0.8,
+              "remediation_match": 0.9,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.87,
+              0.87,
+              0.87
+            ]
+          },
+          {
+            "incident_id": "inc-009",
+            "judge_passed": false,
+            "judge_weighted": 0.33,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.33,
+              0.33,
+              0.33
+            ]
+          },
+          {
+            "incident_id": "inc-010",
+            "judge_passed": false,
+            "judge_weighted": 0.33,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.33,
+              0.33,
+              0.33
+            ]
+          },
+          {
+            "incident_id": "inc-011",
+            "judge_passed": false,
+            "judge_weighted": 0.28,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.6,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.28,
+              0.28,
+              0.28
+            ]
+          },
+          {
+            "incident_id": "inc-012",
+            "judge_passed": false,
+            "judge_weighted": 0.2,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.2,
+              0.2,
+              0.2
+            ]
+          },
+          {
+            "incident_id": "inc-013",
+            "judge_passed": false,
+            "judge_weighted": 0.42,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.4,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.42,
+              0.42,
+              0.42
+            ]
+          },
+          {
+            "incident_id": "inc-014",
+            "judge_passed": false,
+            "judge_weighted": 0.2,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.2,
+              0.2,
+              0.2
+            ]
+          },
+          {
+            "incident_id": "inc-015",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-016",
+            "judge_passed": false,
+            "judge_weighted": 0.2,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.2,
+              0.2,
+              0.2
+            ]
+          },
+          {
+            "incident_id": "inc-017",
+            "judge_passed": true,
+            "judge_weighted": 0.9,
+            "judge_scores": {
+              "root_cause_match": 0.8,
+              "remediation_match": 1.0,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.9,
+              0.9,
+              0.9
+            ]
+          },
+          {
+            "incident_id": "inc-018",
+            "judge_passed": false,
+            "judge_weighted": 0.2,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.2,
+              0.2,
+              0.2
+            ]
+          },
+          {
+            "incident_id": "inc-019",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-020",
+            "judge_passed": false,
+            "judge_weighted": 0.59,
+            "judge_scores": {
+              "root_cause_match": 0.3,
+              "remediation_match": 0.8,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.59,
+              0.59,
+              0.59
+            ]
+          },
+          {
+            "incident_id": "inc-021",
+            "judge_passed": false,
+            "judge_weighted": 0.39,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.3,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.39,
+              0.39,
+              0.39
+            ]
+          },
+          {
+            "incident_id": "inc-022",
+            "judge_passed": false,
+            "judge_weighted": 0.2,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.2,
+              0.2,
+              0.2
+            ]
+          },
+          {
+            "incident_id": "inc-023",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-024",
+            "judge_passed": false,
+            "judge_weighted": 0.5,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 1.0,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.5,
+              0.5,
+              0.5
+            ]
+          },
+          {
+            "incident_id": "inc-025",
+            "judge_passed": false,
+            "judge_weighted": 0.2,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.2,
+              0.2,
+              0.2
+            ]
+          },
+          {
+            "incident_id": "inc-026",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-027",
+            "judge_passed": false,
+            "judge_weighted": 0.13,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.1,
+              "action_correct": 0.0
+            },
+            "run_weighted": [
+              0.13,
+              0.13,
+              0.13
+            ]
+          },
+          {
+            "incident_id": "inc-028",
+            "judge_passed": false,
+            "judge_weighted": 0.2,
+            "judge_scores": {
+              "root_cause_match": 0.0,
+              "remediation_match": 0.0,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.2,
+              0.2,
+              0.2
+            ]
+          },
+          {
+            "incident_id": "inc-029",
+            "judge_passed": false,
+            "judge_weighted": 0.39,
+            "judge_scores": {
+              "root_cause_match": 0.2,
+              "remediation_match": 0.3,
+              "action_correct": 1.0
+            },
+            "run_weighted": [
+              0.39,
+              0.39,
+              0.39
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/labs/lab_002/rubric.yaml
+++ b/labs/lab_002/rubric.yaml
@@ -1,0 +1,11 @@
+# Scoring rubric for Lab-002. An LLM judge (qwen2.5:14b, local) re-scores each
+# recorded finding against the incident's ground truth root cause and
+# remediation, plus whether the proposed action was the sanctioned one.
+weights:
+  root_cause_match: 0.5
+  remediation_match: 0.3
+  action_correct: 0.2
+pass_threshold: 0.6
+judge:
+  provider: local
+  model: qwen2.5:14b

--- a/labs/lab_002/run.py
+++ b/labs/lab_002/run.py
@@ -1,0 +1,352 @@
+"""Run baseline vs contender over the incident set, plus the durability harness.
+
+Usage:
+    LAB002_MODEL=ollama_chat/llama3.2:3b python -m labs.lab_002.run   # full set
+    LAB002_LIMIT=5 python -m labs.lab_002.run                          # smoke test
+
+Env:
+    LAB002_MODEL   Agent model, default "ollama_chat/llama3.2:3b" (wrapped in
+                   LiteLlm, routed to Ollama). A `gemini*` prefix switches to
+                   native Gemini (no LiteLlm, ADK talks to it directly) -- see
+                   the guard in `_build_model`. No Gemini API key is configured
+                   in this environment, so that path is untested here; it
+                   exists so a future paid run only has to set the env var.
+    LAB002_LIMIT   int; if set, only the first N incidents are processed. Lets
+                   the whole pipeline (this script + evaluate.py) be smoke
+                   tested cheaply before committing to a full run.
+
+Records one JSON transcript per (system, incident) under runs/<system>/<id>.json,
+a fixed durability subset under runs/durability/<id>.json, an aggregate
+results.json, and a human-readable RESULTS.md covering the four axes: success
+rate, cost multiple, latency multiple, durability savings. evaluate.py is a
+separate, slower stage that re-scores the recorded findings with an LLM judge
+and folds those numbers into results.json + RESULTS.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import statistics
+import time
+from pathlib import Path
+
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+
+from labs.lab_002 import dataset, durability, metrics
+from labs.lab_002.schema import Incident, RunRecord
+from labs.lab_002.systems import build_baseline, build_contender, run_baseline, run_contender
+
+HERE = Path(__file__).parent
+RUNS_DIR = HERE / "runs"
+
+_DEFAULT_MODEL = "ollama_chat/llama3.2:3b"
+_DURABILITY_SUBSET_N = 5
+
+
+def _build_model(model_name: str):
+    """Wrap the configured model for ADK.
+
+    Gemini models run native (no LiteLlm, ADK resolves the string directly).
+    Everything else -- Ollama and other OpenAI-compatible local models -- goes
+    through LiteLlm. This is the local floor for now: no Gemini key exists in
+    this environment.
+    """
+    if model_name.startswith("gemini"):
+        return model_name
+    from google.adk.models.lite_llm import LiteLlm
+
+    return LiteLlm(model=model_name)
+
+
+def _pctl(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    k = (len(s) - 1) * p
+    lo = int(k)
+    hi = min(lo + 1, len(s) - 1)
+    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+def _aggregate(records: list[RunRecord], incidents_by_id: dict[str, Incident]) -> dict:
+    n = len(records)
+    if n == 0:
+        return {
+            "n": 0,
+            "success_rate": 0.0,
+            "avg_prompt_tokens": 0,
+            "avg_completion_tokens": 0,
+            "avg_total_tokens": 0,
+            "avg_model_calls": 0,
+            "p50_latency_ms": 0,
+            "remediation_rate": 0.0,
+            "records": [],
+        }
+    sr = metrics.success_rate(records, incidents_by_id)
+    per_record = [
+        {
+            "incident_id": r.incident_id,
+            "finding": json.loads(r.finding.model_dump_json()) if r.finding else None,
+            "prompt_tokens": r.prompt_tokens,
+            "completion_tokens": r.completion_tokens,
+            "model_calls": r.model_calls,
+            "latency_ms": round(r.latency_ms, 1),
+            "remediation_applied": r.remediation_applied,
+            "approved": r.approved,
+            "resumed": r.resumed,
+            "heuristic_score": round(
+                metrics.score_finding(r.finding, incidents_by_id[r.incident_id]), 4
+            ),
+        }
+        for r in records
+    ]
+    return {
+        "n": n,
+        "success_rate": round(sr, 4),
+        "avg_prompt_tokens": round(statistics.mean(r.prompt_tokens for r in records), 1),
+        "avg_completion_tokens": round(
+            statistics.mean(r.completion_tokens for r in records), 1
+        ),
+        "avg_total_tokens": round(
+            statistics.mean(r.prompt_tokens + r.completion_tokens for r in records), 1
+        ),
+        "avg_model_calls": round(statistics.mean(r.model_calls for r in records), 2),
+        "p50_latency_ms": round(_pctl([r.latency_ms for r in records], 0.5), 1),
+        "remediation_rate": round(
+            sum(1 for r in records if r.remediation_applied) / n, 4
+        ),
+        "records": per_record,
+    }
+
+
+def _aggregate_durability(pairs: list[tuple[str, RunRecord, RunRecord]]) -> dict:
+    n = len(pairs)
+    if n == 0:
+        return {
+            "n": 0,
+            "avg_tokens_saved": 0,
+            "avg_model_calls_saved": 0,
+            "avg_latency_ms_saved": 0,
+            "avg_frontier_calls": 0,
+            "records": [],
+        }
+    savings = [metrics.durability_savings(pre, post) for _, pre, post in pairs]
+    per_record = [
+        {"incident_id": iid, "savings": sv}
+        for (iid, _pre, _post), sv in zip(pairs, savings, strict=True)
+    ]
+    return {
+        "n": n,
+        "avg_tokens_saved": round(statistics.mean(s["tokens_saved"] for s in savings), 1),
+        "avg_model_calls_saved": round(
+            statistics.mean(s["model_calls_saved"] for s in savings), 2
+        ),
+        "avg_latency_ms_saved": round(
+            statistics.mean(s["latency_ms_saved"] for s in savings), 1
+        ),
+        "avg_frontier_calls": round(statistics.mean(s["frontier_calls"] for s in savings), 2),
+        "records": per_record,
+    }
+
+
+async def main() -> None:
+    model_name = os.environ.get("LAB002_MODEL", _DEFAULT_MODEL)
+    limit_env = os.environ.get("LAB002_LIMIT")
+    limit = int(limit_env) if limit_env else 0
+
+    incidents = dataset.load()
+    if limit:
+        incidents = incidents[:limit]
+    incidents_by_id = {i.id: i for i in incidents}
+
+    model = _build_model(model_name)
+
+    RUNS_DIR.mkdir(exist_ok=True)
+    for system in ("baseline", "contender", "durability"):
+        (RUNS_DIR / system).mkdir(exist_ok=True)
+
+    session_service = InMemorySessionService()
+    baseline_agent = build_baseline(model)
+    contender_workflow = build_contender(model)
+
+    started = time.time()
+    print(f"[run] {len(incidents)} incidents, agent model = {model_name}")
+
+    baseline_records: list[RunRecord] = []
+    contender_records: list[RunRecord] = []
+    errors = 0
+    for i, incident in enumerate(incidents):
+        try:
+            base = await run_baseline(baseline_agent, incident, session_service)
+            cont = await run_contender(
+                contender_workflow, incident, session_service, auto_approve=True
+            )
+        except Exception as exc:  # one bad incident must not abort an unattended batch
+            errors += 1
+            print(f"  [{i + 1}/{len(incidents)}] {incident.id} ERROR: {exc}")
+            continue
+        baseline_records.append(base)
+        contender_records.append(cont)
+        (RUNS_DIR / "baseline" / f"{incident.id}.json").write_text(
+            base.model_dump_json(indent=2)
+        )
+        (RUNS_DIR / "contender" / f"{incident.id}.json").write_text(
+            cont.model_dump_json(indent=2)
+        )
+        print(
+            f"  [{i + 1}/{len(incidents)}] {incident.id} "
+            f"base={base.model_calls}c/{base.prompt_tokens + base.completion_tokens}t "
+            f"cont={cont.model_calls}c/{cont.prompt_tokens + cont.completion_tokens}t "
+            f"resumed={cont.resumed}"
+        )
+
+    # --- Durability: crash + resume over a fixed subset ---
+    durability_subset = incidents[: min(_DURABILITY_SUBSET_N, len(incidents))]
+    db_path = str(RUNS_DIR / "durability.db")
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    durability_pairs: list[tuple[str, RunRecord, RunRecord]] = []
+    durability_skipped = 0
+    for incident in durability_subset:
+        try:
+            pre, post = await durability.run_with_crash(incident, model, db_path)
+        except Exception as exc:
+            # Task 9 review flagged run_with_crash lacks an interrupt guard: if the
+            # gate is never reached (e.g. the investigator/synthesizer failed to
+            # produce a valid Finding on a weak local model), resuming can raise.
+            # One bad incident must not abort the whole durability batch.
+            print(f"  [durability] {incident.id} ERROR: {exc}")
+            durability_skipped += 1
+            continue
+        if pre.finding is None:
+            # Ran without raising but never reached the gate with a usable
+            # finding -- nothing meaningful to resume, so skip it too.
+            print(f"  [durability] {incident.id} skipped: gate not reached (no pre-crash finding)")
+            durability_skipped += 1
+            continue
+        durability_pairs.append((incident.id, pre, post))
+        (RUNS_DIR / "durability" / f"{incident.id}.json").write_text(
+            json.dumps(
+                {
+                    "incident_id": incident.id,
+                    "pre": json.loads(pre.model_dump_json()),
+                    "post": json.loads(post.model_dump_json()),
+                    "savings": metrics.durability_savings(pre, post),
+                },
+                indent=2,
+            )
+        )
+        print(
+            f"  [durability] {incident.id} pre={pre.model_calls}c "
+            f"post={post.model_calls}c resumed={post.resumed}"
+        )
+
+    baseline_agg = _aggregate(baseline_records, incidents_by_id)
+    contender_agg = _aggregate(contender_records, incidents_by_id)
+    durability_agg = _aggregate_durability(durability_pairs)
+
+    cost_multiple = (
+        round(contender_agg["avg_total_tokens"] / baseline_agg["avg_total_tokens"], 2)
+        if baseline_agg["avg_total_tokens"]
+        else 0.0
+    )
+    latency_multiple = (
+        round(contender_agg["p50_latency_ms"] / baseline_agg["p50_latency_ms"], 2)
+        if baseline_agg["p50_latency_ms"]
+        else 0.0
+    )
+
+    results = {
+        "agent_model": model_name,
+        "n_incidents": len(incidents),
+        "limit": limit or None,
+        "errors": errors,
+        "durability_subset": [inc.id for inc in durability_subset],
+        "durability_skipped": durability_skipped,
+        "started": started,
+        "finished": time.time(),
+        "duration_s": round(time.time() - started, 1),
+        "systems": {"baseline": baseline_agg, "contender": contender_agg},
+        "cost_multiple": cost_multiple,
+        "latency_multiple": latency_multiple,
+        "durability": durability_agg,
+    }
+    (HERE / "results.json").write_text(json.dumps(results, indent=2))
+    (HERE / "RESULTS.md").write_text(_render_markdown(results))
+    print(f"[run] done in {results['duration_s']}s; wrote results.json and RESULTS.md")
+
+
+def _render_markdown(r: dict) -> str:
+    base = r["systems"]["baseline"]
+    cont = r["systems"]["contender"]
+    dur = r["durability"]
+    limit_note = f" (limited to first {r['limit']})" if r.get("limit") else ""
+    lines = [
+        "# Lab-002 (local reproduction): static baseline vs durable contender",
+        "",
+        f"Agent model: `{r['agent_model']}`. {r['n_incidents']} incidents{limit_note}, "
+        f"{r['errors']} errors during the main run.",
+        "",
+        "## Results (heuristic scoring)",
+        "",
+        "Success rate here is `metrics.score_finding`: keyword overlap between the "
+        "recorded finding and the incident's ground truth. Run "
+        "`python -m labs.lab_002.evaluate` for an independent LLM-judge cross-check.",
+        "",
+        "| Metric | Baseline | Contender |",
+        "|--------|----------|-----------|",
+        f"| Success rate | {base['success_rate']:.1%} | {cont['success_rate']:.1%} |",
+        f"| Avg total tokens / incident | {base['avg_total_tokens']} | {cont['avg_total_tokens']} |",
+        f"| Avg model calls | {base['avg_model_calls']} | {cont['avg_model_calls']} |",
+        f"| p50 latency (ms) | {base['p50_latency_ms']} | {cont['p50_latency_ms']} |",
+        f"| Remediation applied rate | {base['remediation_rate']:.1%} | {cont['remediation_rate']:.1%} |",
+        "",
+        f"**Cost multiple (contender / baseline avg tokens):** {r['cost_multiple']}x. "
+        f"**Latency multiple (contender / baseline p50):** {r['latency_multiple']}x.",
+        "",
+        "## Durability (crash + resume over a fixed subset)",
+        "",
+        f"{dur['n']} of {len(r['durability_subset'])} incidents in the subset reached "
+        f"the human gate and were crash-tested ({r['durability_skipped']} skipped: no "
+        "finding reached the gate, or the resume errored).",
+        "",
+    ]
+    if dur["n"]:
+        lines += [
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Avg tokens saved on resume | {dur['avg_tokens_saved']} |",
+            f"| Avg model calls saved on resume | {dur['avg_model_calls_saved']} |",
+            f"| Avg latency (ms) saved on resume | {dur['avg_latency_ms_saved']} |",
+            f"| Avg frontier-only calls after resume | {dur['avg_frontier_calls']} |",
+            "",
+        ]
+    else:
+        lines += [
+            "No incidents in the durability subset reached the gate; no savings computed.",
+            "",
+        ]
+    lines += [
+        "## Read this before quoting the numbers",
+        "",
+        "1. Local open models only (agent on the model above, judge on qwen2.5:14b "
+        "via evaluate.py). No Gemini key is configured in this environment, so "
+        "`LAB002_MODEL=gemini-2.0-flash` is an untested path here, not a claim made "
+        "by this run.",
+        "2. Local inference has no dollar cost. The cost axis is tokens and model "
+        "calls per incident, not dollars.",
+        "3. Success rate above is the cheap heuristic. Run "
+        "`python -m labs.lab_002.evaluate` for the LLM-judge cross-check, a "
+        "separate, slower pass over these same recorded findings.",
+        "",
+        f"Run duration: {r['duration_s']}s. Per-incident transcripts are under `runs/`; "
+        "full per-incident detail is in results.json.",
+    ]
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/labs/lab_002/runs/baseline/inc-000.json
+++ b/labs/lab_002/runs/baseline/inc-000.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-000",
+  "finding": {
+    "incident_id": "inc-000",
+    "root_cause": "Incompatible version of `svc-search` causing high latency and errors due to spike in service usage.",
+    "proposed_remediation": "Upgrade `svc-search` to the latest available version (v1.9.6) and verify its functionality.",
+    "proposed_action": "Rollback deploy of `svc-search` to v1.1.0 and wait for further analysis."
+  },
+  "prompt_tokens": 177,
+  "completion_tokens": 100,
+  "model_calls": 1,
+  "latency_ms": 3569.6121670043794,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-001.json
+++ b/labs/lab_002/runs/baseline/inc-001.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-001",
+  "finding": {
+    "incident_id": "inc-001",
+    "root_cause": "Incompatible service version change",
+    "proposed_remediation": "Roll back the svc-auth service to a known good version (v1.0.1) and verify the application functionality.",
+    "proposed_action": "Revert config:svc-auth@v1.3.7"
+  },
+  "prompt_tokens": 176,
+  "completion_tokens": 81,
+  "model_calls": 1,
+  "latency_ms": 1789.501042003394,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-002.json
+++ b/labs/lab_002/runs/baseline/inc-002.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-002",
+  "finding": {
+    "incident_id": "inc-002",
+    "root_cause": "Inconsistent service version update causing data consistency issues and high latency",
+    "proposed_remediation": "Immediately roll back the update to svc-catalog:v1.4.0 using a previous backup or snapshot",
+    "proposed_action": "Rollback update: svc-catalog service reverted to v1.4.0 using most recent available backup, as of 10 minutes ago"
+  },
+  "prompt_tokens": 181,
+  "completion_tokens": 101,
+  "model_calls": 1,
+  "latency_ms": 2220.5996249977034,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-003.json
+++ b/labs/lab_002/runs/baseline/inc-003.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-003",
+  "finding": {
+    "incident_id": "inc-003",
+    "root_cause": "Inconsistent configuration between service version and cached versions",
+    "proposed_remediation": "Verify and update the configuration to match the latest version of svc-pricing (v1.6.1) and consider rebuilding or purging caches for the old version (v1.1.5)",
+    "proposed_action": "Rebuild service cache with latest version (v1.6.1)"
+  },
+  "prompt_tokens": 180,
+  "completion_tokens": 102,
+  "model_calls": 1,
+  "latency_ms": 2235.5022499978077,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-004.json
+++ b/labs/lab_002/runs/baseline/inc-004.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-004",
+  "finding": {
+    "incident_id": "inc-004",
+    "root_cause": "Incompatible version of the service search component leading to unexpected behavior",
+    "proposed_remediation": "Rollback the deployment to the previously deployed stable version (v1.4.9) of the service search component",
+    "proposed_action": "Irreversible action: Immediately cancel any pending deployment of the new service search version (v1.1.3)"
+  },
+  "prompt_tokens": 176,
+  "completion_tokens": 97,
+  "model_calls": 1,
+  "latency_ms": 2133.453874994302,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-005.json
+++ b/labs/lab_002/runs/baseline/inc-005.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-005",
+  "finding": {
+    "incident_id": "inc-005",
+    "root_cause": "The root cause of the incident is likely due to a change in the service auth version, which has caused inconsistencies and errors leading to the spike in errors.",
+    "proposed_remediation": "Revert the service auth configuration to its previous version (v1.6.4) to restore stability and fix the error spike.",
+    "proposed_action": "Revert config:svc-auth@v1.6.4"
+  },
+  "prompt_tokens": 176,
+  "completion_tokens": 108,
+  "model_calls": 1,
+  "latency_ms": 2701.8316250032512,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-006.json
+++ b/labs/lab_002/runs/baseline/inc-006.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-006",
+  "finding": {
+    "incident_id": "inc-006",
+    "root_cause": "Incompatible service version update leading to service unavailability and latency issues",
+    "proposed_remediation": "Roll back the service catalog to its previous stable version (v1.2.8) and investigate the cause of the incompatible version update.",
+    "proposed_action": "Run `baseline_responder restart_service:svc-catalog@v1.5.0`"
+  },
+  "prompt_tokens": 182,
+  "completion_tokens": 99,
+  "model_calls": 1,
+  "latency_ms": 2366.9324170041364,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-007.json
+++ b/labs/lab_002/runs/baseline/inc-007.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-007",
+  "finding": {
+    "incident_id": "inc-007",
+    "root_cause": "Inconsistent service profile version",
+    "proposed_remediation": "Update the service profile to v1.7.6 using a canonical deployment process",
+    "proposed_action": "Purge cache for svc-profile@v1.0.5"
+  },
+  "prompt_tokens": 177,
+  "completion_tokens": 73,
+  "model_calls": 1,
+  "latency_ms": 1675.1835409959313,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-008.json
+++ b/labs/lab_002/runs/baseline/inc-008.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-008",
+  "finding": {
+    "incident_id": "inc-008",
+    "root_cause": "Incompatible service version upgrade causing spike in errors and latency",
+    "proposed_remediation": "Upgrade the service to a compatible version, such as v1.8.0, or roll back to the previous stable version (v1.7.2)",
+    "proposed_action": "rollback_deploy:svc-search@v1.7.2"
+  },
+  "prompt_tokens": 177,
+  "completion_tokens": 94,
+  "model_calls": 1,
+  "latency_ms": 2071.923457988305,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-009.json
+++ b/labs/lab_002/runs/baseline/inc-009.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-009",
+  "finding": {
+    "incident_id": "inc-009",
+    "root_cause": "Inconsistent service version between expected and deployed versions of 'svc-orders', likely causing the 5xx spike.",
+    "proposed_remediation": "Revert to previously deployed version of 'svc-orders' (v1.3.2) using the candidate action ID 'revert_config:svc-orders@v1.3.2'.",
+    "proposed_action": "Apply irreversible change by reverting configuration to previous state. This will involve rolling back the deployment to v1.3.2 and re-running any necessary upgrades or configurations."
+  },
+  "prompt_tokens": 177,
+  "completion_tokens": 133,
+  "model_calls": 1,
+  "latency_ms": 2844.4632080063457,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-010.json
+++ b/labs/lab_002/runs/baseline/inc-010.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-010",
+  "finding": {
+    "incident_id": "inc-010",
+    "root_cause": "Upgrade to a newer version of the service catalog may have caused compatibility issues, leading to errors and spikes.",
+    "proposed_remediation": "Rollback the upgrade to svc-catalog:v1.1.6 as soon as possible to prevent further issues.",
+    "proposed_action": "Irreversible Action: Remove the latest patch version of svc-catalog (v1.1.8) from all nodes in the region, leaving only v1.1.6 intact."
+  },
+  "prompt_tokens": 181,
+  "completion_tokens": 120,
+  "model_calls": 1,
+  "latency_ms": 2588.203124993015,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-011.json
+++ b/labs/lab_002/runs/baseline/inc-011.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-011",
+  "finding": {
+    "incident_id": "inc-011",
+    "root_cause": "Unexpected upgrade to v1.8.1 of the 'svc-pricing' service, potentially introducing performance regressions.",
+    "proposed_remediation": "Immediately roll back to the previous version (v1.5.1) of the 'svc-pricing' service and monitor for improvements in error rates and latency.",
+    "proposed_action": "Revert to v1.5.1 on svc-pricing: Run `purge_cache:svc-pricing@v1.8.1`"
+  },
+  "prompt_tokens": 180,
+  "completion_tokens": 127,
+  "model_calls": 1,
+  "latency_ms": 2724.0214999910677,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-012.json
+++ b/labs/lab_002/runs/baseline/inc-012.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-012",
+  "finding": {
+    "incident_id": "inc-012",
+    "root_cause": "Incompatible changes in the service search version from v1.4.8 to v1.9.5 may be causing intermittent 5xx errors.",
+    "proposed_remediation": "Deploy the latest version of service search (v1.9.5) and monitor for error rates to ensure they are within a healthy threshold.",
+    "proposed_action": "Perform an irreversible action: Remove all existing deployments of v1.4.8 from the system, including any related configuration files or database schema changes."
+  },
+  "prompt_tokens": 178,
+  "completion_tokens": 126,
+  "model_calls": 1,
+  "latency_ms": 2712.9105420026463,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-013.json
+++ b/labs/lab_002/runs/baseline/inc-013.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-013",
+  "finding": {
+    "incident_id": "inc-013",
+    "root_cause": "Incompatible version upgrade of service 'svc-orders' from v1.0.1 to v1.7.1, causing latency issues and 5xx errors.",
+    "proposed_remediation": "Update the service 'svc-orders' to a compatible version, such as v1.6.2 or earlier",
+    "proposed_action": "Revert configuration of service 'svc-orders' to v1.0.1 using the candidate action 'revert_config:svc-orders@v1.0.1'"
+  },
+  "prompt_tokens": 177,
+  "completion_tokens": 128,
+  "model_calls": 1,
+  "latency_ms": 2760.155209005461,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-014.json
+++ b/labs/lab_002/runs/baseline/inc-014.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-014",
+  "finding": {
+    "incident_id": "inc-014",
+    "root_cause": "Incompatible service catalog version update causing latency and errors",
+    "proposed_remediation": "Apply the latest stable version of service catalog (version v1.3.8) to minimize latency and errors.",
+    "proposed_action": "Apply the latest stable version of service catalog (version v1.3.0, not v1.3.8), then restart the service catalog. Note: this is an irreversible action as it will update the configuration and restart the service without reverting to the previous version."
+  },
+  "prompt_tokens": 181,
+  "completion_tokens": 126,
+  "model_calls": 1,
+  "latency_ms": 2708.5700839961646,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-015.json
+++ b/labs/lab_002/runs/baseline/inc-015.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-015",
+  "finding": {
+    "incident_id": "inc-015",
+    "root_cause": "Inconsistent service version in the configuration and codebase, leading to a cache mismatch that caused the 5xx spike.",
+    "proposed_remediation": "Update the service feed version in the configuration to match the version in the codebase.",
+    "proposed_action": "Purge cache for svc-feed@v1.3.4"
+  },
+  "prompt_tokens": 177,
+  "completion_tokens": 91,
+  "model_calls": 1,
+  "latency_ms": 1975.1398750086082,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-016.json
+++ b/labs/lab_002/runs/baseline/inc-016.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-016",
+  "finding": {
+    "incident_id": "inc-016",
+    "root_cause": "Service level agreement (SLA) breach due to high error rate and latency in Kafka cluster.",
+    "proposed_remediation": "Perform a full rollback of the svc-checkout deployment from v1.1.5 to v1.0.3",
+    "proposed_action": "Execute the candidate action 'rollback_deploy:svc-checkout@v1.1.5' with caution and monitoring to ensure successful roll back"
+  },
+  "prompt_tokens": 181,
+  "completion_tokens": 109,
+  "model_calls": 1,
+  "latency_ms": 2356.5894580096938,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-017.json
+++ b/labs/lab_002/runs/baseline/inc-017.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-017",
+  "finding": {
+    "incident_id": "inc-017",
+    "root_cause": "Incompatible version of the `svc-auth` service between the current configuration and the previously deployed version (v1.0.5). The new version (v1.9.9) is not backwards compatible.",
+    "proposed_remediation": "Revert the configuration to use the previous version of the `svc-auth` service (v1.0.5) until a more compatible version can be found and implemented.",
+    "proposed_action": "Revert the `svc-auth` configuration to v1.0.5, which is the previously deployed version."
+  },
+  "prompt_tokens": 177,
+  "completion_tokens": 137,
+  "model_calls": 1,
+  "latency_ms": 2950.6054170051357,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-018.json
+++ b/labs/lab_002/runs/baseline/inc-018.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-018",
+  "finding": {
+    "incident_id": "inc-018",
+    "root_cause": "Incompatible version change in 'svc-ledger': Upgrade from v1.3.7 to v1.6.7 may have introduced new or changed configurations that are causing the observed errors.",
+    "proposed_remediation": "Manually inspect the application code and configuration files for any changes related to the 'svc-ledger' service and verify that all updates were properly tested and validated before deployment.",
+    "proposed_action": "irreversible-action: Run a recovery rollbacks of the container group for 'svc-ledger', and then initiate a partial upgrade to v1.6.7, ensuring to update dependent services and applications accordingly."
+  },
+  "prompt_tokens": 181,
+  "completion_tokens": 152,
+  "model_calls": 1,
+  "latency_ms": 3264.8350420058705,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-019.json
+++ b/labs/lab_002/runs/baseline/inc-019.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-019",
+  "finding": {
+    "incident_id": "inc-019",
+    "root_cause": "Upgrade to new version of service (svc-feed) without proper testing or validation, leading to a spike in errors and latency.",
+    "proposed_remediation": "Immediately roll back the upgrade to svc-feed v1.0.1 using the 'purge_cache:svc-feed@v1.0.1' action",
+    "proposed_action": "Revert service to previous version (v1.0.1) by purging cache and restarting the service"
+  },
+  "prompt_tokens": 177,
+  "completion_tokens": 117,
+  "model_calls": 1,
+  "latency_ms": 2535.6948749977164,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-020.json
+++ b/labs/lab_002/runs/baseline/inc-020.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-020",
+  "finding": {
+    "incident_id": "inc-020",
+    "root_cause": "Recently deployed version of `svc-search` (v1.8.1) may be causing the 5xx spike and high latency issues.",
+    "proposed_remediation": "Rollback to the previous known good version (`v1.7.2`) and re-deploy",
+    "proposed_action": "{'type': 'rollBack', 'resourceId': '/services/v1/search', 'revision': 'v1.7.2'}"
+  },
+  "prompt_tokens": 177,
+  "completion_tokens": 115,
+  "model_calls": 1,
+  "latency_ms": 2485.424291007803,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-021.json
+++ b/labs/lab_002/runs/baseline/inc-021.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-021",
+  "finding": {
+    "incident_id": "inc-021",
+    "root_cause": "Unexpected changes to the service auth configuration, potentially causing spikes in errors and high latency.",
+    "proposed_remediation": "Revert the service auth configuration to its previous version (v1.8.0) to stabilize the system and reduce errors.",
+    "proposed_action": "Revert config: svc-auth@v1.8.0"
+  },
+  "prompt_tokens": 177,
+  "completion_tokens": 93,
+  "model_calls": 1,
+  "latency_ms": 2026.9941250007832,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-022.json
+++ b/labs/lab_002/runs/baseline/inc-022.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-022",
+  "finding": {
+    "incident_id": "inc-022",
+    "root_cause": "Incompatible version upgrade of service 'svc-ledger' to v1.2.3, causing a spike in errors and increased latency.",
+    "proposed_remediation": "Roll back the service to version v1.0.6 immediately to prevent further issues.",
+    "proposed_action": "Irreversible action: Delete the latest patch from the container registry for 'svc-ledger'."
+  },
+  "prompt_tokens": 181,
+  "completion_tokens": 102,
+  "model_calls": 1,
+  "latency_ms": 2223.968042002525,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-023.json
+++ b/labs/lab_002/runs/baseline/inc-023.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-023",
+  "finding": {
+    "incident_id": "inc-023",
+    "root_cause": "Inconsistent service version between the current deployment and expected version, potentially causing unexpected behavior or errors.",
+    "proposed_remediation": "Update the service to the latest version (v1.9.7) of svc-pricing to ensure consistency with other components.",
+    "proposed_action": "Revert to a previous known good state by purging the cache for the 'svc-pricing' service at version v1.3.0."
+  },
+  "prompt_tokens": 182,
+  "completion_tokens": 112,
+  "model_calls": 1,
+  "latency_ms": 2429.3293749942677,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-024.json
+++ b/labs/lab_002/runs/baseline/inc-024.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-024",
+  "finding": {
+    "incident_id": "inc-024",
+    "root_cause": "The incorrect deployment of service 'svc-search' at version 'v1.6.1' likely caused a spike in errors and increased latency, as the newer version may have introduced bugs or compatibility issues.",
+    "proposed_remediation": "Redeploy service 'svc-search' to version 'v1.8.2' using the most recent available version.",
+    "proposed_action": "Roll back deployment of 'svc-search' to its previous version ('v1.8.2') immediately."
+  },
+  "prompt_tokens": 176,
+  "completion_tokens": 123,
+  "model_calls": 1,
+  "latency_ms": 2944.250166998245,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-025.json
+++ b/labs/lab_002/runs/baseline/inc-025.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-025",
+  "finding": {
+    "incident_id": "inc-025",
+    "root_cause": "Upgrade to a newer version of the service inventory component may have introduced an unexpected change that is causing high latency and spike in errors.",
+    "proposed_remediation": "Roll back to the previous version of the service inventory component to revert to known good configuration.",
+    "proposed_action": "Revert config:svc-inventory@v1.3.9"
+  },
+  "prompt_tokens": 182,
+  "completion_tokens": 95,
+  "model_calls": 1,
+  "latency_ms": 3707.243707991438,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-026.json
+++ b/labs/lab_002/runs/baseline/inc-026.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-026",
+  "finding": {
+    "incident_id": "inc-026",
+    "root_cause": "Inconsistent service version mismatch between expected and actual versions of the 'svc-catalog' service, leading to unexpected behavior.",
+    "proposed_remediation": "Update the service version in the configuration to match the expected version (v1.5.3) of the 'svc-catalog' service.",
+    "proposed_action": "Revert changes made to the 'svc-catalog' service from v1.1.0 to v1.5.3 and restore to the latest stable version."
+  },
+  "prompt_tokens": 181,
+  "completion_tokens": 123,
+  "model_calls": 1,
+  "latency_ms": 2641.3268329924904,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-027.json
+++ b/labs/lab_002/runs/baseline/inc-027.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-027",
+  "finding": {
+    "incident_id": "inc-027",
+    "root_cause": "Inconsistent or outdated cache causing a spike in errors for the svc-pricing service.",
+    "proposed_remediation": "Clear the cache for the svc-pricing service to resolve the issue, and verify the new version (v1.1.3) is being used.",
+    "proposed_action": "Clear the svc-pricing service cache using the candidate action 'purge_cache:svc-pricing@v1.9.9' in place of the proposed action."
+  },
+  "prompt_tokens": 181,
+  "completion_tokens": 119,
+  "model_calls": 1,
+  "latency_ms": 2569.1205830080435,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-028.json
+++ b/labs/lab_002/runs/baseline/inc-028.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-028",
+  "finding": {
+    "incident_id": "inc-028",
+    "root_cause": "Unintended changes to the `svc-payments` service, causing a spike in errors and high latency on Kafka.",
+    "proposed_remediation": "Roll back the deployment of `svc-payments` to version v1.4.2 from v1.8.4 using the candidate action: rollback_deploy:svc-payments@v1.4.2",
+    "proposed_action": "Rollback the `svc-payments` service to version v1.4.2"
+  },
+  "prompt_tokens": 181,
+  "completion_tokens": 122,
+  "model_calls": 1,
+  "latency_ms": 2642.3510829918087,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/baseline/inc-029.json
+++ b/labs/lab_002/runs/baseline/inc-029.json
@@ -1,0 +1,17 @@
+{
+  "system": "baseline",
+  "incident_id": "inc-029",
+  "finding": {
+    "incident_id": "inc-029",
+    "root_cause": "Unexpected spike in service inventory error rate and latency, potentially due to incompatible configuration update.",
+    "proposed_remediation": "Review the changelog for svc-inventory v1.4.9 to identify the cause of the issues and revert the configuration to a known good version (v1.1.2) as indicated by the candidate action.",
+    "proposed_action": "Revert configuration to svc-inventory: v1.1.2"
+  },
+  "prompt_tokens": 181,
+  "completion_tokens": 113,
+  "model_calls": 1,
+  "latency_ms": 2450.1857080031186,
+  "remediation_applied": false,
+  "approved": false,
+  "resumed": false
+}

--- a/labs/lab_002/runs/contender/inc-000.json
+++ b/labs/lab_002/runs/contender/inc-000.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-000",
+  "finding": {
+    "incident_id": "inc-000",
+    "root_cause": "A spike in svc-search service errors, high latency on postgres, and increased error rate may be caused by the recent deployment of v1.9.6, which could have introduced compatibility or performance issues.",
+    "proposed_remediation": "Investigate the changes made between v1.1.0 and v1.9.6 in the svc-search service to identify potential causes of the errors and high latency.",
+    "proposed_action": "Roll back the deployment to v1.1.0"
+  },
+  "prompt_tokens": 4079,
+  "completion_tokens": 2168,
+  "model_calls": 17,
+  "latency_ms": 48813.57716600178,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-001.json
+++ b/labs/lab_002/runs/contender/inc-001.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-001",
+  "finding": {
+    "incident_id": "inc-001",
+    "root_cause": "Inconsistent service version leading to a spike in errors and increased latency.",
+    "proposed_remediation": "Revert the configuration to a known good version (svc-auth:v1.0.1) to mitigate the effects of the service version mismatch.",
+    "proposed_action": "revert_config:svc-auth@v1.0.1"
+  },
+  "prompt_tokens": 4078,
+  "completion_tokens": 2279,
+  "model_calls": 17,
+  "latency_ms": 51194.41279101011,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-002.json
+++ b/labs/lab_002/runs/contender/inc-002.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-002",
+  "finding": {
+    "incident_id": "inc-002",
+    "root_cause": "A recent configuration change to v1.1.1 may have caused instability leading to the need for restarting the service.",
+    "proposed_remediation": "Restarting the svc-catalog service to address potential instability caused by the version change.",
+    "proposed_action": "restart_service:svc-catalog@v1.4.0"
+  },
+  "prompt_tokens": 4313,
+  "completion_tokens": 1922,
+  "model_calls": 17,
+  "latency_ms": 43622.41791699489,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-003.json
+++ b/labs/lab_002/runs/contender/inc-003.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-003",
+  "finding": {
+    "incident_id": "inc-003",
+    "root_cause": "Potential upgrade to svc-pricing v1.6.1 caused a spike in errors and high latency.",
+    "proposed_remediation": "Investigate the cause of the spike, gather logs and metrics data to understand the impact of the upgrade.",
+    "proposed_action": "Purge_cache:svc-pricing@v1.1.5"
+  },
+  "prompt_tokens": 4235,
+  "completion_tokens": 2357,
+  "model_calls": 17,
+  "latency_ms": 52478.342208007234,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-004.json
+++ b/labs/lab_002/runs/contender/inc-004.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-004",
+  "finding": {
+    "incident_id": "inc-004",
+    "root_cause": "Spike in error rate for svc-search service, with p99 latency of 464ms, potentially due to changes from v1.4.9 to v1.1.3.",
+    "proposed_remediation": "Investigate and analyze the cause of the spike in error rate and latency, and consider applying a patch or update to restore stability.",
+    "proposed_action": "rollback_deploy:svc-search@v1.4.9"
+  },
+  "prompt_tokens": 3997,
+  "completion_tokens": 1917,
+  "model_calls": 17,
+  "latency_ms": 43934.13712500478,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-005.json
+++ b/labs/lab_002/runs/contender/inc-005.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-005",
+  "finding": {
+    "incident_id": "inc-005",
+    "root_cause": "The deployment of version 1.6.4 of the svc-auth service likely caused a spike in errors and high latency issues, leading to a temporary disruption in service availability.",
+    "proposed_remediation": "Revert the configuration to use a previous version of the svc-auth service, such as v1.4.1, to address the performance issue and communication problems with other services.",
+    "proposed_action": "revert_config:svc-auth@v1.6.4"
+  },
+  "prompt_tokens": 4177,
+  "completion_tokens": 2391,
+  "model_calls": 17,
+  "latency_ms": 58906.103290995816,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-006.json
+++ b/labs/lab_002/runs/contender/inc-006.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-006",
+  "finding": {
+    "incident_id": "inc-006",
+    "root_cause": "The sudden spike in service catalog errors is likely caused by an issue with the redis latency, which may be related to the upgrade from svc-catalog v1.2.8 to v1.5.0.",
+    "proposed_remediation": "Upgrade svc-catalog to a newer version (e.g., v1.4.0) or investigate and address any issues with the redis configuration.",
+    "proposed_action": "restart_service:svc-catalog@v1.2.8"
+  },
+  "prompt_tokens": 4224,
+  "completion_tokens": 2352,
+  "model_calls": 17,
+  "latency_ms": 54990.227250003954,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-007.json
+++ b/labs/lab_002/runs/contender/inc-007.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-007",
+  "finding": {
+    "incident_id": "inc-007",
+    "root_cause": "The spike in errors and high latency on the service profile is likely due to changes made during the upgrade from v1.0.5 to v1.7.6, which may have introduced compatibility issues or performance regressions.",
+    "proposed_remediation": "Thoroughly review the changelog for version 1.7.6 of the service profile to identify potential causes of the spike and high latency, and apply any necessary fixes or updates.",
+    "proposed_action": "Purge cache:svc-profile@v1.0.5"
+  },
+  "prompt_tokens": 4083,
+  "completion_tokens": 2275,
+  "model_calls": 17,
+  "latency_ms": 52435.217249993,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-008.json
+++ b/labs/lab_002/runs/contender/inc-008.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-008",
+  "finding": {
+    "incident_id": "inc-008",
+    "root_cause": "A performance spike in the svc-search service, with an error rate of 0.46 and a p99 latency of 2333.2ms, which was caused by a deployment of version v1.9.6, is affecting the application.",
+    "proposed_remediation": "Roll back to a previous version of the svc-search service, such as v1.7.2, to reduce performance issues and stabilize the system.",
+    "proposed_action": "rollback_deploy:svc-search@v1.7.2"
+  },
+  "prompt_tokens": 4200,
+  "completion_tokens": 2258,
+  "model_calls": 17,
+  "latency_ms": 50517.47712500219,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-009.json
+++ b/labs/lab_002/runs/contender/inc-009.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-009",
+  "finding": {
+    "incident_id": "inc-009",
+    "root_cause": "The root cause of the incident is unclear, but it is likely related to a configuration change or an unexpected spike in service usage.",
+    "proposed_remediation": "Investigate and analyze logs and metrics to identify the root cause of the issue and implement corrective actions.",
+    "proposed_action": "revert_config:svc-orders@v1.3.2"
+  },
+  "prompt_tokens": 4264,
+  "completion_tokens": 2449,
+  "model_calls": 17,
+  "latency_ms": 54406.34687501006,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-010.json
+++ b/labs/lab_002/runs/contender/inc-010.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-010",
+  "finding": {
+    "incident_id": "inc-010",
+    "root_cause": "The high error rate (95%) and latency spike in the service catalog may be related to a version mismatch between the expected v1.1.6 and the deployed v1.1.8, which could be causing issues with the Kafka latency.",
+    "proposed_remediation": "Try updating the service catalog to the latest version (v1.1.8) to resolve the potential issue.",
+    "proposed_action": "restart_service:svc-catalog@v1.1.6"
+  },
+  "prompt_tokens": 4300,
+  "completion_tokens": 2137,
+  "model_calls": 17,
+  "latency_ms": 47905.0713339966,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-011.json
+++ b/labs/lab_002/runs/contender/inc-011.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-011",
+  "finding": {
+    "incident_id": "inc-011",
+    "root_cause": "A spike in 5xx errors from the svc-pricing service, combined with high latency and poor performance metrics, suggests a potential issue with the new version of svc-pricing (v1.8.1) that was recently deployed.",
+    "proposed_remediation": "Revert to the previous version of svc-pricing (v1.5.1) by running the purge_cache action.",
+    "proposed_action": "Purge cache:svc-pricing@v1.5.1"
+  },
+  "prompt_tokens": 4031,
+  "completion_tokens": 1787,
+  "model_calls": 17,
+  "latency_ms": 40324.7560000018,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-012.json
+++ b/labs/lab_002/runs/contender/inc-012.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-012",
+  "finding": {
+    "incident_id": "inc-012",
+    "root_cause": "Inconsistent versioning of the svc-search service, with a more recent version (v1.9.5) being deployed while an older version (v1.4.8) is still active.",
+    "proposed_remediation": "Deploy a newer version of the svc-search service to ensure consistent and up-to-date functionality",
+    "proposed_action": "rollback_deploy:svc-search@v1.4.8"
+  },
+  "prompt_tokens": 4068,
+  "completion_tokens": 2036,
+  "model_calls": 17,
+  "latency_ms": 45580.98566599074,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-013.json
+++ b/labs/lab_002/runs/contender/inc-013.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-013",
+  "finding": {
+    "incident_id": "inc-013",
+    "root_cause": "The spike in errors for the 'svc-orders' service resulted from an upgrade to version v1.7.1, which may have introduced unintended changes that are causing latency issues with the PostgreSQL database.",
+    "proposed_remediation": "Roll back the update to version v1.0.1 of the 'svc-orders' service to address the spike in errors and improve overall performance.",
+    "proposed_action": "revert_config:svc-orders@v1.0.1"
+  },
+  "prompt_tokens": 4048,
+  "completion_tokens": 2157,
+  "model_calls": 17,
+  "latency_ms": 48135.88137499755,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-014.json
+++ b/labs/lab_002/runs/contender/inc-014.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-014",
+  "finding": {
+    "incident_id": "inc-014",
+    "root_cause": "The data service experienced high error rates and slow response times potentially due to the version upgrade from v1.2.2 to v1.3.8, which may be causing performance issues.",
+    "proposed_remediation": "Review and refine configuration settings, such as max_conns, to mitigate potential oversubscription leading to performance issues.",
+    "proposed_action": "restart_service:svc-catalog@v1.2.2"
+  },
+  "prompt_tokens": 3934,
+  "completion_tokens": 1940,
+  "model_calls": 15,
+  "latency_ms": 43394.50704200135,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-015.json
+++ b/labs/lab_002/runs/contender/inc-015.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-015",
+  "finding": {
+    "incident_id": "inc-015",
+    "root_cause": "Potential issue with service feed version upgrade causing increased errors and latency.",
+    "proposed_remediation": "Verify that the new service feed version v1.1.3 is properly deployed and functioning correctly.",
+    "proposed_action": "Purge cache:svc-feed@v1.3.4"
+  },
+  "prompt_tokens": 3942,
+  "completion_tokens": 1899,
+  "model_calls": 17,
+  "latency_ms": 42621.761374990456,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-016.json
+++ b/labs/lab_002/runs/contender/inc-016.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-016",
+  "finding": {
+    "incident_id": "inc-016",
+    "root_cause": "Potential service discovery issue due to inconsistent configuration",
+    "proposed_remediation": "Verify service discovery configuration and reconcile differences between v1.1.5 and v1.0.3",
+    "proposed_action": "rollback_deploy:svc-checkout@v1.1.5"
+  },
+  "prompt_tokens": 4101,
+  "completion_tokens": 2045,
+  "model_calls": 17,
+  "latency_ms": 45614.63383400405,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-017.json
+++ b/labs/lab_002/runs/contender/inc-017.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-017",
+  "finding": {
+    "incident_id": "inc-017",
+    "root_cause": "The high latency on the Kafka service may be related to a discrepancy in the replica count, as the new version of svc-auth has increased the number of replicas from 4 to an unspecified amount.",
+    "proposed_remediation": "Verify the current number of replicas and adjust them according to the specified value (4) to reduce latency on the Kafka service.",
+    "proposed_action": "revert_config:svc-auth@v1.0.5"
+  },
+  "prompt_tokens": 4310,
+  "completion_tokens": 2304,
+  "model_calls": 17,
+  "latency_ms": 51209.446915992885,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-018.json
+++ b/labs/lab_002/runs/contender/inc-018.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-018",
+  "finding": {
+    "incident_id": "inc-018",
+    "root_cause": "Inconsistent service version leading to unexpected behavior and errors in the 'svc-ledger' service.",
+    "proposed_remediation": "Update the service version of 'svc-ledger' to a consistent version, such as v1.6.7, to prevent similar issues in the future.",
+    "proposed_action": "restart_service:svc-ledger@v1.3.7"
+  },
+  "prompt_tokens": 4136,
+  "completion_tokens": 1997,
+  "model_calls": 17,
+  "latency_ms": 44713.62162499281,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-019.json
+++ b/labs/lab_002/runs/contender/inc-019.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-019",
+  "finding": {
+    "incident_id": "inc-019",
+    "root_cause": "A change in the svc-feed service to version v1.3.3 resulted in a high error rate (77%) and latency issues, causing a 5xx spike.",
+    "proposed_remediation": "Investigate and identify the root cause of the issue, and consider rolling back the svc-feed service to a previous stable version if necessary.",
+    "proposed_action": "Purge_cache:svc-feed@v1.0.1"
+  },
+  "prompt_tokens": 4144,
+  "completion_tokens": 2272,
+  "model_calls": 17,
+  "latency_ms": 50509.84420799068,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-020.json
+++ b/labs/lab_002/runs/contender/inc-020.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-020",
+  "finding": {
+    "incident_id": "inc-020",
+    "root_cause": "Unconfirmed hypotheses, but high error rate (0.48) and long response time (p99_ms=1149.3) suggest issues with the updated svc-search service version v1.8.1.",
+    "proposed_remediation": "Investigate and verify the updates to svc-search, and consider rolling back to a known good version (v1.7.2) if necessary.",
+    "proposed_action": "rollback_deploy:svc-search@v1.7.2"
+  },
+  "prompt_tokens": 4053,
+  "completion_tokens": 1911,
+  "model_calls": 17,
+  "latency_ms": 42796.78420900018,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-021.json
+++ b/labs/lab_002/runs/contender/inc-021.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-021",
+  "finding": {
+    "incident_id": "inc-021",
+    "root_cause": "Inconsistent configuration and potential version mismatch between the expected v1.8.0 of svc-auth and the deployed v1.0.2, leading to unexpected spike in errors.",
+    "proposed_remediation": "Revert the configuration to a consistent version, for example by reverting to v1.8.0 of svc-auth",
+    "proposed_action": "revert_config:svc-auth@v1.8.0"
+  },
+  "prompt_tokens": 4107,
+  "completion_tokens": 2038,
+  "model_calls": 17,
+  "latency_ms": 46943.65562500025,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-022.json
+++ b/labs/lab_002/runs/contender/inc-022.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-022",
+  "finding": {
+    "incident_id": "inc-022",
+    "root_cause": "Inconsistent service version upgrade may have introduced instability in the system.",
+    "proposed_remediation": "Verify and validate all service upgrades to prevent future issues.",
+    "proposed_action": "restart_service:svc-ledger@v1.0.6"
+  },
+  "prompt_tokens": 4182,
+  "completion_tokens": 1855,
+  "model_calls": 17,
+  "latency_ms": 43635.99279199843,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-023.json
+++ b/labs/lab_002/runs/contender/inc-023.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-023",
+  "finding": {
+    "incident_id": "inc-023",
+    "root_cause": "The spike in errors (err_rate=0.65) and latency high warning ([warn] kafka latency high) on svc-pricing suggest a potential issue with the new version v1.9.7, which may be causing errors or performance degradation.",
+    "proposed_remediation": "Investigate the changes between versions v1.3.0 and v1.9.7 of svc-pricing to identify the cause of the issues.",
+    "proposed_action": "Purge_cache:svc-pricing@v1.3.0"
+  },
+  "prompt_tokens": 4345,
+  "completion_tokens": 2258,
+  "model_calls": 17,
+  "latency_ms": 53811.824499993236,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-024.json
+++ b/labs/lab_002/runs/contender/inc-024.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-024",
+  "finding": {
+    "incident_id": "inc-024",
+    "root_cause": "The recent deployment of service search v1.6.1 has resulted in a spike of errors (err_rate=0.35) and high latency issues (p99_ms=906.1), indicating potential performance degradation.",
+    "proposed_remediation": "Revert the affected deployment to the previous version, v1.8.2, to restore expected service performance.",
+    "proposed_action": "rollback_deploy:svc-search@v1.8.2"
+  },
+  "prompt_tokens": 4198,
+  "completion_tokens": 2422,
+  "model_calls": 17,
+  "latency_ms": 71353.32112500328,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-025.json
+++ b/labs/lab_002/runs/contender/inc-025.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-025",
+  "finding": {
+    "incident_id": "inc-025",
+    "root_cause": "The high performance of the updated version of service inventory (v1.4.3) is causing a spike in errors, leading to a 70% error rate.",
+    "proposed_remediation": "Gradually roll out a version of the service inventory that is closer to the current update to reduce the impact on the system.",
+    "proposed_action": "revert_config:svc-inventory@v1.3.9"
+  },
+  "prompt_tokens": 4065,
+  "completion_tokens": 1874,
+  "model_calls": 17,
+  "latency_ms": 53224.88062499906,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-026.json
+++ b/labs/lab_002/runs/contender/inc-026.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-026",
+  "finding": {
+    "incident_id": "inc-026",
+    "root_cause": "The service catalog is experiencing a 5xx spike and high latency issues due to an incompatible update.",
+    "proposed_remediation": "Apply the latest stable version of svc-catalog (v1.1.0) to resolve compatibility issues and improve performance.",
+    "proposed_action": "restart_service:svc-catalog@v1.1.0"
+  },
+  "prompt_tokens": 4092,
+  "completion_tokens": 2208,
+  "model_calls": 17,
+  "latency_ms": 48886.58183399821,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-027.json
+++ b/labs/lab_002/runs/contender/inc-027.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-027",
+  "finding": {
+    "incident_id": "inc-027",
+    "root_cause": "Unexpected spike in service-level error rate and high latency issues with Redis, likely caused by changes to the svc-pricing service.",
+    "proposed_remediation": "Investigate and address the root cause of the changes to the svc-pricing service that led to the spike in errors and latency issues.",
+    "proposed_action": "Purge_cache:svc-pricing@v1.9.9"
+  },
+  "prompt_tokens": 4177,
+  "completion_tokens": 1937,
+  "model_calls": 17,
+  "latency_ms": 43805.56074999913,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-028.json
+++ b/labs/lab_002/runs/contender/inc-028.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-028",
+  "finding": {
+    "incident_id": "inc-028",
+    "root_cause": "A spike in errors for the svc-payments service, leading to a high error rate and prolonged latency in the Kafka cluster.",
+    "proposed_remediation": "Investigate the root cause of the issues with the updated svc-payments version v1.8.4.",
+    "proposed_action": "rollback_deploy:svc-payments@v1.4.2"
+  },
+  "prompt_tokens": 4227,
+  "completion_tokens": 2077,
+  "model_calls": 17,
+  "latency_ms": 48076.08183300181,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/contender/inc-029.json
+++ b/labs/lab_002/runs/contender/inc-029.json
@@ -1,0 +1,17 @@
+{
+  "system": "contender",
+  "incident_id": "inc-029",
+  "finding": {
+    "incident_id": "inc-029",
+    "root_cause": "Inconsistent version of the service inventory, likely causing a 5xx spike in svc-inventory",
+    "proposed_remediation": "Update the service inventory to a consistent version (v1.1.2) or investigate why v1.4.9 is being used",
+    "proposed_action": "revert_config:svc-inventory@v1.1.2"
+  },
+  "prompt_tokens": 4061,
+  "completion_tokens": 1987,
+  "model_calls": 17,
+  "latency_ms": 45817.81158299418,
+  "remediation_applied": true,
+  "approved": true,
+  "resumed": true
+}

--- a/labs/lab_002/runs/durability/inc-000.json
+++ b/labs/lab_002/runs/durability/inc-000.json
@@ -1,0 +1,43 @@
+{
+  "incident_id": "inc-000",
+  "pre": {
+    "system": "contender",
+    "incident_id": "inc-000",
+    "finding": {
+      "incident_id": "inc-000",
+      "root_cause": "The service search component experienced a 5xx spike in errors, leading to high latency on the PostgreSQL database, which may be caused by the updated version of the service search module.",
+      "proposed_remediation": "Update the service search module to a previous version (v1.1.0) that has been proven stable and reduce the risk of further issues.",
+      "proposed_action": "rollback_deploy:svc-search@v1.1.0"
+    },
+    "prompt_tokens": 4169,
+    "completion_tokens": 2347,
+    "model_calls": 17,
+    "latency_ms": 51953.365791996475,
+    "remediation_applied": false,
+    "approved": false,
+    "resumed": false
+  },
+  "post": {
+    "system": "contender",
+    "incident_id": "inc-000",
+    "finding": {
+      "incident_id": "inc-000",
+      "root_cause": "The service search component experienced a 5xx spike in errors, leading to high latency on the PostgreSQL database, which may be caused by the updated version of the service search module.",
+      "proposed_remediation": "Update the service search module to a previous version (v1.1.0) that has been proven stable and reduce the risk of further issues.",
+      "proposed_action": "rollback_deploy:svc-search@v1.1.0"
+    },
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "model_calls": 0,
+    "latency_ms": 4.943124993587844,
+    "remediation_applied": true,
+    "approved": true,
+    "resumed": true
+  },
+  "savings": {
+    "tokens_saved": 6516.0,
+    "model_calls_saved": 17.0,
+    "latency_ms_saved": 51953.365791996475,
+    "frontier_calls": 0.0
+  }
+}

--- a/labs/lab_002/runs/durability/inc-001.json
+++ b/labs/lab_002/runs/durability/inc-001.json
@@ -1,0 +1,43 @@
+{
+  "incident_id": "inc-001",
+  "pre": {
+    "system": "contender",
+    "incident_id": "inc-001",
+    "finding": {
+      "incident_id": "inc-001",
+      "root_cause": "The high latency in the Redis service led to a spike in errors for the svc-auth service.",
+      "proposed_remediation": "Optimize the Redis service to improve its performance and reduce latency.",
+      "proposed_action": "revert_config:svc-auth@v1.0.1"
+    },
+    "prompt_tokens": 4001,
+    "completion_tokens": 1945,
+    "model_calls": 17,
+    "latency_ms": 43854.71458299435,
+    "remediation_applied": false,
+    "approved": false,
+    "resumed": false
+  },
+  "post": {
+    "system": "contender",
+    "incident_id": "inc-001",
+    "finding": {
+      "incident_id": "inc-001",
+      "root_cause": "The high latency in the Redis service led to a spike in errors for the svc-auth service.",
+      "proposed_remediation": "Optimize the Redis service to improve its performance and reduce latency.",
+      "proposed_action": "revert_config:svc-auth@v1.0.1"
+    },
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "model_calls": 0,
+    "latency_ms": 5.342959004337899,
+    "remediation_applied": true,
+    "approved": true,
+    "resumed": true
+  },
+  "savings": {
+    "tokens_saved": 5946.0,
+    "model_calls_saved": 17.0,
+    "latency_ms_saved": 43854.71458299435,
+    "frontier_calls": 0.0
+  }
+}

--- a/labs/lab_002/runs/durability/inc-002.json
+++ b/labs/lab_002/runs/durability/inc-002.json
@@ -1,0 +1,43 @@
+{
+  "incident_id": "inc-002",
+  "pre": {
+    "system": "contender",
+    "incident_id": "inc-002",
+    "finding": {
+      "incident_id": "inc-002",
+      "root_cause": "The service catalog is experiencing a spike in errors, with an error rate of 57% and high latency in Kafka, likely due to a version upgrade from v1.4.0 to v1.1.1.",
+      "proposed_remediation": "Revert the recent version upgrade of the service catalog back to v1.4.0",
+      "proposed_action": "restart_service:svc-catalog@v1.4.0"
+    },
+    "prompt_tokens": 4328,
+    "completion_tokens": 2326,
+    "model_calls": 17,
+    "latency_ms": 53183.23570799839,
+    "remediation_applied": false,
+    "approved": false,
+    "resumed": false
+  },
+  "post": {
+    "system": "contender",
+    "incident_id": "inc-002",
+    "finding": {
+      "incident_id": "inc-002",
+      "root_cause": "The service catalog is experiencing a spike in errors, with an error rate of 57% and high latency in Kafka, likely due to a version upgrade from v1.4.0 to v1.1.1.",
+      "proposed_remediation": "Revert the recent version upgrade of the service catalog back to v1.4.0",
+      "proposed_action": "restart_service:svc-catalog@v1.4.0"
+    },
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "model_calls": 0,
+    "latency_ms": 6.0485419962788,
+    "remediation_applied": true,
+    "approved": true,
+    "resumed": true
+  },
+  "savings": {
+    "tokens_saved": 6654.0,
+    "model_calls_saved": 17.0,
+    "latency_ms_saved": 53183.23570799839,
+    "frontier_calls": 0.0
+  }
+}

--- a/labs/lab_002/runs/durability/inc-003.json
+++ b/labs/lab_002/runs/durability/inc-003.json
@@ -1,0 +1,43 @@
+{
+  "incident_id": "inc-003",
+  "pre": {
+    "system": "contender",
+    "incident_id": "inc-003",
+    "finding": {
+      "incident_id": "inc-003",
+      "root_cause": "Possible cache overflow due to service upgrade, leading to increased latency and errors.",
+      "proposed_remediation": "Upgrade to the latest version of svc-pricing (v1.6.1) to mitigate potential issues with cache overflow.",
+      "proposed_action": "Purge_cache:svc-pricing@v1.1.5"
+    },
+    "prompt_tokens": 4123,
+    "completion_tokens": 2003,
+    "model_calls": 17,
+    "latency_ms": 46987.40908400214,
+    "remediation_applied": false,
+    "approved": false,
+    "resumed": false
+  },
+  "post": {
+    "system": "contender",
+    "incident_id": "inc-003",
+    "finding": {
+      "incident_id": "inc-003",
+      "root_cause": "Possible cache overflow due to service upgrade, leading to increased latency and errors.",
+      "proposed_remediation": "Upgrade to the latest version of svc-pricing (v1.6.1) to mitigate potential issues with cache overflow.",
+      "proposed_action": "Purge_cache:svc-pricing@v1.1.5"
+    },
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "model_calls": 0,
+    "latency_ms": 5.103208008222282,
+    "remediation_applied": true,
+    "approved": true,
+    "resumed": true
+  },
+  "savings": {
+    "tokens_saved": 6126.0,
+    "model_calls_saved": 17.0,
+    "latency_ms_saved": 46987.40908400214,
+    "frontier_calls": 0.0
+  }
+}

--- a/labs/lab_002/runs/durability/inc-004.json
+++ b/labs/lab_002/runs/durability/inc-004.json
@@ -1,0 +1,43 @@
+{
+  "incident_id": "inc-004",
+  "pre": {
+    "system": "contender",
+    "incident_id": "inc-004",
+    "finding": {
+      "incident_id": "inc-004",
+      "root_cause": "The deployment of version v1.1.3 of the service 'svc-search' caused a 5xx spike, resulting in high latency on Kafka and increased error rates.",
+      "proposed_remediation": "Roll back the deployment to the previous version (v1.4.9) to resolve the issues and restore normal operation.",
+      "proposed_action": "rollback_deploy:svc-search@v1.4.9"
+    },
+    "prompt_tokens": 4072,
+    "completion_tokens": 2011,
+    "model_calls": 17,
+    "latency_ms": 46972.64162500505,
+    "remediation_applied": false,
+    "approved": false,
+    "resumed": false
+  },
+  "post": {
+    "system": "contender",
+    "incident_id": "inc-004",
+    "finding": {
+      "incident_id": "inc-004",
+      "root_cause": "The deployment of version v1.1.3 of the service 'svc-search' caused a 5xx spike, resulting in high latency on Kafka and increased error rates.",
+      "proposed_remediation": "Roll back the deployment to the previous version (v1.4.9) to resolve the issues and restore normal operation.",
+      "proposed_action": "rollback_deploy:svc-search@v1.4.9"
+    },
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "model_calls": 0,
+    "latency_ms": 5.647541009238921,
+    "remediation_applied": true,
+    "approved": true,
+    "resumed": true
+  },
+  "savings": {
+    "tokens_saved": 6083.0,
+    "model_calls_saved": 17.0,
+    "latency_ms_saved": 46972.64162500505,
+    "frontier_calls": 0.0
+  }
+}

--- a/labs/lab_002/schema.py
+++ b/labs/lab_002/schema.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
-class FaultFamily(str, Enum):
+class FaultFamily(StrEnum):
     BAD_DEPLOY = "bad_deploy"
     CONFIG_DRIFT = "config_drift"
     DEPENDENCY_FAILURE = "dependency_failure"

--- a/labs/lab_002/schema.py
+++ b/labs/lab_002/schema.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class FaultFamily(str, Enum):
+    BAD_DEPLOY = "bad_deploy"
+    CONFIG_DRIFT = "config_drift"
+    DEPENDENCY_FAILURE = "dependency_failure"
+    DATA_ISSUE = "data_issue"
+
+
+class IncidentBundle(BaseModel):
+    logs: list[str]
+    metrics: dict[str, float]
+    config: dict[str, str]
+    diff: str
+
+
+class Incident(BaseModel):
+    id: str
+    fault_family: FaultFamily
+    bundle: IncidentBundle
+    ground_truth_root_cause: str
+    ground_truth_remediation: str
+    irreversible_action: str
+
+
+class Hypothesis(BaseModel):
+    branch: str
+    claim: str
+    evidence: str
+
+
+class Verdict(BaseModel):
+    grounded: bool
+    reason: str
+
+
+class Finding(BaseModel):
+    incident_id: str
+    root_cause: str
+    proposed_remediation: str
+    proposed_action: str
+
+
+class RemediationDecision(BaseModel):
+    approved: bool
+    approver: str = "unknown"
+
+
+class RunRecord(BaseModel):
+    system: str
+    incident_id: str
+    finding: Finding | None = None
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    model_calls: int = 0
+    latency_ms: float = 0.0
+    remediation_applied: bool = False
+    approved: bool = False
+    resumed: bool = False

--- a/labs/lab_002/systems.py
+++ b/labs/lab_002/systems.py
@@ -1,0 +1,79 @@
+"""Lab-002 systems: baseline static ADK agent (Task 7) and contender (Task 8)."""
+
+from __future__ import annotations
+
+import time
+
+from google.adk import Agent
+from google.adk.runners import Runner
+from google.genai import types
+
+from labs.lab_002 import tools
+from labs.lab_002.gate import ApprovalToken
+from labs.lab_002.schema import Finding, Incident, RunRecord
+
+_APP = "lab002"
+_USER = "sre"
+
+_BASELINE_INSTR = (
+    "You are an incident responder. Given the incident context, output the single "
+    "most likely root cause, a remediation, and the exact irreversible action to "
+    "take, as JSON matching the Finding schema. Do not take the action yourself."
+)
+
+
+def build_baseline(model) -> Agent:
+    """A single static ADK agent: one pass, one Finding, no runtime decomposition."""
+    return Agent(
+        name="baseline_responder",
+        model=model,
+        instruction=_BASELINE_INSTR,
+        output_schema=Finding,
+        output_key="finding",
+    )
+
+
+def _context_blob(incident: Incident) -> str:
+    return (
+        f"incident_id: {incident.id}\n"
+        f"logs:\n{tools.log_search(incident)}\n"
+        f"metrics: {tools.metric_query(incident)}\n"
+        f"config:\n{tools.config_read(incident)}\n"
+        f"diff:\n{tools.diff_read(incident)}\n"
+        f"candidate action id: {incident.irreversible_action}"
+    )
+
+
+async def run_baseline(agent: Agent, incident: Incident, session_service) -> RunRecord:
+    session = await session_service.create_session(
+        app_name=_APP, user_id=_USER, session_id=f"base-{incident.id}")
+    runner = Runner(agent=agent, app_name=_APP, session_service=session_service)
+    content = types.Content(role="user",
+                             parts=[types.Part(text=_context_blob(incident))])
+    start = time.monotonic()
+    finding: Finding | None = None
+    calls = prompt_tok = comp_tok = 0
+    async for event in runner.run_async(
+            session_id=session.id, user_id=_USER, new_message=content):
+        if event.usage_metadata:
+            calls += 1
+            prompt_tok += event.usage_metadata.prompt_token_count or 0
+            comp_tok += event.usage_metadata.candidates_token_count or 0
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    try:
+                        finding = Finding.model_validate_json(part.text)
+                    except Exception:
+                        pass
+    rec = RunRecord(system="baseline", incident_id=incident.id, finding=finding,
+                     prompt_tokens=prompt_tok, completion_tokens=comp_tok,
+                     model_calls=calls, latency_ms=(time.monotonic() - start) * 1000)
+    # static, fixed gate: apply only if the finding names the sanctioned action
+    if finding and finding.proposed_action == incident.irreversible_action:
+        tools.apply_remediation(
+            incident.irreversible_action,
+            ApprovalToken(action=incident.irreversible_action, approver="static-policy"))
+        rec.remediation_applied = True
+        rec.approved = True
+    return rec

--- a/labs/lab_002/systems.py
+++ b/labs/lab_002/systems.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 import time
 
-from google.adk import Agent
+from google.adk import Agent, Context, Event, Workflow
+from google.adk.events import RequestInput
 from google.adk.runners import Runner
+from google.adk.workflow import node
+from google.adk.workflow.utils._workflow_hitl_utils import create_request_input_response
 from google.genai import types
 
 from labs.lab_002 import tools
 from labs.lab_002.gate import ApprovalToken
-from labs.lab_002.schema import Finding, Incident, RunRecord
+from labs.lab_002.schema import (
+    Finding,
+    Hypothesis,
+    Incident,
+    RemediationDecision,
+    RunRecord,
+    Verdict,
+)
 
 _APP = "lab002"
 _USER = "sre"
@@ -76,4 +86,148 @@ async def run_baseline(agent: Agent, incident: Incident, session_service) -> Run
             ApprovalToken(action=incident.irreversible_action, approver="static-policy"))
         rec.remediation_applied = True
         rec.approved = True
+    return rec
+
+
+# --- Contender: dynamic Workflow graph with a human-in-the-loop gate (Task 8) ---
+
+_MAX_RETRY = 2
+_BRANCHES = ("deploy", "config", "dependency", "data")
+
+_INVESTIGATOR_INSTR = (
+    "You are investigating one angle of an incident. The input starts with a "
+    "'branch: <name>' line naming which angle to investigate, followed by the "
+    "incident context. Given that, return a Hypothesis: branch (echo the branch "
+    "name given to you), claim (what you think happened on this branch), and "
+    "evidence (the specific log/metric/config/diff lines that support it)."
+)
+_VERIFIER_INSTR = (
+    "You are a strict verifier. Given a Hypothesis and the original incident "
+    "context, judge whether the hypothesis's claim is actually grounded in the "
+    "evidence present in the incident context. Return a Verdict: grounded "
+    "(true only if the evidence genuinely supports the claim) and reason."
+)
+_SYNTHESIZER_INSTR = (
+    "Combine the confirmed hypotheses (if any) and the incident context into "
+    "one Finding: incident_id (copy the incident_id line verbatim), root_cause, "
+    "proposed_remediation, and proposed_action (copy the candidate action id "
+    "line verbatim). If no hypotheses were confirmed, use the incident context "
+    "directly to produce your best-effort Finding."
+)
+
+
+def build_contender(model) -> Workflow:
+    """Dynamic investigator/verifier fan-out, synthesized into a Finding that
+    pauses at a human approval gate before the irreversible remediation runs.
+    """
+    investigator = Agent(
+        name="investigator", model=model, output_schema=Hypothesis,
+        output_key="hypothesis", instruction=_INVESTIGATOR_INSTR)
+    verifier = Agent(
+        name="verifier", model=model, output_schema=Verdict, output_key="verdict",
+        instruction=_VERIFIER_INSTR)
+    synthesizer = Agent(
+        name="synthesizer", model=model, output_schema=Finding,
+        output_key="finding", instruction=_SYNTHESIZER_INSTR)
+
+    @node(rerun_on_resume=True)
+    async def investigate(ctx: Context, node_input: str):
+        confirmed: list[Hypothesis] = []
+        for branch in _BRANCHES:
+            for _ in range(_MAX_RETRY):
+                h = Hypothesis.model_validate(await ctx.run_node(
+                    investigator, node_input=f"branch: {branch}\n{node_input}"))
+                v = Verdict.model_validate(await ctx.run_node(
+                    verifier, node_input=f"{h.model_dump_json()}\n\n"
+                                         f"incident context:\n{node_input}"))
+                if v.grounded:
+                    confirmed.append(h)
+                    break
+        synth_input = (
+            "confirmed hypotheses:\n"
+            + ("\n".join(h.model_dump_json() for h in confirmed)
+               if confirmed else "(none confirmed)")
+            + f"\n\nincident context:\n{node_input}"
+        )
+        finding = Finding.model_validate(
+            await ctx.run_node(synthesizer, node_input=synth_input))
+        yield finding
+
+    def gate(finding: Finding):
+        # Returning a RequestInput pauses the workflow until a human responds.
+        return RequestInput(
+            interrupt_id="remediation_approval",
+            message="Approve remediation before it touches prod.",
+            payload=finding, response_schema=RemediationDecision)
+
+    def apply(finding: Finding, node_input: RemediationDecision):
+        if node_input.approved:
+            tok = ApprovalToken(action=finding.proposed_action, approver=node_input.approver)
+            tools.apply_remediation(finding.proposed_action, tok)
+            text = f"applied {finding.proposed_action}"
+        else:
+            text = "remediation denied"
+        yield Event(content=types.Content(role="model", parts=[types.Part(text=text)]))
+
+    return Workflow(name="contender", edges=[("START", investigate, gate, apply)])
+
+
+def _tally(rec: RunRecord, event: Event) -> None:
+    """Accumulate model-call/token counters from a run event, in place."""
+    if event.usage_metadata:
+        rec.model_calls += 1
+        rec.prompt_tokens += event.usage_metadata.prompt_token_count or 0
+        rec.completion_tokens += event.usage_metadata.candidates_token_count or 0
+
+
+def _extract_finding(event: Event) -> Finding | None:
+    """Try to parse a Finding out of any text part of the event."""
+    if not (event.content and event.content.parts):
+        return None
+    for part in event.content.parts:
+        if part.text:
+            try:
+                return Finding.model_validate_json(part.text)
+            except Exception:
+                pass
+    return None
+
+
+async def _resume(runner: Runner, session, interrupt_id: str, decision: RemediationDecision):
+    """Resume a paused run by answering the given interrupt on the same session."""
+    part = create_request_input_response(interrupt_id, decision.model_dump())
+    content = types.Content(role="user", parts=[part])
+    async for event in runner.run_async(
+            session_id=session.id, user_id=_USER, new_message=content):
+        yield event
+
+
+async def run_contender(workflow: Workflow, incident: Incident, session_service,
+                         *, auto_approve: bool) -> RunRecord:
+    session = await session_service.create_session(
+        app_name=_APP, user_id=_USER, session_id=f"cont-{incident.id}")
+    runner = Runner(agent=workflow, app_name=_APP, session_service=session_service)
+    content = types.Content(role="user",
+                             parts=[types.Part(text=_context_blob(incident))])
+    start = time.monotonic()
+    rec = RunRecord(system="contender", incident_id=incident.id)
+    interrupt_id: str | None = None
+    async for event in runner.run_async(
+            session_id=session.id, user_id=_USER, new_message=content):
+        _tally(rec, event)
+        finding = _extract_finding(event)
+        if finding is not None:
+            rec.finding = finding
+        if event.long_running_tool_ids:
+            interrupt_id = next(iter(event.long_running_tool_ids))
+    if auto_approve and interrupt_id and rec.finding is not None:
+        decision = RemediationDecision(approved=True, approver="sre-oncall")
+        async for event in _resume(runner, session, interrupt_id, decision):
+            _tally(rec, event)
+            if event.content and event.content.parts and any(
+                    "applied" in (part.text or "") for part in event.content.parts):
+                rec.remediation_applied = True
+        rec.approved = True
+        rec.resumed = True
+    rec.latency_ms = (time.monotonic() - start) * 1000
     return rec

--- a/labs/lab_002/systems.py
+++ b/labs/lab_002/systems.py
@@ -8,6 +8,10 @@ from google.adk import Agent, Context, Event, Workflow
 from google.adk.events import RequestInput
 from google.adk.runners import Runner
 from google.adk.workflow import node
+
+# Private ADK module: no public re-export exists for the resume-response helper in
+# 2.3.0. Verified against google-adk 2.3.0; pyproject pins ~=2.3.0 to keep this path
+# stable. If a later ADK release relocates it, update this import.
 from google.adk.workflow.utils._workflow_hitl_utils import create_request_input_response
 from google.genai import types
 

--- a/labs/lab_002/tools.py
+++ b/labs/lab_002/tools.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from labs.lab_002.gate import ApprovalToken, require_approval
+from labs.lab_002.schema import Incident
+
+
+def log_search(incident: Incident, query: str = "") -> str:
+    hits = [ln for ln in incident.bundle.logs if query.lower() in ln.lower()] \
+        if query else incident.bundle.logs
+    return "\n".join(hits) or "no matching log lines"
+
+
+def metric_query(incident: Incident, name: str = "") -> str:
+    m = incident.bundle.metrics
+    if name and name in m:
+        return f"{name}={m[name]}"
+    return ", ".join(f"{k}={v}" for k, v in m.items())
+
+
+def config_read(incident: Incident) -> str:
+    return "\n".join(f"{k}={v}" for k, v in incident.bundle.config.items())
+
+
+def diff_read(incident: Incident) -> str:
+    return incident.bundle.diff
+
+
+def apply_remediation(action: str, token: ApprovalToken | None) -> str:
+    """The single irreversible action. Gated by an out-of-band approval token."""
+    require_approval(action, token)
+    return f"remediation applied: {action}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ foundations = [
     "langchain-anthropic>=0.3",
     "langgraph>=0.2",
 ]
+lab002 = [
+    "google-adk>=2.3.0",
+    "litellm>=1.40",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ foundations = [
     "langgraph>=0.2",
 ]
 lab002 = [
-    "google-adk>=2.3.0",
+    "google-adk~=2.3.0",
     "litellm>=1.40",
 ]
 

--- a/src/content/labs/incident-triage-durable-agent.mdx
+++ b/src/content/labs/incident-triage-durable-agent.mdx
@@ -1,0 +1,96 @@
+---
+id: lab-002
+title: The durable agent, and whether ADK 2.0's crash-resilient runtime earns its overhead
+description: A static router and a dynamic, human-gated ADK 2.0 Workflow graph run over 30 synthetic incidents on a local model. The multi-agent graph loses on accuracy at 21x the cost, but its durable runtime recovers every crashed run for free.
+hypothesis: A dynamic, human-gated multi-agent graph earns its overhead on a complex incident-triage task a static router cannot decompose, and its durable runtime recovers crashed work on resume instead of re-paying for it.
+result: 17 calls, 0 re-run
+resultLabel: Dynamic multi-agent lost on accuracy at 21x cost; the durable runtime recovered a crashed run for free
+date: 2026-07-03
+readingTime: 12
+seed: 42
+references:
+  - ch-04
+  - ch-07
+  - fn-004
+---
+
+import Callout from '~/components/universal/Callout.astro';
+
+The question this Lab answers: when an incident needs more than one clean step to resolve, does a dynamic multi-agent system built on Google's [ADK 2.0](https://google.github.io/adk-docs/) Workflow Runtime earn its overhead over a static router, and does its headline feature, a durable runtime that survives a crash, actually deliver? The short version is a split verdict. On a weak local model the multi-agent graph did not win on accuracy, and it cost 21 times the tokens to lose. But its durable runtime did exactly what it claims: a run that crashed at the human approval gate resumed without re-running a single one of its 17 prior model calls. The accuracy verdict is capability-dependent and it is the same story [Lab-001](/labs/multi-agent-vs-router-100-queries/) told. The durability result is not capability-dependent, and it is the reason to read this.
+
+## Setup
+
+**Dataset.** 30 synthetic incidents, generated from a seeded deterministic script (seed 42), balanced across four fault families: a bad deploy, config drift, a dependency failure, and a data issue. Each incident carries a bundle (logs, metrics, a config snapshot, a code diff), a known ground-truth root cause, a known correct remediation, and one irreversible action that a fix would have to take. The generator and the exact 30-incident set are committed under `labs/lab_002/`, so this run reproduces. That is the first thing Lab-001 got wrong and this Lab fixes.
+
+**Baseline (static router).** A single ADK agent that receives the whole incident context in one pass and returns a structured finding: root cause, remediation, and the exact action id. One model call per incident. It applies the remediation only when its named action matches the sanctioned action id verbatim.
+
+**Contender (dynamic Workflow graph).** An ADK 2.0 `Workflow` whose orchestrator node fans out at runtime into four investigation branches, runs each through an investigator and an external verifier with a retry loop, synthesizes the confirmed hypotheses into one finding, and then pauses at a human approval gate before any remediation touches the incident. The gate is a real interrupt, not a prompt: the workflow returns a `RequestInput` and stops until a decision comes back.
+
+**Both** run on the same local model (llama3.2:3b) for the agents. Findings are scored two ways: a cheap keyword-overlap heuristic, and an independent LLM judge (qwen2.5:14b, three passes, weighted rubric, pass threshold 0.6). The judge variance across passes was 0.000, so the judge numbers are stable.
+
+## Method
+
+Every incident ran through both systems. Each system logged its full record: the finding, token counts, model calls, latency, whether remediation was applied, and whether the run was resumed after a crash. The durability harness ran a fixed subset of 5 incidents through a genuine crash: the contender ran to the approval gate on a persisted SQLite session, then the runner and the session service were destroyed to simulate a process death, and a fresh runner reopened the same database and resumed. What we measured on resume is how much of the pre-crash work re-ran.
+
+<Callout type="gotcha">
+ADK 2.0's own test suite marks broad workflow resumability as expected-to-fail: "Resumability broken in V2" and "Checkpoint/resume not yet in new Workflow" appear across the workflow HITL tests. Those cover a different scenario (an LLM agent driving a long-running tool under an app-level resumability config). The pattern this Lab uses, a node that returns a `RequestInput` and a resume driven off a persisted `SqliteSessionService`, does work in 2.3.0. We only trusted that after building a crash-and-resume harness and watching it recover. On a runtime this young, verify the exact path you depend on rather than the feature name.
+</Callout>
+
+## Results
+
+**Accuracy.** The heuristic keyword-overlap success rate was 20.0% for the baseline and 10.0% for the contender. The LLM judge pass rate (weighted score at or above 0.6) was 16.7% for the baseline and 10.0% for the contender. So on the metric that matters, clearing the bar, the dynamic graph did worse. The one number that leans the other way is the average judge weighted score: 0.273 for the baseline against 0.326 for the contender. The multi-branch investigation produced findings that were marginally better on average, but not better often enough to pass more often. Neither system is good here. A 3B model is weak for open-ended root-cause work, and that weakness is most of the story.
+
+**Cost.** The baseline averaged 290 tokens and one model call per incident. The contender averaged 6,256 tokens and 16.93 model calls. That is a 21.56x token multiple to produce a lower pass rate.
+
+**Latency.** Baseline p50 was 2.55 seconds. Contender p50 was 48.1 seconds, an 18.85x multiple, because the investigation runs its branches and verifier retries in sequence.
+
+**Remediation reached.** The baseline applied a remediation on 3.3% of incidents; the contender on 100%. This is not the contender being reckless. The baseline's rigid rule requires the weak model to echo the exact action id string, which it almost never does because it paraphrases. The contender's synthesizer is told to copy the action id, and every remediation it applied went through the approval gate first. So the contender is the system that actually reaches a gated, approved action, and the baseline mostly stalls before doing anything.
+
+**Durability.** This is where the runtime earns its keep. Across all 5 crash tests, the contender resumed after the simulated process death and re-ran nothing: an average of 6,265 tokens, 17 model calls, and 48.6 seconds of work per incident were recovered from the persisted event log rather than repeated. Frontier calls after resume averaged 0. A naive harness that lost its state on the crash would have re-paid every token and every second of that pre-gate investigation. ADK's durable runtime re-paid none of it.
+
+## Conclusion
+
+On a weak local model, dynamic multi-agent decomposition does not earn its 21x overhead for incident triage. Findings get slightly better on average and pass the bar less often, at 21 times the tokens and 19 times the latency. That is the same shape as Lab-001: the value of orchestration is a decision, not a maturity level, and here the decision does not pay. The obvious next run is the same experiment on a frontier model, where a stronger agent might convert the marginal quality edge into a real pass-rate win. That run needs a paid model and is deferred, so this Lab does not claim it either way. It names it as the open question.
+
+The result that does not depend on model strength is durability. When a long, expensive, human-gated agent run crashes, ADK 2.0's durable Workflow Runtime brought it back and recovered 100% of the work already done. If you are going to run agents that pause for a human and hold that pause across minutes or a restart, that property is the thing worth building on, independent of whether the multi-agent topology wins on accuracy.
+
+And the gate held. The irreversible remediation never fired before an approval came back. That is the enforced stop from [Field Note 004](/field-notes/004-loop-engineering-30-year-old-loop/), now measured rather than argued. It also raises the question that a durable pause makes unavoidable: the runtime gives you the pause, but it does not tell you who is allowed to resolve it. That authority has to live outside the model, and it is the layer a durable, human-gated agent still needs.
+
+## What we got wrong
+
+**We expected the contender to win on accuracy and it did not.** The pre-registered hypothesis was that a task the router cannot decompose would reward the multi-agent graph. On a 3B model it did not. The honest read is that base-model capability is the dominant variable, and 30 incidents on a weak model is not the regime where decomposition pays. We are reporting the loss rather than reaching for a model that would flip it.
+
+**The baseline's low remediation rate is a metric artifact, not a safety win.** The baseline applied almost nothing because it could not echo an exact action id, not because it was being careful. We left the rigid rule in because it is the honest static baseline, but it means the 3.3% versus 100% remediation numbers are about string matching, not judgment.
+
+## Caveats
+
+- Local open models only. Agents on llama3.2:3b, judge on qwen2.5:14b. No frontier-model run was done, so nothing here speaks to what a stronger agent would do.
+- Local inference has no dollar cost, so the cost axis is tokens and model calls, not dollars.
+- 30 incidents is a small set. The direction is clear but the exact percentages carry the noise of a small-N run on a weak model. Per-incident detail, including every judge pass, is in `labs/lab_002/results.json`.
+- The durability result is the strongest claim here, and it is the one built on a runtime whose broader resumability its own maintainers still mark as unfinished. It holds for the specific gate-and-resume path measured, not for ADK resumability in general.
+
+## In code
+
+The contender's whole shape is the fan-out, the external verifier, and the gate. The investigation node must be marked to re-run on resume, which is what lets the runtime replay it from the event log and hand back the cached child results instead of calling the model again.
+
+```python
+# Illustrative. Full harness, dataset, and run outputs are committed under labs/lab_002/.
+@node(rerun_on_resume=True)
+async def investigate(ctx, node_input):
+    confirmed = []
+    for branch in BRANCHES:                    # dynamic fan-out at runtime
+        for _ in range(MAX_RETRY):
+            h = await ctx.run_node(investigator, node_input=branch_prompt(branch, node_input))
+            v = await ctx.run_node(verifier, node_input=verify_prompt(h, node_input))
+            if v.grounded:
+                confirmed.append(h)
+                break
+    yield await ctx.run_node(synthesizer, node_input=synth_prompt(confirmed, node_input))
+
+def gate(finding):
+    # Returning RequestInput pauses the run until a human resolves it.
+    return RequestInput(interrupt_id="remediation_approval",
+                        payload=finding, response_schema=RemediationDecision)
+```
+
+The crash test is the reproducible part worth running yourself. Take the contender to the gate on a `SqliteSessionService`, drop the runner, reopen the same database in a fresh runner, and resume. Count the model calls before and after. In this run it was 17 before and 0 after.

--- a/tests/integration/test_lab002_durability.py
+++ b/tests/integration/test_lab002_durability.py
@@ -1,0 +1,31 @@
+import httpx
+import pytest
+
+from labs.lab_002.dataset import generate
+from labs.lab_002.metrics import durability_savings
+
+
+def _ollama_up() -> bool:
+    try:
+        httpx.get("http://localhost:11434/api/tags", timeout=1.0)
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _ollama_up(), reason="needs local Ollama")
+
+
+@pytest.mark.asyncio
+async def test_resume_skips_completed_work_and_applies_once(tmp_path):
+    from google.adk.models.lite_llm import LiteLlm
+
+    from labs.lab_002.durability import run_with_crash
+    inc = generate(4, seed=42)[0]
+    db = str(tmp_path / "sess.db")
+    pre, post = await run_with_crash(inc, LiteLlm(model="ollama_chat/llama3.2:3b"), db)
+    # pre-interrupt did the expensive investigation; post-resume ran far fewer calls
+    assert pre.model_calls > post.model_calls          # dedup skipped completed nodes
+    assert post.remediation_applied is True            # resumed to completion
+    saved = durability_savings(pre, post)
+    assert saved["model_calls_saved"] == pre.model_calls

--- a/tests/integration/test_lab002_systems.py
+++ b/tests/integration/test_lab002_systems.py
@@ -1,0 +1,28 @@
+import httpx
+import pytest
+
+from labs.lab_002.dataset import generate
+from labs.lab_002.systems import build_baseline, run_baseline
+
+
+def _ollama_up() -> bool:
+    try:
+        httpx.get("http://localhost:11434/api/tags", timeout=1.0)
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _ollama_up(), reason="needs local Ollama")
+
+
+@pytest.mark.asyncio
+async def test_baseline_produces_a_finding():
+    from google.adk.models.lite_llm import LiteLlm
+    from google.adk.sessions.in_memory_session_service import InMemorySessionService
+    inc = generate(4, seed=42)[0]
+    agent = build_baseline(LiteLlm(model="ollama_chat/llama3.2:3b"))
+    rec = await run_baseline(agent, inc, InMemorySessionService())
+    assert rec.system == "baseline"
+    assert rec.finding is not None
+    assert rec.model_calls >= 1

--- a/tests/integration/test_lab002_systems.py
+++ b/tests/integration/test_lab002_systems.py
@@ -26,3 +26,31 @@ async def test_baseline_produces_a_finding():
     assert rec.system == "baseline"
     assert rec.finding is not None
     assert rec.model_calls >= 1
+
+
+@pytest.mark.asyncio
+async def test_contender_pauses_before_remediation():
+    from google.adk.models.lite_llm import LiteLlm
+    from google.adk.sessions.in_memory_session_service import InMemorySessionService
+
+    from labs.lab_002.systems import build_contender, run_contender
+    inc = generate(4, seed=42)[0]
+    wf = build_contender(LiteLlm(model="ollama_chat/llama3.2:3b"))
+    # auto_approve=False: run only up to the human gate
+    rec = await run_contender(wf, inc, InMemorySessionService(), auto_approve=False)
+    assert rec.remediation_applied is False  # gate not resolved -> nothing applied
+    assert rec.finding is not None           # investigation completed to a finding
+
+
+@pytest.mark.asyncio
+async def test_contender_resumes_and_applies_remediation():
+    from google.adk.models.lite_llm import LiteLlm
+    from google.adk.sessions.in_memory_session_service import InMemorySessionService
+
+    from labs.lab_002.systems import build_contender, run_contender
+    inc = generate(4, seed=42)[1]
+    wf = build_contender(LiteLlm(model="ollama_chat/llama3.2:3b"))
+    rec = await run_contender(wf, inc, InMemorySessionService(), auto_approve=True)
+    assert rec.finding is not None
+    assert rec.remediation_applied is True
+    assert rec.approved is True

--- a/tests/unit/test_lab002_dataset.py
+++ b/tests/unit/test_lab002_dataset.py
@@ -1,0 +1,28 @@
+from labs.lab_002.dataset import generate
+from labs.lab_002.schema import FaultFamily
+
+
+def test_generation_is_deterministic():
+    a = generate(20, seed=42)
+    b = generate(20, seed=42)
+    assert [i.model_dump() for i in a] == [i.model_dump() for i in b]
+
+
+def test_seed_changes_output():
+    assert generate(20, seed=1)[0].id == generate(20, seed=2)[0].id  # ids stable
+    assert generate(20, seed=1)[0].bundle != generate(20, seed=2)[0].bundle
+
+
+def test_families_are_balanced():
+    items = generate(20, seed=42)
+    counts = {f: 0 for f in FaultFamily}
+    for i in items:
+        counts[i.fault_family] += 1
+    assert all(c == 5 for c in counts.values())  # 20 / 4 families
+
+
+def test_every_incident_has_ground_truth_and_gated_action():
+    for i in generate(12, seed=42):
+        assert i.ground_truth_root_cause
+        assert i.irreversible_action.startswith(("rollback_deploy:", "revert_config:",
+                                                 "restart_service:", "purge_cache:"))

--- a/tests/unit/test_lab002_gate.py
+++ b/tests/unit/test_lab002_gate.py
@@ -1,0 +1,19 @@
+import pytest
+
+from labs.lab_002.gate import ApprovalError, ApprovalToken, require_approval
+
+
+def test_no_token_blocks():
+    with pytest.raises(ApprovalError):
+        require_approval("rollback_deploy:svc@v1", None)
+
+
+def test_mismatched_action_blocks():
+    tok = ApprovalToken(action="rollback_deploy:other@v9", approver="sre")
+    with pytest.raises(ApprovalError):
+        require_approval("rollback_deploy:svc@v1", tok)
+
+
+def test_matching_token_allows():
+    tok = ApprovalToken(action="rollback_deploy:svc@v1", approver="sre")
+    require_approval("rollback_deploy:svc@v1", tok)  # no raise

--- a/tests/unit/test_lab002_metrics.py
+++ b/tests/unit/test_lab002_metrics.py
@@ -1,0 +1,36 @@
+from labs.lab_002.dataset import generate
+from labs.lab_002.metrics import durability_savings, score_finding, success_rate
+from labs.lab_002.schema import Finding, RunRecord
+
+
+def test_score_rewards_ground_truth_overlap():
+    inc = generate(4, seed=42)[0]
+    good = Finding(incident_id=inc.id, root_cause=inc.ground_truth_root_cause,
+                   proposed_remediation=inc.ground_truth_remediation,
+                   proposed_action=inc.irreversible_action)
+    bad = Finding(incident_id=inc.id, root_cause="the moon",
+                  proposed_remediation="reboot everything", proposed_action="x")
+    assert score_finding(good, inc) > score_finding(bad, inc)
+    assert score_finding(None, inc) == 0.0
+
+
+def test_success_rate_counts_passing():
+    incs = {i.id: i for i in generate(4, seed=42)}
+    rec = RunRecord(system="c", incident_id="inc-000",
+                    finding=Finding(incident_id="inc-000",
+                                    root_cause=incs["inc-000"].ground_truth_root_cause,
+                                    proposed_remediation=incs["inc-000"].ground_truth_remediation,
+                                    proposed_action="x"))
+    assert success_rate([rec], incs) == 1.0
+
+
+def test_durability_savings_is_pre_interrupt_work():
+    pre = RunRecord(system="c", incident_id="i", prompt_tokens=800,
+                    completion_tokens=200, model_calls=6, latency_ms=5000)
+    post = RunRecord(system="c", incident_id="i", prompt_tokens=100,
+                     completion_tokens=50, model_calls=1, latency_ms=700)
+    s = durability_savings(pre, post)
+    assert s["tokens_saved"] == 1000
+    assert s["model_calls_saved"] == 6
+    assert s["latency_ms_saved"] == 5000
+    assert s["frontier_calls"] == 1  # post-resume ran only the frontier

--- a/tests/unit/test_lab002_schema.py
+++ b/tests/unit/test_lab002_schema.py
@@ -1,2 +1,31 @@
 def test_package_imports():
     import labs.lab_002  # noqa: F401
+
+
+from labs.lab_002.schema import (
+    Finding, Incident, IncidentBundle, FaultFamily, RunRecord,
+)
+
+
+def test_incident_roundtrips():
+    inc = Incident(
+        id="inc-001",
+        fault_family=FaultFamily.BAD_DEPLOY,
+        bundle=IncidentBundle(logs=["boom"], metrics={"err_rate": 0.9},
+                              config={"replicas": "3"}, diff="- old\n+ new"),
+        ground_truth_root_cause="bad deploy of svc-checkout v1.4.2",
+        ground_truth_remediation="rollback svc-checkout to v1.4.1",
+        irreversible_action="rollback_deploy:svc-checkout@v1.4.1",
+    )
+    assert Incident.model_validate_json(inc.model_dump_json()) == inc
+
+
+def test_runrecord_defaults_are_zero():
+    r = RunRecord(system="baseline", incident_id="inc-001")
+    assert r.model_calls == 0 and r.remediation_applied is False
+
+
+def test_finding_carries_proposed_action():
+    f = Finding(incident_id="inc-001", root_cause="x",
+                proposed_remediation="y", proposed_action="rollback_deploy:z")
+    assert f.proposed_action == "rollback_deploy:z"

--- a/tests/unit/test_lab002_schema.py
+++ b/tests/unit/test_lab002_schema.py
@@ -1,0 +1,2 @@
+def test_package_imports():
+    import labs.lab_002  # noqa: F401

--- a/tests/unit/test_lab002_schema.py
+++ b/tests/unit/test_lab002_schema.py
@@ -1,10 +1,14 @@
+from labs.lab_002.schema import (
+    FaultFamily,
+    Finding,
+    Incident,
+    IncidentBundle,
+    RunRecord,
+)
+
+
 def test_package_imports():
     import labs.lab_002  # noqa: F401
-
-
-from labs.lab_002.schema import (
-    Finding, Incident, IncidentBundle, FaultFamily, RunRecord,
-)
 
 
 def test_incident_roundtrips():

--- a/tests/unit/test_lab002_tools.py
+++ b/tests/unit/test_lab002_tools.py
@@ -1,0 +1,27 @@
+import pytest
+
+from labs.lab_002 import tools
+from labs.lab_002.dataset import generate
+from labs.lab_002.gate import ApprovalError, ApprovalToken
+
+
+def _incident():
+    return generate(4, seed=42)[0]
+
+
+def test_read_tools_return_text():
+    inc = _incident()
+    assert isinstance(tools.log_search(inc, "error"), str)
+    assert isinstance(tools.metric_query(inc, "err_rate"), str)
+    assert isinstance(tools.config_read(inc), str)
+    assert isinstance(tools.diff_read(inc), str)
+
+
+def test_apply_remediation_blocked_without_token():
+    with pytest.raises(ApprovalError):
+        tools.apply_remediation("rollback_deploy:svc@v1", None)
+
+
+def test_apply_remediation_runs_with_matching_token():
+    tok = ApprovalToken(action="rollback_deploy:svc@v1", approver="sre")
+    assert "applied" in tools.apply_remediation("rollback_deploy:svc@v1", tok).lower()


### PR DESCRIPTION
## Lab-002: the durable, human-gated agent (ADK 2.0)

A reproducible Lab that puts Google ADK 2.0's dynamic, human-gated Workflow Runtime under the same measured, honest lens as Lab-001: does a dynamic multi-agent graph earn its overhead on incident triage, and does the runtime's headline durability actually deliver?

### The honest result (local floor, `llama3.2:3b` agents, `qwen2.5:14b` judge, 30 synthetic incidents)

- **Accuracy: the contender loses.** Judge pass rate baseline 16.7% vs contender 10.0% (heuristic 20% vs 10%), at **21.6x tokens** and **18.9x latency**. Average judge weighted score edges the other way (0.273 vs 0.326): the multi-branch investigation produces marginally better findings but clears the bar less often. Same shape as Lab-001, the verdict is capability-dependent. The frontier-model run is deferred (no API key) and named as the open question, not claimed.
- **Durability: the unambiguous, model-independent win.** Across 5 crash tests, a run that died at the human approval gate resumed and re-ran **nothing**: avg 6,265 tokens / 17 model calls / 48.6s recovered from the persisted event log, 0 frontier calls. A naive harness would re-pay all of it.
- **The enforced gate held.** The irreversible remediation never fired before approval, across all 30 records.

### What's in the branch

- `labs/lab_002/` — reproducible harness: seeded 30-incident generator + committed dataset, exact-match capability gate (CI-proven), mock incident tools, metrics + durability accounting, static baseline + dynamic contender on ADK 2.0, crash-and-resume SQLite durability harness, run + LLM-judge evaluate orchestration, committed run outputs.
- `src/content/labs/incident-triage-durable-agent.mdx` — the published Lab issue (builds and renders).
- Isolated `lab002` extras group pinned `google-adk~=2.3.0`, kept separate from the ADK 1.x `foundations` group.

### Notable finding

ADK 2.3.0's own test suite marks broad workflow resumability xfail ("Resumability broken in V2"), but that covers a different LlmAgent + long-running-tool scenario. The gate pattern this Lab uses (a node returns `RequestInput`, resume off a persisted `SqliteSessionService`) does work in 2.3.0, verified by the crash-and-resume harness before relying on it.

### Tests

- Deterministic core (schema, dataset determinism, gate, tools, metrics): 141 unit tests, no API keys.
- ADK integration (baseline, contender pause + resume, crash-and-resume dedup): verified live against Ollama.
- Site builds clean; Lab page emits.

### Deferred (intentional)

- Banner/spot art via the codex image pipeline (schema makes it optional; left off to avoid a broken image link).
- Frontier-model (Gemini) run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new lab for incident triage with a baseline workflow, a human-approval gate, durability/resume support, and evaluation metrics.
  * Added commands to generate data, run experiments, and evaluate results.
  * Added synthetic incident datasets and saved run outputs for baseline, contender, and durability comparisons.

* **Documentation**
  * Added lab documentation and a results report with setup, usage, and outcome summaries.

* **Tests**
  * Added unit and integration coverage for dataset generation, approval gating, metrics, tools, and resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->