### PR TITLE
Foundations: The Production Boundary (00F) + cross-cutting edits

### DIFF
--- a/src/components/universal/ChapterMap.astro
+++ b/src/components/universal/ChapterMap.astro
@@ -1,6 +1,6 @@
 ---
 /**
- * ChapterMap — visual sitemap of all 18 chapters, current one highlighted.
+ * ChapterMap — visual sitemap of all 19 chapters, current one highlighted.
  * Renders as 5 stacked rows (one per Part) of tiny rectangles.
  */
 interface Props {
@@ -12,7 +12,7 @@ const { currentSlug } = Astro.props;
 const parts = [
   {
     label: 'Foundations',
-    chapters: ['00a-how-llms-work', '00b-api-to-tools', '00c-first-agent', '00d-frameworks', '00e-connecting-to-mcp'],
+    chapters: ['00a-how-llms-work', '00b-api-to-tools', '00c-first-agent', '00d-frameworks', '00e-connecting-to-mcp', '00f-the-production-boundary'],
   },
   {
     label: 'I · Build',

--- a/src/content/chapters/00a-how-llms-work.mdx
+++ b/src/content/chapters/00a-how-llms-work.mdx
@@ -423,6 +423,22 @@ The key principle: if structured output fails after your retry budget, return a 
 Picture a classification agent that returns `{"confidence": 1.5, "category": "high_risk", "review_date": "next Tuesday"}`. The JSON parses without errors. Without a validation layer, downstream routing logic would treat 1.5 as a valid confidence score, escalate the case as ultra-high-confidence, and pass "next Tuesday" along as a date string that breaks the first batch job that tries to parse it. Schema validation (Pydantic) catches the confidence value immediately. Semantic validation catches the non-ISO date. Without the validation ladder, syntactically correct garbage flows downstream and breaks things far from the source.
 </Callout>
 
+## Provider behavior leaks through the abstraction
+
+A provider-neutral client is worth building, but provider behavior still leaks through it.
+
+| Area | How it varies across providers |
+|------|--------------------------------|
+| Tool-call format | message shape and tool-choice control differ |
+| Structured output | strict schema enforcement is not universal |
+| Streaming | different event formats |
+| Context caching | not portable across providers |
+| Refusal behavior | different safety thresholds and phrasing |
+| Token accounting | counted and priced differently per model |
+| Parallel tool calls | supported unevenly |
+
+The abstraction is worth keeping, but write tests against the provider you actually ship on.
+
 ## Putting it together
 
 You now have a mental model of the machine you are building with. It takes text, returns text, costs money per token, has a fixed memory, and confidently makes things up. Every engineering decision from here forward is about working within and around these constraints.
@@ -432,6 +448,10 @@ Now that you know the model is probabilistic, bounded by context, vulnerable to 
 The next three sections build these answers. Section 0b gives the model hands. Section 0c gives it a loop -- [FN-004](/field-notes/004-loop-engineering-30-year-old-loop/) has more on why the stop condition inside that loop is the hard, still-unsolved part. Section 0d shows you what frameworks do with both.
 
 For hands-on experiments with everything in this section, see the [LLM Explorer](/projects/llm-explorer/) project.
+
+<Callout type="tip" label="How you know this worked">
+Test that the model: respects the output format you asked for; stays inside its token budget; refuses claims it cannot support; and admits uncertainty rather than inventing an answer.
+</Callout>
 
 ## Further reading
 

--- a/src/content/chapters/00b-api-to-tools.mdx
+++ b/src/content/chapters/00b-api-to-tools.mdx
@@ -470,6 +470,23 @@ A representative failure, composited from patterns seen across data pipeline age
 
 Validation isn't just about preventing crashes. It's about giving the model enough information to self-correct. A model that receives "Validation error: Input should be 'add', 'subtract', 'multiply' or 'divide'" will fix its next attempt. A model that receives "Error: unhandled exception in tool execution" will guess, and guess wrong.
 
+## Validation is not authorization
+
+Everything above proves the arguments are well-formed: the type is right, the required fields are present, the values sit inside their range. None of that proves the action itself is allowed.
+
+Run the calculator's arguments and a send-money tool's arguments through the same kind of Pydantic model and they can both pass: right types, required fields present, values in range. Pydantic has no opinion about what happens after it returns. It checks the shape of the argument, not the shape of the consequence. Real tools send email, move money, and delete records, and a validator that only checks shape will wave all three through with the same confidence it waves through a calculator call.
+
+That's why every tool needs a second classification, separate from its input schema: read-only or side-effecting. A read-only tool looks something up and leaves the world exactly as it found it: search a knowledge base, check a weather API, read a customer record. Get it wrong and you've shown someone the wrong answer. A side-effecting tool changes something outside the model's context window. Get it wrong and something happened that you now have to notice, undo, or apologize for, and some of the time you can't undo it at all.
+
+Schema validation treats both kinds of tool identically, because to a validator they are identical: a name and an object of arguments. The check that tells them apart sits after validation, right before execution:
+
+```python
+if not policy.allowed(user, tool_name, args):
+    return ToolResult(error="not authorized")
+```
+
+A call that clears every check in the section above, right type, all fields present, values in range, can still fail this one. Valid is not the same as allowed. Section 0f turns that single check into five separate questions you ask before every tool call.
+
 ## Multiple tools and selection
 
 Give the model three tools and a question. Watch what happens.
@@ -583,6 +600,10 @@ Key takeaways:
 The next section adds the loop that removes that ceiling: about 100 lines of Python, a while loop with an LLM inside it, and the engineering challenge of knowing when it should stop.
 
 For a fully built tool-using assistant with proper error handling and logging, see the [Tool-Using Assistant](/projects/tool-using-assistant/) project.
+
+<Callout type="tip" label="How you know this worked">
+Test that the agent: rejects malformed tool arguments; handles missing fields; does not call a tool that is not registered; and reports a tool error instead of hiding it.
+</Callout>
 
 ## Further reading
 

--- a/src/content/chapters/00c-first-agent.mdx
+++ b/src/content/chapters/00c-first-agent.mdx
@@ -405,6 +405,26 @@ In production, replace `print` with structured logging -- but `print` beats noth
 
 This is 10% of production hardening. Chapter 6 gives you the other 90%: evaluation suites, cost tracking, retry policies, circuit breakers, structured observability. These three guardrails are the ones you add on day one.
 
+### Guardrail 4: Survive duplicate and slow calls
+
+The loop sometimes calls the same tool twice after an unclear result -- a truncated response or a timeout reads to the model like nothing happened, so it tries again. A tool can also hang: no exception, no result, just silence. Two more guardrails cover both.
+
+First, a timeout budget per call. Give every tool call a deadline; if it doesn't return in time, the loop treats it as a failed step instead of waiting on it forever.
+
+Second, an idempotency key. Before running a tool, check whether this exact call already ran, keyed on the user, the tool name, and its normalized arguments:
+
+```python
+key = (user_id, tool_name, normalized_args)
+if key in already_done:
+    return already_done[key]   # do not send the email twice
+```
+
+A repeat lookup returns the prior result instead of repeating the side effect. For `search`, a duplicate call is harmless. For `send_email` or `charge_card`, it's the difference between one email and three.
+
+The third rule isn't code, it's policy: if a repeat looks risky and no cached result exists to return, confirm before running it again instead of guessing.
+
+Read-only tools can retry freely; side-effecting tools cannot. Section 0f goes deeper on execution safety.
+
 ## The stop condition and the gate
 
 The loop stops in exactly one place: `if response.content:`, when the model returns text instead of a tool call. Nobody verifies the answer or asks permission -- it stops because the model said it's done, and none of this chapter's guardrails touch that decision. `max_steps` bounds how long it runs, validation bounds what comes in, logging tells you what happened after the fact. Nothing checks whether the model was right to stop or right to act, in the moment it mattered.
@@ -436,6 +456,10 @@ This is the agent you compare against every framework you evaluate. In Section 0
 You just built an agent. It works. It also breaks in predictable ways. Guardrails and a gate help, but you still made judgment calls on gut feel: how big the budget, when to stop searching, whether this task needed an agent at all. Fine solo; it doesn't scale to a team building agent systems on a shared codebase. Chapter 1 gives you the vocabulary to make these calls explicit -- five system types, from single LLM calls through multi-agent orchestrations, and a decision framework for when a task needs the loop you just built versus a deterministic workflow. The rest of the book gives you the engineering to build whichever one you pick, for production.
 
 For an expanded version with more tools, proper error handling, and example queries, see the [Research Agent](/projects/research-agent/) project.
+
+<Callout type="tip" label="How you know this worked">
+Test that the loop: stops within its step budget; does not repeat the same action forever; handles a tool failure without crashing; and produces a trace you can read afterward.
+</Callout>
 
 ## Further reading
 

--- a/src/content/chapters/00d-frameworks.mdx
+++ b/src/content/chapters/00d-frameworks.mdx
@@ -38,6 +38,20 @@ The tool logic (the actual `calculator`, `search`, `word_count` functions) stays
 
 With that in mind, let's see how two frameworks handle the same agent.
 
+## What frameworks hide that you must re-expose
+
+Automation is the point, but production debugging needs the things the framework does by default.
+
+| What you lose sight of | Why you need it back |
+|------------------------|----------------------|
+| The exact tool schema sent to the model | tool-selection bugs live here |
+| Retry count and backoff | to tell a flake from a real failure |
+| The hidden system prompt | it shapes every answer |
+| Per-step token usage | cost and context budgeting |
+| Tool latency | to find the slow step |
+| The final stop reason | to know why the loop ended |
+| A raw trace export | to replay and evaluate the run |
+
 ## Google ADK: the primary walkthrough
 
 Google's [Agent Development Kit](https://google.github.io/adk-docs/) is opinionated about the things that matter in production: tracing, evaluation, and tool registration. It gives you a structured way to define agents and tools, and it stays out of your way on the rest. Let's rebuild the research agent.

--- a/src/content/chapters/00e-connecting-to-mcp.mdx
+++ b/src/content/chapters/00e-connecting-to-mcp.mdx
@@ -286,6 +286,15 @@ MCP standardizes how agents discover and call tools. It does not solve:
 
 These gaps matter in production. Chapter 13 of the book covers how to address them with governance, access control, and the identity layer (AIP).
 
+MCP solves tool interoperability. It does not solve tool authority. The path-traversal risk from earlier in this chapter is one instance of a wider category: the [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html) documents tool poisoning, prompt injection through tool descriptions or return values, supply-chain risk from unreviewed registry packages, data exfiltration through ordinary-looking tool calls, and cross-system privilege escalation.
+
+Before you connect an MCP server, ask:
+
+- Who maintains it, and where does it run?
+- What files, network, and credentials does it receive?
+- What tools does it expose, and can their descriptions steer the model?
+- Are its calls logged, and can they be policy-checked before they execute?
+
 ## What to build next
 
 You now have the building blocks:
@@ -296,6 +305,10 @@ You now have the building blocks:
 - **Section 0e**: Connecting to tools via MCP
 
 From here, the book takes you into the engineering decisions that determine whether your agent survives production: when to use an agent versus a workflow (Chapter 3), how to evaluate and harden it (Chapter 6), when not to use an agent at all (Chapter 7), and how to govern, secure, and scale it (Chapters 10-13).
+
+<Callout type="tip" label="How you know this worked">
+Test that your MCP integration: discovers only the tools you approved; rejects unsafe paths and arguments; does not leak secrets in tool results; and logs every invocation.
+</Callout>
 
 ## Further reading
 

--- a/src/content/chapters/00f-the-production-boundary.mdx
+++ b/src/content/chapters/00f-the-production-boundary.mdx
@@ -11,8 +11,6 @@ patterns: []
 status: published
 ---
 
-import Callout from '~/components/universal/Callout.astro';
-
 A chatbot that gets something wrong is annoying. An agent that gets something wrong has already sent the email, deleted the record, or booked the flight.
 
 Sections 0a through 0e taught you how an agent works: messages, tokens, tool calls, the loop, frameworks, MCP. Every tool call in that story, going back to 0b, looked like a JSON object: a name and some arguments. It is not just data. It is a request to exercise power over something outside the model.

--- a/src/content/chapters/00f-the-production-boundary.mdx
+++ b/src/content/chapters/00f-the-production-boundary.mdx
@@ -1,0 +1,159 @@
+---
+title: The Production Boundary
+part: foundations
+description: "An LLM gets dangerous not when it speaks but when it acts. What every tool call really asks for, and the boundary that turns an agent into a system component you can trust."
+readingTime: 20
+date: 2026-07-05
+references:
+  - 00e-connecting-to-mcp
+cites: []
+patterns: []
+status: published
+---
+
+import Callout from '~/components/universal/Callout.astro';
+
+A chatbot that gets something wrong is annoying. An agent that gets something wrong has already sent the email, deleted the record, or booked the flight.
+
+Sections 0a through 0e taught you how an agent works: messages, tokens, tool calls, the loop, frameworks, MCP. Every tool call in that story, going back to 0b, looked like a JSON object: a name and some arguments. It is not just data. It is a request to exercise power over something outside the model.
+
+This chapter is about what changes the moment that request is granted. It is not the mechanics of building a tool call, Section 0b already covered that. And it is not any single production concern done in depth, chapters 5, 6, 10, 11, 12, and 13 each own one of those. This is the mental model that sits between them: what a tool call actually asks for, what has to be true before you let it run, and the shape of what can still go wrong once you do. A set of checks you carry into the next tool you wire up, not a rehearsal of chapters still to come.
+
+## Tools are capabilities
+
+Every tool schema from Section 0b has the same shape: a name, a description, a JSON object of arguments. Nothing in that shape tells you how dangerous the tool is. `search_docs` and `delete_record` look identical to a schema validator. The difference isn't in the JSON. It's in what happens on the other side of the call.
+
+| Tool type | Example | Risk |
+|-----------|---------|------|
+| Read-only | search docs, check weather | low |
+| Internal read | read a customer profile, search internal email | privacy |
+| Internal write | create a ticket, update a record | business |
+| External side effect | send an email, call a partner API, book a meeting | reputation |
+| Privileged | deploy, approve a payment, delete a record | high |
+
+The same agent loop from 0c is safe wired to the top row and dangerous wired to the bottom, and the code you've written so far treats every tool identically: validate the schema, execute, return the result. That's the gap this chapter closes.
+
+## Five questions before every tool call
+
+A tool call that passes schema validation has cleared exactly one bar. Before you let it run, five separate questions need an answer:
+
+1. Can the agent call this tool at all?
+2. Can it call it for this user?
+3. Can it call it on this resource?
+4. Can it call it with these arguments?
+5. Should a human approve first?
+
+Five questions, one shape: actor, action, resource, scope, approval. Every access-control system you'll ever wire into an agent is some arrangement of those five fields.
+
+```python
+def before_tool_call(actor, tool, resource, args):
+    # Schema validation already passed (chapter 00b). That is not enough.
+    if not policy.allowed(actor, tool.name, resource, args):
+        return ToolResult(error=f"{actor} may not call {tool.name} on {resource}")
+    if tool.risk == "privileged":
+        approval = require_human_approval(actor, tool, resource, args)
+        if not approval.granted:
+            return ToolResult(error="awaiting human approval")
+    return None  # authorized: proceed to execute
+```
+
+A valid tool call, one that passed 00b's schema check, can still be forbidden. Validation is not authorization.
+
+Chapter 10 builds the policy engine `policy.allowed` stands in for here. Chapter 5 covers the human-approval step in depth: where it fits in the loop and how to design it so it isn't just a rubber stamp.
+
+## A message list is not memory
+
+The message array from Section 0c, the one `messages.append()` grows every turn, looks like memory because it persists across the run. It isn't the same thing, and treating it as such is one of the more expensive mistakes in early agent systems. A production agent is carrying at least seven distinct kinds of state, and a message list is only one of them:
+
+| State | What it is |
+|-------|-----------|
+| Prompt state | what is in the current request |
+| Conversation state | prior messages replayed into context |
+| Scratchpad state | intermediate reasoning or notes |
+| Tool state | results returned from an API or database |
+| Durable state | persisted memory, records, workflow state |
+| User-visible state | what the user can inspect |
+| Hidden system state | policies, secrets, credentials, internal traces |
+
+A message list is not memory. A vector database is not memory either, it's a retrieval mechanism sitting in front of some other store. Durable state, the record that survives after the conversation and the process both end, is a product decision made deliberately. It is not a side effect of using an LLM with a big context window. Chapter 12 goes deep on how to design and govern it.
+
+## Agents must survive duplicate actions
+
+An agent repeats a tool call for reasons that have nothing to do with malice: the first result was ambiguous, so it tries again. A network call times out and retry logic fires. A user double-taps a button that maps to the same request twice. None of this is unusual, it's the default behavior of any distributed system, and an agent calling external tools is a distributed system with an LLM making the retry decisions. A calculator tolerates being called twice with identical input. `send_email`, `charge_card`, and `delete_record` do not.
+
+| Concept | Why it matters |
+|---------|----------------|
+| Timeout budget | a slow tool must not hang the whole loop |
+| Retry | transient failures are normal |
+| Idempotency key | a repeated call must not repeat the side effect |
+| Cancellation | the user may stop the task |
+| Compensation | a partial side effect may need undoing |
+| Dry run | show the intended action before doing it |
+
+```python
+def call_tool_once(tool, args, *, user_id):
+    key = idempotency_key(user_id, tool.name, normalize(args))
+    cached = results_store.get(key)
+    if cached is not None:
+        return cached  # repeated call, do not repeat the side effect
+    result = run_with_timeout(tool, args, seconds=tool.timeout_budget)
+    if tool.side_effecting:
+        results_store.put(key, result)
+    return result
+```
+
+## If you cannot replay it, it is a demo
+
+Every failure mode in this chapter eventually reaches someone asking what actually happened. Answering that needs more than server logs or a print statement. It needs a trace: a structured record of the run.
+
+```json
+{
+  "run_id": "run_123", "user_id": "u_456", "agent": "support_agent",
+  "model": "the model under test", "input": "the user request",
+  "tool_calls": [
+    {"tool": "search_docs", "arguments": {"q": "refund policy"},
+     "authorized": true, "latency_ms": 280, "result_summary": "3 documents"}
+  ],
+  "final_answer": "the response returned to the user",
+  "cost": {"input_tokens": 4210, "output_tokens": 780},
+  "stop_reason": "completed"
+}
+```
+
+If you cannot replay, inspect, and evaluate a run from its trace, you do not have a production agent. You have a demo that happened to work the last time someone was watching. This is the same trace shape Chapter 6's evaluation suites score, field for field.
+
+## A failure taxonomy
+
+Ten kinds of failure, not one. Knowing which one you're looking at determines the fix, which is why this table is worth returning to any time an agent misbehaves in a way you haven't diagnosed before:
+
+| Failure | Example | Mitigation |
+|---------|---------|-----------|
+| Model | hallucinated answer | grounding, evals |
+| Format | invalid JSON from the model | schema validation, retry |
+| Tool selection | wrong tool chosen | better tool descriptions, evals |
+| Tool execution | API timeout or error | timeout, retry, fallback |
+| Authorization | agent attempts a forbidden action | policy gate |
+| State | stale context drives a wrong step | state refresh |
+| Memory | a wrong remembered fact | memory governance |
+| Loop | repeats the same step | step budget, repetition detection |
+| Security | prompt injection via tool output | input isolation, tool policy |
+| Product | user cannot trust the result | trace, explanation, handoff |
+
+Model and format failures are 0a and 0b's territory, tool selection and execution are 0c's. The rest, authorization, state, memory, loop, security, product, are what the sections above named and what chapters 5 through 13 build the real defenses for.
+
+## How you know the boundary holds
+
+Every claim made above, that a tool call was authorized, that a retry was idempotent, that a trace is complete, is testable, and none of it is verified by code review alone. Four layers of evaluation catch what review misses:
+
+- **Unit tests for tools.** Does the tool do what its schema promises, on valid input and on the edge cases.
+- **Scenario tests for loops.** Does the full agent, run end to end on a realistic task, make the right sequence of calls and land on the right answer.
+- **Regression tests for prompts.** Does a change to the system prompt or the model version break a case that used to pass.
+- **Adversarial tests for injection.** Does the agent hold its authorization boundary when a tool result tries to talk it into something else.
+
+This is the same eval habit flagged by the eval callouts placed throughout the rest of the book's chapters. Chapter 6 builds the harness that runs all four layers against a real agent, with the metrics that tell you whether a change made things better or worse.
+
+## Where this goes
+
+Six chapters build out pieces of this boundary in depth. Chapter 5 covers human-in-the-loop as architecture: where approval fits in the loop and how to keep it from becoming theater. Chapter 6 builds the evaluation and hardening harness that scores the trace from the section above. Chapter 10 covers governance and auditability: the policy engine behind `before_tool_call`, and what an audit needs beyond a log line. Chapter 11 is the security deep dive: prompt injection through tool output, the confused-deputy problem, and what changes when the tool itself is compromised, not just the model. Chapter 12 covers memory management: designing the durable-state row from the state section as an actual product decision instead of an accident of context-window size. Chapter 13 covers agent protocols in production, including what a protocol like MCP leaves unsolved: who is calling, on whose authority, and how you prove it after the fact.
+
+That last question, who is allowed to act and how you prove it after the fact, is the subject of the author's ongoing work on agent identity and authorization, including the piece "Who Authorized That?", and readers who want to follow it further can start at [sunilprakash.com/writing](https://sunilprakash.com/writing/).

--- a/src/pages/book/index.astro
+++ b/src/pages/book/index.astro
@@ -12,7 +12,7 @@ const parts = [
   {
     id: 'foundations',
     label: 'Foundations',
-    description: 'Five hands-on sections that take you from zero to building your first agent and connecting it to tools via MCP.',
+    description: 'Six hands-on sections that take you from zero to building your first agent, connecting it to tools via MCP, and drawing the line around what it can safely do.',
     filter: (id: string) => id.startsWith('00'),
   },
   {
@@ -49,7 +49,7 @@ function chapterPrefix(slug: string): string {
 
 <PageLayout
   title="The Book — Agent Engineering Lab"
-  description="A field guide to building reliable, evaluable, production-grade agent systems. 5 Foundations + 13 chapters across 4 parts."
+  description="A field guide to building reliable, evaluable, production-grade agent systems. 6 Foundations + 13 chapters across 4 parts."
   currentNav="Book"
 >
   <Container>


### PR DESCRIPTION
## Foundations: The Production Boundary

Adds the production-boundary layer a reviewer flagged as the gap in the foundation chapters. The foundations taught how agents work (model, tokens, tool calls, loop, framework, MCP) but deferred authority, state, execution safety, trace, and eval entirely to later chapters. This closes that gap at foundation altitude.

### New chapter: 00F — The Production Boundary

A synthesis chapter that introduces the mental model and reusable checks, then points to the deep chapters instead of duplicating them:

- Tools are capabilities (read-only through privileged)
- The five questions before every tool call (validation is not authorization)
- A message list is not memory (the state taxonomy)
- Agents must survive duplicate actions (timeout, retry, idempotency, compensation)
- If you cannot replay it, it is a demo (trace anatomy)
- A failure taxonomy (a reference table)
- How you know the boundary holds (unit / scenario / regression / adversarial eval)
- Forward-pointers to ch05/06/10/11/12/13, plus one pointer to the AIP work

### Cross-cutting edits to 00a-00e

- **00a:** provider-difference box (the neutral client is useful, but provider behavior leaks) + eval close
- **00b:** "Validation is not authorization" + eval close
- **00c:** a Guardrail 4 on idempotency, timeouts, and duplicate calls + eval close
- **00d:** a "what frameworks hide that you must re-expose" table
- **00e:** an MCP registry-trust checklist, "MCP solves interoperability, not authority", and the MCP attack-surface categories attributed to the OWASP MCP Security Cheat Sheet

Each chapter that has one carries the same `How you know this worked` eval close, so eval reads as a habit from the first chapter.

### Notes

- Every external fact was verified against a primary source before it went in; 00F is pure synthesis (no new external claims).
- Voice is plain, no em dashes; all changes are additive (existing prose untouched).
- Nav registered (6 Foundations), `pnpm build` clean (68 pages), 00F emits at `/book/00f-the-production-boundary/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new chapter covering the production boundary for agent tool use, including access checks, idempotency, traceability, failure types, and evaluation layers.
  * Expanded the chapter map and book index to reflect 19 chapters and 6 Foundations sections.

* **Documentation**
  * Clarified how LLM and tool behavior can vary in practice, including validation, safety checks, retries, and handling duplicates.
  * Added guidance and validation tips for MCP connections, framework visibility, and agent behavior testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->