### PR TITLE
Add Architecture pillar: blueprint reference section

### DIFF
--- a/src/components/universal/SectionAnchors.astro
+++ b/src/components/universal/SectionAnchors.astro
@@ -10,13 +10,15 @@ interface Section {
 
 interface Props {
   items: Section[];
+  /** Heading for the bar. Defaults to the Lab Report wording. */
+  label?: string;
 }
 
-const { items } = Astro.props;
+const { items, label = 'In this Lab' } = Astro.props;
 ---
 
 <nav class="section-anchors" aria-label="In-page navigation">
-  <div class="section-anchors__label">In this Lab</div>
+  <div class="section-anchors__label">{label}</div>
   <ul class="section-anchors__list">
     {items.map((s) => (
       <li>

--- a/src/components/universal/TopNav.astro
+++ b/src/components/universal/TopNav.astro
@@ -1,6 +1,6 @@
 ---
 /**
- * TopNav — 6-item primary navigation.
+ * TopNav — primary navigation.
  * Sticky on scroll. Highlights current section.
  */
 import Brand from './Brand.astro';
@@ -14,6 +14,7 @@ const { current = '' } = Astro.props;
 const items = [
   { href: '/start/', label: 'Start' },
   { href: '/book/', label: 'Book' },
+  { href: '/architecture/', label: 'Architecture' },
   { href: '/labs/', label: 'Labs' },
   { href: '/field-notes/', label: 'Field Notes' },
   { href: '/signal/', label: 'Signal' },

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -164,4 +164,38 @@ const patterns = defineCollection({
   }),
 });
 
-export const collections = { chapters, fieldNotes, recipes, signal, projects, evidence, labs, patterns };
+const architecture = defineCollection({
+  loader: glob({ pattern: '**/*.mdx', base: './src/content/architecture' }),
+  schema: z.object({
+    id: z.string(),                 // arch-001
+    title: z.string(),
+    dek: z.string(),
+    description: z.string(),
+    // The three-layer spine of the section.
+    layer: z.enum(['capability', 'control', 'evidence']),
+    order: z.number(),              // sequence position; the section reads in order, not by date
+    readingTime: z.number(),
+    updated: z.coerce.date(),       // blueprints are revised, not published once
+    specifies: z.string(),          // one line: what this blueprint pins down
+    appliesTo: z.array(z.string()), // RAG platform, coding assistant, agent system, ...
+    decisions: z.array(z.string()).optional(),          // decisions this blueprint forces
+    anchors: z.array(z.object({                          // in-page nav
+      label: z.string(),
+      anchor: z.string(),
+    })).optional(),
+    spot: z.string().optional(),
+    spotCaption: z.string().optional(),
+    references: z.array(z.string()).optional(),
+    cites: z.array(z.string()).optional(),
+    patterns: z.array(z.string()).optional(),
+    sources: z.array(z.object({
+      title: z.string(),
+      url: z.string().url(),
+      authors: z.array(z.string()).optional(),
+      year: z.number().optional(),
+    })).optional(),
+    status: z.enum(['draft', 'published']).default('published'),
+  }),
+});
+
+export const collections = { chapters, fieldNotes, recipes, signal, projects, evidence, labs, patterns, architecture };

--- a/src/content/architecture/001-the-control-plane.mdx
+++ b/src/content/architecture/001-the-control-plane.mdx
@@ -1,0 +1,182 @@
+---
+id: arch-001
+title: The Control Plane
+dek: A single-pass AI request has six places where a control can sit, and each one can see a different amount of the truth. Placement sets the accuracy ceiling before you pick a single model.
+description: "The six chokepoints in an enterprise AI request path, what each one can and cannot observe, and why placing a detector at the wrong chokepoint caps its accuracy no matter how good the classifier is."
+layer: control
+order: 1
+readingTime: 12
+updated: 2026-08-18
+specifies: The chokepoints in an AI request path and the observability each one has
+appliesTo: [RAG platform, Coding assistant, Agent system]
+decisions:
+  - Which chokepoints you instrument, and which you accept as blind
+  - Whether a control blocks information harm or action harm
+  - Where the latency budget for detection is spent
+anchors:
+  - label: The request path
+    anchor: the-request-path
+  - label: Six chokepoints
+    anchor: six-chokepoints
+  - label: What each one can see
+    anchor: what-each-chokepoint-can-see
+  - label: Information harm and action harm
+    anchor: information-harm-and-action-harm
+  - label: The coverage table
+    anchor: the-coverage-table
+  - label: Where it breaks
+    anchor: where-this-blueprint-stops-working
+references: [ch-11, ch-06]
+patterns: [approval-gate, tool-registry]
+sources:
+  - title: "OWASP Top 10 for LLM Applications 2025"
+    url: https://genai.owasp.org/llm-top-10/
+    year: 2025
+  - title: "The Lethal Trifecta for AI agents"
+    url: https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/
+    authors: [Willison S.]
+    year: 2025
+---
+
+import Callout from '~/components/universal/Callout.astro';
+import PullQuote from '~/components/universal/PullQuote.astro';
+import Footer3Col from '~/components/universal/Footer3Col.astro';
+
+Ask an engineering team where their AI guardrails live and you will usually get one answer: in front of the model. A classifier reads the user's prompt, decides whether it looks like an attack, and passes it through or blocks it. Some teams add a second pass on the way out.
+
+That design has a ceiling, and the ceiling has nothing to do with the quality of the classifier. A prompt-layer detector cannot see the document that the retriever is about to fetch. If the attack arrives inside that document, the detector is being asked to classify text that does not contain the attack. No amount of fine-tuning fixes an input that is missing the evidence.
+
+This is the first thing to get right, and it is an architecture decision rather than a model decision. Before you choose detectors, you choose where they sit. Placement determines what each detector can observe, and observability sets the accuracy ceiling.
+
+## The request path
+
+Strip an enterprise AI system down to the path a single request takes. Whether the product is a RAG assistant, a coding copilot, or a multi-step agent, the same stages appear:
+
+```
+  ingest              a document enters the corpus
+    |
+  retrieve            the system selects context for this request
+    |
+  assemble            system prompt + context + input become one payload
+    |
+  infer               the model produces tokens
+    |
+  act                 the model's output triggers a tool call
+    |
+  respond             text reaches the user
+    |
+  record              the exchange is written down
+```
+
+Two of these stages are commonly missed in threat modelling. `ingest` happens long before the request, sometimes months before, and the person who uploaded the document is not the person now being attacked by it. `act` happens after the model has already decided, and it is the only stage where the system touches something outside itself.
+
+## Six chokepoints
+
+A chokepoint is a stage where the request is fully materialised and execution can be suspended. Take a single pass through the path above and there are six. Memory reads and writes, model-provider egress, and agent-to-agent messages are deliberately not separate entries: each one resolves to a tool execution, a retrieval, or a nested request path with its own six, which is the case the last section returns to.
+
+```
+ 1  UPLOAD          document enters the corpus
+ 2  RETRIEVAL       context is selected for this request
+ 3  PROMPT          the assembled payload, before inference
+ 4  RESPONSE        model output, before it is used
+ 5  TOOL EXECUTION  a requested action, before it happens
+ 6  LOGGING         what gets written down, and who can read it
+```
+
+Everything in the control layer is a choice about which of these you instrument, what you put there, and what you do when it fires. A system with controls only at 3 and 4 is a common starting configuration, and it is the one that leaves both retrieval-borne injection and tool-mediated harm uninstrumented.
+
+<Callout type="tip" label="The placement test">
+For any control you are about to build, ask: is the evidence this detector needs actually present in the input it receives at this chokepoint? If the answer is no, you are not building a detector. You are building a source of false confidence.
+</Callout>
+
+## What each chokepoint can see
+
+This is the part that decides your architecture. Each chokepoint has a different view of the truth, and the differences are not subtle.
+
+**Upload** sees the full document, unhurried. This is the only chokepoint with no latency pressure, because ingestion is asynchronous. It is therefore the correct home for anything expensive: full-document classification, entity extraction across the whole text, structural analysis, a slow model. What it cannot see is who will eventually retrieve this document, or in what context. A document that is harmless for the team that uploaded it may be a leak the moment it is retrievable by another business unit.
+
+**Retrieval** sees which chunks were selected and, critically, the requester's identity. This is the only chokepoint that can answer "is this person allowed to see this content", because it is the only one that has both the content and the principal at the same time. It is also where injected instructions inside a retrieved document first become visible to the system. In systems whose controls sit only at the prompt and response layers, this is the largest uninstrumented surface.
+
+**Prompt** sees the assembled payload: system prompt, retrieved context, conversation history, and the user's input, concatenated. It sees everything, and unless you have deliberately preserved structure it can distinguish nothing. Provenance survives only if the assembly step records it. The detector cannot otherwise tell whether "ignore prior instructions" arrived from the user, from a retrieved PDF, or from a previous turn, unless you deliberately preserve that structure. Most frameworks flatten it.
+
+<PullQuote>By the prompt layer, everything is visible and nothing is attributable. That trade is the reason prompt-layer detection underperforms its benchmarks in production.</PullQuote>
+
+**Response** sees what the model produced. It can catch leaked system prompts, PII in output, unsafe content, and claims that contradict the retrieved context. It cannot see intent, and it cannot undo anything, because in a tool-calling system the action has often already been requested by the time text is being generated.
+
+**Tool execution** sees the concrete action: the function, the arguments, the target, and the identity under which it will run. This is the only chokepoint that can prevent an irreversible act, and the only one where the decision is about a specific operation on a specific resource rather than about text. That makes the decision auditable rather than infallible: it is only as good as the identity, the resource metadata, and the policy behind it, and stale identity or mislabelled resources will produce a confident wrong answer here as readily as anywhere else.
+
+**Logging** sees the whole exchange after the fact. It cannot prevent anything. It is what makes everything else auditable, and it is itself a leak surface, because prompts and responses in a log are the same sensitive data that the other five chokepoints were defending.
+
+## Information harm and action harm
+
+Split the harms you are defending against into two families, because the chokepoints that address them are different.
+
+**Information harm** is data reaching someone who should not have it. Leaked PII, a disclosed system prompt, a retrieved document outside the requester's entitlement, sensitive content in a log. These harms happen at the moment information moves, so they are addressable at upload, retrieval, response, and logging.
+
+**Action harm** is the system doing something in the world that should not have happened. A row deleted, a payment issued, a ticket closed, a pull request merged. Tool execution is the only chokepoint that can prevent these, because it is the only one that sees the act before it happens.
+
+Tool execution belongs to both families, and this is the case worth stating plainly rather than tidying away. A tool call is also an egress path: an email send, an outbound webhook, a search query, a write to a shared document all move information out of the system. Willison's lethal trifecta names this directly, and it is why treating tool execution as purely an action control leaves the exfiltration route uninstrumented.
+
+```
+ information harm  -->  upload, retrieval, response, logging,
+                        and tool execution (egress)
+ action harm       -->  tool execution  (only)
+```
+
+Text-in-text-out classification is the tractable, sellable shape for a guardrail product, and the commercial guardrail category reflects that. As a system moves from answering questions to taking actions, more of its risk lands on the one chokepoint that text classification cannot reach.
+
+If your roadmap says the assistant will start taking actions next quarter, and your guardrail budget is entirely allocated to prompt and response filtering, you have a stated plan to be undefended against the harm class that will matter.
+
+## The coverage table
+
+Mapping the OWASP Top 10 for LLM Applications 2025 onto the chokepoints turns an abstract risk list into a placement argument. All ten entries are listed, because the ones that do not resolve to a request-path chokepoint are as informative as the ones that do.
+
+| Risk | Best chokepoint | Why not the prompt layer |
+|---|---|---|
+| LLM01 Prompt Injection | Retrieval, then prompt | Injected text usually arrives inside retrieved content, which the prompt layer sees but cannot attribute |
+| LLM02 Sensitive Information Disclosure | Upload and retrieval for input, response and tool execution for output | Entitlement is only knowable where content and principal meet; egress includes tool calls |
+| LLM05 Improper Output Handling | Response and tool execution | The harm is in what the output is used for, not what it says |
+| LLM06 Excessive Agency | Tool execution | Nothing in the text tells you whether this actor may perform this act |
+| LLM07 System Prompt Leakage | Response | The only stage where the leak is observable |
+| LLM08 Vector and Embedding Weaknesses | Upload and retrieval | Invisible downstream; by the prompt layer the poisoned chunk looks like context |
+| LLM10 Unbounded Consumption | Tool execution and the loop governor | A budget is a runtime property, not a text property |
+| LLM03 Supply Chain | Outside the request path | A build-time and procurement control; no runtime chokepoint sees it |
+| LLM04 Data and Model Poisoning | Upload, and outside the path for model weights | Corpus poisoning is an upload control; weight poisoning is a supply-chain problem |
+| LLM09 Misinformation | Response, weakly | Grounding against retrieved context is checkable; general truth is not |
+
+Three of those ten have no runtime chokepoint at all, which is worth saying out loud in a design review: a control plane does not address supply chain or model poisoning, and anyone presenting one as complete coverage of the OWASP list is overselling it. Separately, content safety and harmful content do not appear in the OWASP list at all. That list is a security taxonomy; content safety is a trust and safety concern with a different owner, a different review workflow, and usually a different regulator. Keep them as separate detector families with separate thresholds. Merging them produces a single opaque "safety score" that no reviewer can act on.
+
+## What good placement looks like
+
+A defensible default for an enterprise RAG system, ordered by value per unit of effort:
+
+1. **Retrieval-layer entitlement check.** Filter candidate chunks against the requester's permissions before they reach the payload. This is access control, not machine learning, and it eliminates a whole class of disclosure incidents deterministically.
+2. **Tool-execution policy.** Every tool call passes a policy decision that knows the actor, the action, and the resource. Deterministic, auditable, and the only defence against action harm.
+3. **Upload-time classification.** Expensive detectors run here, once per document, off the request path. Label sensitivity, extract entities, flag instruction-like content in documents that should contain none.
+4. **Response-layer output checks.** System prompt leakage, PII in output, grounding against retrieved context.
+5. **Prompt-layer detection.** Useful, cheap, and the weakest of the five for the reasons above. Worth having. Not worth being your only control.
+6. **Logging controls.** Redaction and access control on the audit trail itself.
+
+Notice that the two highest-value items are not detectors. They are policy decisions with deterministic answers. Work that gets handed to a classifier is often an authorization question in disguise. Authorization fails differently: it does not have a false positive rate in the statistical sense, but it does fail through stale entitlements, mislabelled resources, and policy that no longer matches the org chart. Those failures are findable and fixable, which a classifier's error surface is not.
+
+<Callout type="warn" label="The order this list is usually built in">
+The reverse order is the tempting one: prompt filtering first because it is the easiest to demo, then response filtering, then the rest "when we have time". That order front-loads the weakest control and defers the two deterministic ones, which is how a system ends up well defended against the attacks in the tutorial and undefended against the ones in the incident report.
+</Callout>
+
+## Where this blueprint stops working
+
+Three honest limits.
+
+**The chokepoint model assumes a request path.** Batch pipelines, streaming ingestion, and background agents that run on a schedule do not have a clean request boundary, and the "principal" in whose name the work happens is often a service account with no meaningful entitlement. Those systems need the authority question answered at design time instead, because there is no runtime moment where a user's permissions are available to check against.
+
+**Six chokepoints is a simplification of multi-agent systems.** When one agent calls another, the second agent has its own full path, and the calling agent's output is the called agent's input. The chokepoints nest. A single-pass mental model will miss the case where agent A is authorized for an action, agent B is not, and B accomplishes it by asking A. That is the delegation problem, and it needs identity that survives the hop rather than a detector.
+
+**Placement improves the ceiling, not the floor.** Putting a detector at the right chokepoint means the evidence is present in its input. It does not mean the detector is any good. That is a measurement question, and measurement is where most guardrail programmes actually fail.
+
+<Footer3Col
+  fromBook={[
+    { label: "Ch 6: Evaluating and Hardening Agents", href: "/book/06-evaluating-and-hardening/" },
+    { label: "Ch 11: Security Deep Dive", href: "/book/11-security/" },
+  ]}
+  readNext={{ label: "ARCH-002: Detector Architecture", href: "/architecture/002-detector-architecture/" }}
+/>

--- a/src/content/architecture/002-detector-architecture.mdx
+++ b/src/content/architecture/002-detector-architecture.mdx
@@ -1,0 +1,180 @@
+---
+id: arch-002
+title: Detector Architecture
+dek: Four detection techniques, a sourcing decision people mistake for a fifth, one interface contract, and the calibration problem that breaks every ensemble built by averaging scores that do not mean the same thing.
+description: "The four detection techniques behind production AI safety detectors, why a managed safety service is a sourcing choice rather than a technique, a common interface contract that separates decisions from execution failures, and why scores from a regex, a classifier, and an LLM judge cannot be combined without per-detector calibration."
+layer: control
+order: 2
+readingTime: 13
+updated: 2026-08-18
+specifies: The detector interface contract and the composition rules for combining detectors
+appliesTo: [RAG platform, Coding assistant, Agent system]
+decisions:
+  - Which technique answers which question, and which to run yourself
+  - Whether the ensemble combines scores or verdicts
+  - What a detector is allowed to do when it times out
+anchors:
+  - label: Techniques and sourcing
+    anchor: four-techniques-two-sourcing-models
+  - label: The interface
+    anchor: the-interface-contract
+  - label: The calibration trap
+    anchor: the-calibration-trap
+  - label: Composing detectors
+    anchor: composing-detectors
+  - label: Failure behaviour
+    anchor: failure-behaviour
+  - label: Where it breaks
+    anchor: where-this-blueprint-stops-working
+references: [ch-06, ch-11]
+patterns: [verifier-loop, failure-buckets]
+sources:
+  - title: "OWASP Top 10 for LLM Applications 2025"
+    url: https://genai.owasp.org/llm-top-10/
+    year: 2025
+---
+
+import Callout from '~/components/universal/Callout.astro';
+import PullQuote from '~/components/universal/PullQuote.astro';
+import Footer3Col from '~/components/universal/Footer3Col.astro';
+
+A detector answers one question about one input and returns a verdict. That is the whole job. The engineering difficulty is not writing detectors, it is making a dozen of them, built with different techniques and sourced in different ways, behave like one coherent system that a policy layer can reason about and an operator can tune.
+
+This blueprint fixes the interface and the composition rules. [ARCH-001](/architecture/001-the-control-plane/) decided where detectors sit; this one decides what they are.
+
+## Four techniques, two sourcing models
+
+Detectors vary on two independent axes, and collapsing them into one list is a mistake that shows up later as a procurement argument. The first axis is **technique**: how the judgement is made. The second is **sourcing**: whether you run it or someone else does. A managed safety service is not a fifth technique, it is one of the four techniques with the sourcing decision already taken for you, and usually without telling you which technique it is.
+
+Four techniques, each with a distinct cost profile and a distinct failure mode.
+
+**Rules and pattern matching.** Regular expressions, keyword lists, structural checks. Negligible latency, negligible marginal cost, fully explainable, and evadable by anyone who knows the pattern exists. Correct for structured data with a defined format: account numbers, national identifiers, card numbers, API keys, base64 blobs where none should be. Wrong for anything expressed in natural language, because natural language has unbounded surface forms and your pattern list does not.
+
+**Classical NLP.** Named entity recognition, part-of-speech analysis, similarity to a known corpus. Fast and cheap relative to a model call, and it generalises across surface forms in a way regex cannot. This is the right tool for unstructured personal data: names, addresses, employers, dates of birth. Its weakness is context. An NER model will find a person's name; it will not tell you whether that name appearing in this document, retrieved by this user, is a disclosure.
+
+**Trained classifiers.** A small supervised model fine-tuned on labelled examples of the thing you are detecting. Cheap at inference, and the technique whose improvement path is most direct, because the labelled set you needed to build it is the same one you tune against. Every technique here can be measured against labelled data; this is the one that cannot exist without it. Its weakness is that you need that labelled data, it decays as attacks shift, and it will confidently misclassify anything unlike its training distribution.
+
+**LLM-as-judge.** A model prompted to evaluate the input against a written policy. The slowest and most expensive per call, and the most flexible in one specific sense: you can express a nuanced policy in a paragraph and change it without retraining. Three weaknesses that matter. It is non-deterministic, so the same input can produce different verdicts. It is itself susceptible to injection, because you are feeding attacker-controlled text to a model and asking it a question. And it is expensive enough that you cannot run it on every request at the prompt layer without a latency conversation.
+
+Then the sourcing axis. **Managed safety services** from cloud and model vendors package one or more of the four techniques behind an API: good coverage of the commodity categories, maintained by someone else, and a real reduction in work. The costs are a network hop in the request path, a data-residency question that is not optional in a regulated environment, a model you cannot audit or tune, and a version that can change underneath you. The technique inside is usually undisclosed, which means you inherit its failure mode without being able to name it. Treat a managed service as a technique you did not choose rather than as a category of its own.
+
+<Callout type="tip" label="Matching technique to question">
+Structured and format-defined, use rules. Unstructured entities, use NLP. High volume with labelled data, train a classifier. Nuanced policy that changes often, use a judge. Then decide sourcing separately, on residency, auditability, and whether the category is one you need to differentiate on. The judge is the easiest to prototype and the most expensive to run on every request, so it is worth pricing at the design stage rather than after the first month's bill.
+</Callout>
+
+## The interface contract
+
+Every detector, regardless of family, returns the same shape. This is what lets the policy layer stay uniform and lets you swap a regex for a classifier without touching anything downstream.
+
+```
+DetectorResult
+  detector_id       stable identifier, no version in it
+  detector_version  model or ruleset version, for audit reconstruction
+  threshold_version which threshold produced `band`
+
+  execution_status  ok | error | timeout | skipped
+  decision          clear | flagged | abstain  (null unless status ok)
+
+  score             float 0..1
+  score_kind        raw | calibrated  (raw: this detector only)
+  band              below | near | above  (vs this detector's threshold)
+
+  categories        list of matched risk categories
+  category_schema   version of the category vocabulary
+  evidence          spans or excerpts that triggered the decision
+  latency_ms        observed, always recorded
+  degraded          bool, true if the detector ran in a reduced mode
+```
+
+The shape matters more than the field names. Five decisions are encoded in it.
+
+**`execution_status` and `decision` are separate.** A timeout is not a verdict. Collapsing "it did not flag" and "it did not run" into one enum is how a system silently fails open, because every downstream consumer reads the absence of a flag as safety. Keep them apart and the policy layer is forced to handle the outage case explicitly.
+
+**`decision` includes `abstain`.** A detector that ran successfully and does not have enough signal to answer is telling you something real, and it is a different fact from a clear. Abstention is what lets a cheap detector defer to an expensive one without pretending to a judgement it does not have.
+
+**Version lives in its own fields, and there are three.** A `detector_id` with a version baked into it cannot be tracked across upgrades. The detector, its threshold, and the category vocabulary all change on different cycles, and an incident review three months later needs all three to reconstruct why a given input produced a given result.
+
+**`score_kind` is explicit.** A raw score is meaningful only within one detector. Marking it prevents the next section's failure from happening by accident downstream.
+
+**`band` exists so the policy layer never sees a raw score.** Policies written against raw numbers break every time you retune a threshold. Policies written against bands survive retuning, and the threshold becomes an operational parameter rather than a code change.
+
+`evidence` exists because a verdict without evidence cannot be reviewed. A human deciding whether to override a block needs the span that triggered it, and a false positive analysis with no evidence field is a spreadsheet of numbers that nobody can diagnose.
+
+`degraded` exists because a detector that fell back to a cheaper path did not answer the same question, and pretending otherwise silently changes your risk posture during exactly the incidents where it matters.
+
+## The calibration trap
+
+Here is a failure that is easy to build and hard to see afterwards.
+
+A regex returns confidence 1.0 when it matches, because it either matched or it did not. That number describes the match, not the likelihood that the match was the thing you cared about: a sixteen-digit internal reference will trip a card-number pattern with exactly the same 1.0. A trained classifier returns 0.9 as an approximately calibrated probability. An LLM judge asked to rate severity out of ten returns 9, which is a sampled token and not a probability at all.
+
+Then someone builds an ensemble that averages them, or takes the maximum, or sums them with weights.
+
+<PullQuote>The number 0.9 means three unrelated things depending on which detector emitted it. Averaging them produces a value that means nothing, on a scale nobody can reason about.</PullQuote>
+
+The system that results has a behaviour no one can predict from first principles and no one can tune, because moving the global threshold changes the effective sensitivity of each family by a different and unknown amount. Teams then discover empirically that 0.72 "works" and freeze it, and the number becomes folklore.
+
+Two ways out, and you should pick one deliberately.
+
+**Per-detector calibration.** Map each detector's raw output onto a common scale using held-out labelled data, so that a calibrated 0.9 means the same empirical thing whichever detector emitted it: roughly nine out of ten items scored here are true positives. Two conditions are easy to miss. The calibration set has to match the population the detector will actually run against, because calibration is population-dependent in the same way precision is. And it has to be redone whenever the detector, the threshold, or the traffic mix changes. It is the right answer when you have the volume and the labelling capacity to keep it current.
+
+**Verdict composition.** Do not combine scores at all. Give each detector its own threshold, tuned on its own data, and let it emit a verdict. Combine verdicts with explicit logic. This is weaker statistically and much easier to reason about, audit, and explain to a risk function.
+
+Verdict composition is the correct default. Score fusion is an optimisation to reach for once you have the labelled data to justify it, and never before.
+
+## Composing detectors
+
+With verdicts rather than scores, composition becomes policy you can write down and review.
+
+```
+  ANY      fire if any detector flags
+           high recall, high false positive rate
+           correct for irreversible harm
+
+  MAJORITY fire if k of n flag
+           balanced, needs detectors with independent failure modes
+
+  WEIGHTED fire if a high-precision detector flags,
+           or if two low-precision detectors agree
+           the usual production answer
+
+  ALL      fire only on unanimity
+           high precision, low recall
+           correct only where a false positive is itself costly
+```
+
+The rule that makes or breaks an ensemble is **independence**. Majority voting assumes the detectors fail for different reasons. Three detectors that are all regex variants over the same keyword list are one detector with three names, and their agreement is not evidence. Before adding a detector to an ensemble, ask what it catches that the others miss, and check that its errors do not correlate with theirs. If you cannot answer, you are adding latency rather than coverage.
+
+Deliberate diversity is worth designing for: one cheap deterministic detector for known-format cases, one trained classifier for the volume, and one judge reserved for the ambiguous band between the other two. Those three fail differently, which is the property that makes voting meaningful.
+
+## Failure behaviour
+
+A detector that times out has not returned "clear". This is where AI safety architecture meets ordinary distributed systems discipline, and it is the reason `execution_status` and `decision` are separate fields above.
+
+Decide explicitly, per detector and per chokepoint, what a timeout means:
+
+- **Fail closed.** Block the request. Correct at tool execution, where the action is irreversible and a refusal is recoverable.
+- **Fail open with a record.** Allow, mark the exchange `degraded`, and raise it in telemetry. Defensible at the prompt layer for a low-severity category, where blocking every request during a detector outage is its own incident.
+- **Fail to a cheaper detector.** Fall back to the rules-based path, mark `degraded`, and accept the reduced coverage knowingly.
+
+Whatever you choose, the outcome must be recorded, because "we were not detecting for four hours" is a fact that surfaces during an incident review and needs to be answerable from the logs rather than from memory.
+
+<Callout type="warn" label="The default nobody chose">
+An unhandled detector exception caught by a generic try/except that returns a passing result is a decision to fail open, made accidentally, applied to every category including the irreversible ones. It is worth grepping for.
+</Callout>
+
+## Where this blueprint stops working
+
+**The interface assumes a verdict per input.** Detectors that need conversational state, such as a slow multi-turn escalation where no single turn is an attack, do not fit a stateless contract. Those need a session-scoped analyser with its own state store, and it is a different component rather than another detector.
+
+**Independence is easier to state than to verify.** Genuinely checking that two detectors fail differently requires a labelled corpus and a correlation analysis on their errors. Most teams assert independence and never test it. That assertion is where majority voting quietly degrades into an expensive single detector.
+
+**Judges cannot safely judge their own input class.** Using an LLM to detect prompt injection means handing attacker-controlled text to a model and trusting its answer about that text. It works against unsophisticated attacks and is a known target for sophisticated ones. Structure the judge call so that the untrusted content is clearly delimited and the judge is never asked to follow instructions found within it, and treat the residual risk as real rather than solved.
+
+<Footer3Col
+  fromBook={[
+    { label: "Ch 6: Evaluating and Hardening Agents", href: "/book/06-evaluating-and-hardening/" },
+    { label: "Ch 11: Security Deep Dive", href: "/book/11-security/" },
+  ]}
+  readNext={{ label: "ARCH-003: Measuring Detectors", href: "/architecture/003-measuring-detectors/" }}
+/>

--- a/src/content/architecture/003-measuring-detectors.mdx
+++ b/src/content/architecture/003-measuring-detectors.mdx
@@ -1,0 +1,187 @@
+---
+id: arch-003
+title: Measuring Detectors
+dek: A detector with 95 percent recall and a 1 percent false alarm rate is wrong nine times out of ten when the attack is rare. Prevalence, not model quality, decides whether a guardrail is usable, and most test sets are too small to settle the question either way.
+description: "Evaluation architecture for AI guardrails: why prevalence dominates precision, how threshold selection combines a cost ratio with a measured curve, what an offline test set can and cannot statistically support, and the regression discipline that keeps a detector honest in production."
+layer: control
+order: 3
+readingTime: 14
+updated: 2026-08-18
+specifies: The evaluation workflow for a detector, from offline test set to production regression
+appliesTo: [RAG platform, Coding assistant, Agent system]
+decisions:
+  - The cost ratio between a false positive and a false negative, per category
+  - How large a test set has to be before a precision claim is meaningful
+  - What fires a rollback when a detector regresses
+anchors:
+  - label: Accuracy is the wrong metric
+    anchor: accuracy-is-the-wrong-metric
+  - label: The base rate calculation
+    anchor: the-base-rate-calculation
+  - label: The threshold is a cost decision
+    anchor: the-threshold-is-a-cost-decision
+  - label: What a test set can support
+    anchor: what-a-test-set-can-support
+  - label: Online validation
+    anchor: online-validation
+  - label: Regression discipline
+    anchor: regression-discipline
+  - label: Where it breaks
+    anchor: where-this-blueprint-stops-working
+references: [ch-06]
+patterns: [eval-loop, failure-buckets]
+---
+
+import Callout from '~/components/universal/Callout.astro';
+import PullQuote from '~/components/universal/PullQuote.astro';
+import Footer3Col from '~/components/universal/Footer3Col.astro';
+
+A detector ships with a number attached. Ninety-four percent accurate, or ninety-nine, measured on a held-out set, printed in the vendor deck or the internal design review. That number is close to useless on its own, and acting on it is the most reliable way to deploy a guardrail that nobody trusts within a month.
+
+The reason is arithmetic rather than machine learning, and once you have done the calculation once you cannot unsee it.
+
+## Accuracy is the wrong metric
+
+Accuracy is the fraction of all decisions that were correct. When the thing you are detecting is rare, accuracy is dominated by the easy negatives. A detector that flags nothing at all is 99.9 percent accurate against an attack that occurs in one request per thousand, and it is worth nothing.
+
+The two numbers that matter are:
+
+- **Recall**, or true positive rate: of the attacks that occurred, what fraction did you catch. This is your exposure.
+- **Precision**: of the items you flagged, what fraction were real. This is your operational cost, and it is what determines whether humans keep paying attention to your alerts.
+
+These trade against each other, and the trade is governed by the threshold. The consequence that gets skipped is that precision is not a property of the detector at all. It is a property of the detector and the population it runs against.
+
+## The base rate calculation
+
+Take a hypothetical detector with numbers most teams would be pleased with: 95 percent recall, and a 1 percent false positive rate on benign traffic. Run it against an assumed workload where prompt injection appears in one request in a thousand. Both figures are stipulated here to make the arithmetic legible, not measured; your own two numbers are the ones that matter and the point of this page is that you need them.
+
+```
+  100,000 requests
+       100  actual attacks        (0.1% base rate)
+    99,900  benign
+
+  caught:            100 x 0.95   =    95   true positives
+  false alarms:   99,900 x 0.01   =   999   false positives
+
+  precision = 95 / (95 + 999) = 8.7%
+```
+
+Ninety-one percent of everything this detector flags is wrong. If each alert costs a reviewer two minutes, this detector generates about 33 hours of review work per 100,000 requests to find 95 real events.
+
+<PullQuote>Precision is not a property of your detector. It is a property of your detector meeting your traffic. Vendor benchmarks are run on balanced sets, and your production traffic is not balanced.</PullQuote>
+
+This is why guardrail programmes fail socially before they fail technically. The alerts are mostly wrong, reviewers learn to dismiss them, and the queue becomes a formality. By the time a real event arrives, the muscle that was supposed to catch it has atrophied.
+
+Three consequences for architecture:
+
+1. **Know your base rate before you choose a threshold.** If you do not know it, measuring it is the first piece of work, ahead of building the detector. Sample production traffic and label it.
+2. **Reduce the population before you detect.** Every deterministic filter that runs first shrinks the denominator. Entitlement checks at retrieval, format validation, and channel restrictions all raise the effective base rate for the expensive detector that runs after them. This is the strongest argument for the tiered design in ARCH-002.
+3. **Do not send low-precision alerts to humans.** Route them to an automatic mitigation that is cheap to be wrong about, such as redaction or an extra verification pass, and reserve human review for the high-precision band.
+
+## The threshold is a cost decision
+
+A threshold is not a tuning parameter. It is an explicit statement about how much worse a missed attack is than a false alarm, and it should be signed off by whoever owns that risk rather than by whoever owns the model.
+
+Write it down in that form:
+
+```
+  category:              pii_in_response
+  cost(false negative):  regulatory disclosure, reportable
+  cost(false positive):  one redacted field, user re-asks
+  ratio:                 ~500:1
+  implication:           tune for recall, accept low precision,
+                         mitigate automatically rather than alert
+```
+
+```
+  category:              block_user_request
+  cost(false negative):  one attack proceeds to the next control
+  cost(false positive):  legitimate user blocked, trust damage
+  ratio:                 ~1:20
+  implication:           tune for precision, high threshold,
+                         never the only control
+```
+
+Both ratios above are illustrative, not benchmarks; the numbers that belong there are your own, and writing them down is the exercise. The ratio on its own does not give you a threshold. It gives you the objective. Turning it into a number needs two more things: the prevalence in the population the detector will run against, and a measured precision-recall curve for that detector on that population. With all three you can pick the operating point that minimises expected cost, and revisit it when the business context changes rather than when someone complains.
+
+<Callout type="tip" label="One threshold per category, never one per system">
+A single global sensitivity setting forces the same cost ratio onto a PII redaction and a hard block. Those two decisions have ratios that differ by four orders of magnitude. Systems with one dial end up tuned for whichever category complained most recently.
+</Callout>
+
+## What a test set can support
+
+Here is the discipline that separates a measured detector from a claimed one.
+
+You hand-label 200 examples, run the detector, and report precision of 0.91.
+
+The first thing to get right is which number is the sample size. Precision is measured over the items the detector *flagged*, not over the whole set. If those 200 examples produced 45 flags, your precision estimate rests on 45 observations, not 200, and its 95 percent interval is roughly 0.79 to 0.98. A competing detector that scored 0.88 on the same set is not distinguishable from it. Teams make that comparison on the point estimates and ship the loser.
+
+Recall has the same problem with the other denominator: it rests on the number of actual positives in the set, which in a realistic sample of rare attacks is often a dozen or fewer. A recall figure computed from eleven true attacks should be reported as a range, and usually a range wide enough to be useless for ranking two detectors.
+
+It gets sharper at the tail. To claim a false positive rate below some level, you need enough negative examples to have observed the absence. With zero false positives in n benign examples, the rule of three gives an upper bound of roughly 3/n at 95 percent confidence. So:
+
+```
+    100 clean, 0 false positives  ->  FPR could be as high as 3%
+  1,000 clean, 0 false positives  ->  FPR could be as high as 0.3%
+ 10,000 clean, 0 false positives  ->  FPR could be as high as 0.03%
+```
+
+A team claiming a 0.1 percent false positive rate from a 500-example test set is claiming something their corpus cannot support. Given the base rate arithmetic above, the difference between 0.3 percent and 0.03 percent is the difference between a usable alert queue and an abandoned one.
+
+Practical rules for the offline set:
+
+- **Label the negatives as carefully as the positives.** Most effort goes into collecting attacks. Precision is determined by the benign class, and a benign set drawn from a different distribution than production makes the whole measurement fiction.
+- **Declare a label noise floor.** Some fraction of your labels are wrong, and inter-annotator disagreement is the cheapest estimate of how large that fraction is. It does not impose a hard ceiling: a detector can legitimately exceed inter-annotator agreement, and disagreement can be resolved by adjudication. What it does mean is that differences smaller than the noise level are not interpretable, so a jump from 96 to 98.5 percent against a 4 percent disagreement rate is not evidence of an improvement. Report the disagreement rate next to the metric.
+- **Keep an untouched holdout.** A test set that has been used to tune thresholds is a training set. Once you have iterated against it, it no longer estimates generalisation.
+- **Version the set.** A metric that moves because the set changed, and one that moves because the detector changed, look identical in a dashboard.
+
+## Online validation
+
+The offline set tells you how the detector behaves on the distribution you assembled. Production tells you how it behaves on the one you have. Three mechanisms, in the order you should build them:
+
+**Shadow mode.** Run the detector on live traffic with its decisions recorded and not enforced. This is the only way to observe the real base rate and the real false positive volume before anyone is affected by it. Every detector should spend time here, and the exit criterion should be a number agreed in advance rather than a feeling that it looks fine.
+
+**Stratified sampling for labels.** You cannot label everything. Sample deliberately across the score bands, oversampling the region near the threshold, because that is where the decisions are made and where your uncertainty is concentrated. Uniform random sampling spends almost all of its budget confirming that obvious negatives are negative.
+
+The catch is that a stratified sample is no longer representative, so any population-level figure computed from it must be reweighted by the inverse of each band's sampling rate. Skip the reweighting and you will report a precision that reflects your sampling design rather than your traffic, usually a pessimistic one, and the error is invisible in the dashboard.
+
+**A review queue that closes the loop.** Human decisions on flagged items are a continuous source of fresh labels, already paid for by the review work itself. They become an asset only if the reviewer's verdict is written back into a labelled store with the input, the detector version, and the evidence. Review workflows that discard this leave the programme starting each retraining cycle from nothing.
+
+Two limits on that data. It is drawn entirely from items the detector flagged, so it can tell you about precision and can say nothing at all about false negatives. Measuring recall needs a separate sample of unflagged traffic, labelled independently, and that sample is pure cost with no operational by-product, which is why it is the first thing cut and the reason most guardrail programmes know their precision and merely assert their recall.
+
+## Regression discipline
+
+Detectors are code and models, and both change. Treat the evaluation set as a test suite that runs in CI.
+
+```
+ on every change to a detector, ruleset, threshold, or model version:
+
+   1  run the frozen regression set
+   2  compare precision and recall per category vs the baseline
+   3  fail the build on a drop beyond the agreed tolerance
+   4  require an explicit, recorded override to ship a known regression
+   5  record the new baseline only on a deliberate, approved change
+```
+
+Two additions that catch the failures a plain metric comparison misses:
+
+**A per-category breakdown, never an aggregate.** An overall score that holds steady while one category collapses is the normal shape of a regression. Aggregates hide it by construction.
+
+**A canary set of previously-fixed false positives.** Every false positive that gets fixed becomes a permanent test case. Without this, threshold tuning reintroduces old failures on a cycle, and the same complaint arrives from the same team twice a year.
+
+The trigger for re-evaluation is not only a code change. Upstream model upgrades change the distribution of what your detectors see, and a prompt template change can shift the input distribution more than a detector change would. Both should fire the suite.
+
+## Where this blueprint stops working
+
+**Rare attacks resist measurement.** For a category that occurs a handful of times a year, you will never assemble enough true positives to estimate recall. Synthetic attacks fill the gap and measure your ability to catch synthetic attacks, which is a different quantity. Be explicit about which categories are measured and which are asserted, and do not let the measured ones lend credibility to the rest.
+
+**Adversarial traffic is not stationary.** Every metric here assumes tomorrow's distribution resembles today's. An adversary who learns your threshold invalidates that assumption deliberately. Metrics tell you about the attacks you have seen, and they are silent about the next class.
+
+**Human labels have a ceiling.** Whether a given retrieval was a disclosure often depends on entitlement context the annotator does not have. Where the ground truth is genuinely contested, the honest move is to report the disagreement rate alongside the metric rather than resolve it by fiat and quote a clean number.
+
+<Footer3Col
+  fromBook={[
+    { label: "Ch 6: Evaluating and Hardening Agents", href: "/book/06-evaluating-and-hardening/" },
+  ]}
+  readNext={{ label: "ARCH-004: The Decision Layer", href: "/architecture/004-the-decision-layer/" }}
+/>

--- a/src/content/architecture/004-the-decision-layer.mdx
+++ b/src/content/architecture/004-the-decision-layer.mdx
@@ -1,0 +1,241 @@
+---
+id: arch-004
+title: The Decision Layer
+dek: Six possible actions, and the two easiest to build are the two most systems have. Which one fires belongs to the reversal cost, the exposure, and the confidence band, never to the detector.
+description: "Policy enforcement architecture for AI systems: the six actions a decision service can take, choosing between them on reversal cost and exposure rather than on which detector fired, policy as versioned data with real load and rollback semantics, and designing the human approval queue that most systems leave undefined."
+layer: control
+order: 4
+readingTime: 13
+updated: 2026-08-18
+specifies: The decisioning service that turns detector verdicts into enforced actions
+appliesTo: [RAG platform, Coding assistant, Agent system]
+decisions:
+  - Which action each category and band maps to
+  - Whether policy is code or versioned data
+  - What happens when a human approver does not respond
+anchors:
+  - label: Six actions
+    anchor: six-actions
+  - label: Choosing by consequence
+    anchor: choosing-by-consequence-not-by-detector
+  - label: Policy as data
+    anchor: policy-as-data
+  - label: The decision record
+    anchor: the-decision-record
+  - label: The approval queue
+    anchor: the-approval-queue
+  - label: Where it breaks
+    anchor: where-this-blueprint-stops-working
+references: [ch-05, ch-10]
+patterns: [approval-gate, escalation-path]
+---
+
+import Callout from '~/components/universal/Callout.astro';
+import PullQuote from '~/components/universal/PullQuote.astro';
+import Footer3Col from '~/components/universal/Footer3Col.astro';
+
+Detectors produce verdicts. Verdicts are not decisions. Something has to turn "the PII detector flagged this response with high confidence" into a specific thing that happens to a specific request, and that something is a service with its own design, its own policy, and its own audit obligations.
+
+Collapsing this into an if-statement next to the detector call works until the second detector arrives, and it has no answer at all the first time someone in risk asks why a particular request was blocked in March.
+
+## Six actions
+
+The full vocabulary is larger than most implementations use.
+
+**Allow.** Proceed unchanged. Worth naming explicitly, because an allow that was reached after three detectors ran and cleared is a different fact from an allow where no detector ran at all. The audit trail should distinguish them.
+
+**Block.** Refuse the request and return a message. Total, obvious to the user, and the only correct choice when the harm is irreversible and confidence is high. Also the action that generates escalations, because a false block is loud. A false redaction is quiet, which is worse rather than better: it produces a confident answer with a hole in it, and nobody files a ticket about information they never saw was missing.
+
+**Redact.** Remove the offending content and continue. The response still arrives, minus the account number. The user's task usually still completes.
+
+**Mask.** Replace with a placeholder that preserves structure. Distinct from redaction because it keeps the shape of the data, so the model or a downstream parser can still reason about it. Turning an account number into `ACCT_7F2A` rather than deleting it lets an agent continue a workflow that references it without ever holding the real value.
+
+**Escalate for review.** Suspend and route to a human queue asynchronously. The request does not complete now. It may complete later.
+
+**Require approval.** Suspend and route to a human who must positively authorise this specific action before it proceeds. Distinct from escalation because the human is in the critical path by design rather than as an exception, and the workflow is built around the wait.
+
+Allow and block are the two that get implemented first, because they need no product design. The middle four are the ones that repay it: redaction and masking remove the harm while leaving the user's task intact, and the two human paths buy a decision the system cannot make. A system with only allow and block converts every detector false positive into a failed user interaction, which is how a guardrail programme loses its mandate.
+
+<PullQuote>Block is the action you reach for when you have not designed the other five. It is also the one your users will describe to your sponsor.</PullQuote>
+
+## Choosing by consequence, not by detector
+
+The action does not belong to the detector. A PII detector firing on a chat response and the same detector firing on a tool call that writes to an external system are the same verdict attached to different consequences.
+
+Consequence is not one property, and treating it as one is where this kind of table usually goes wrong. Three things vary independently, and each is declared on the tool or the surface rather than inferred from the text:
+
+- **Reversal cost.** What it takes to undo the effect: free, expensive, or impossible. This is a single ordered axis, and "expensive" means expensive to reverse, not that the harm is large.
+- **Exposure.** Whether the operation moves information across a trust boundary: contained, internal, or external. A tool can be perfectly reversible in effect and still be an irreversible disclosure, because you cannot un-send.
+- **Blast radius.** How many principals or records the operation touches.
+
+The action grid is keyed on reversal cost and confidence band, and exposure then promotes a cell upward.
+
+```
+  reversal cost      band: near threshold        band: above threshold
+
+  free               allow + record              redact or mask
+  (chat response)    monitor, do not interrupt   fix it silently, log it
+
+  expensive          mask + record               escalate for review
+  (shared doc,       keep the flow, flag it    async, task resumes
+   downstream sync)
+
+  impossible         require approval            block
+  (payment, delete)  human in the path         refuse, escalate
+```
+
+**Exposure promotes.** Any operation with external exposure is evaluated one row lower than its reversal cost alone would place it. A `send_email` call is free to reverse in the sense that the draft can be deleted, and impossible to reverse in the sense that matters. Blast radius promotes on the same rule once it crosses a threshold you set per environment.
+
+Two properties of the grid matter more than its exact contents. There is no cell that blocks a free-to-reverse operation at low confidence, which is the configuration that produces the most user pain for the least risk reduction. And human approval sits where the operation cannot be undone and the system is genuinely unsure, which is the only place a human's time is well spent.
+
+All three properties are declared in the tool registry, because none of them can be recovered from the text at runtime:
+
+```
+  tool: transfer_funds
+    reversal_cost: impossible
+    exposure: external
+    blast_radius: single_account
+    default_action_on_flag: require_approval
+
+  tool: draft_email
+    reversal_cost: free
+    exposure: contained        # send is a separate tool
+    blast_radius: single_thread
+    default_action_on_flag: mask
+```
+
+A tool definition missing these leaves the decision layer guessing at the moment it must not. Splitting `draft_email` from `send_email` so the two carry different exposure is the kind of registry design this forces, and it is the point.
+
+## Policy as data
+
+The mapping from category and band to action is policy. It changes more often than the code around it, it is reviewed by people who do not read code, and it needs an audit history. So it should be versioned data that the service loads, not conditionals compiled into the service.
+
+```
+  policy_version: 2026-08-18.3
+  approved_by: risk-forum
+  rules:
+    - category: pii_in_response
+      band: above
+      context: chat
+      action: redact
+      record: full
+
+    - category: pii_in_response
+      band: above
+      context: tool_call
+      target_reversible: false
+      action: require_approval
+      approver_role: data-owner
+
+    - category: prompt_injection
+      band: near
+      action: allow
+      record: full
+      note: below-threshold, retained for base-rate measurement
+
+    # No bare catch-all. Defaults are per surface, and the surface
+    # whose consequences are irreversible does not default to allow.
+    - default:
+      context: chat
+      action: allow
+      record: summary
+
+    - default:
+      context: tool_call
+      target_reversal_cost: impossible
+      action: require_approval
+      record: full
+```
+
+What this buys you: a risk function can read it, a change to a threshold does not require a deployment, the version identifier lands in every decision record so an old decision can be reconstructed against the policy that produced it, and the diff between two policy versions is reviewable.
+
+A single bare `default: allow` is worth calling out as an anti-pattern. It reads as a sensible fallback and behaves as a silent fail-open for every category nobody has written a rule for yet, which is precisely the set of categories you have not thought about. Scope defaults to a surface, and make the irreversible surface default to a human.
+
+### Policy lifecycle
+
+Policy is data, so it needs the operational discipline of data that gates production traffic.
+
+```
+  validate    schema check + conflict detection in CI; a policy that
+              does not compile never reaches a running service
+
+  precedence  most specific rule wins; ties are an error at validation
+              time, not a resolution rule at runtime
+
+  rollout     atomic. a request is evaluated against exactly one policy
+              version, never a half-loaded one
+
+  rollback    previous version stays loadable; rollback is a version
+              pointer change, not an edit
+
+  load failure  keep serving last-known-good, alarm loudly, and mark
+                every decision `degraded`. never fall back to empty
+                policy, because an empty policy allows everything
+```
+
+The load-failure line is the one that gets written last and matters most. A decision service that starts with no policy because the config store was unreachable is an open gate that reports itself healthy.
+
+<Callout type="tip" label="Test the policy, not just the detectors">
+Policy files need their own test suite: a set of synthetic verdicts with expected actions, run in CI. A policy edit that accidentally widens a default from redact to allow is invisible in review and obvious in a test.
+</Callout>
+
+## The decision record
+
+Every decision produces one record. This is the artefact that makes the whole control layer auditable, and it is the thing that is missing when an incident review stalls.
+
+```
+DecisionRecord
+  request_id         correlates across all chokepoints for this request
+  chokepoint         upload|retrieval|prompt|response|tool|logging
+  principal          who, or which agent, on whose authority
+  detectors_run      ids and versions, including those that cleared
+  verdicts           per detector: verdict, band, categories, evidence
+  policy_version     which policy produced the action
+  action             the action taken
+  degraded           whether any detector ran reduced or timed out
+  latency_ms         detection overhead, separate from inference
+  outcome            completed | blocked | pending_approval | overridden
+  override           if overridden: who, when, stated reason
+```
+
+Two fields are routinely omitted and both are load-bearing. Recording detectors that **cleared** is what lets you answer "was this checked", which is the first question in any review, and distinguishes a clean pass from a detector that never ran. Recording the **override** with a stated reason turns human dismissals into data: a rule that is overridden ninety percent of the time is not a rule, it is a queue of noise, and the record is what proves it.
+
+## The approval queue
+
+Human approval is the action most often specified and least often designed. Three questions decide whether it works.
+
+**What does the user see while waiting?** A synchronous request that blocks on a human is a request that times out at the gateway. Approval-bearing flows need to be asynchronous end to end, with a durable task the user can leave and return to. If the agent framework cannot suspend and resume a run, human approval is not actually available to you, whatever the policy file says.
+
+**What happens when nobody responds?** This is the question with no default answer, and leaving it undefined means choosing one accidentally. Pick explicitly:
+
+```
+  timeout: 4h
+  on_timeout: expire      the task fails, the user is told
+                            correct for irreversible actions
+
+  on_timeout: escalate      route to a second approver group
+                          correct where the action is required
+
+  on_timeout: proceed       NEVER for an irreversible action.
+                          this turns your approval gate into a delay
+```
+
+**Who is a valid approver?** The approver must be someone with the authority to accept the risk, and must not be the same principal that requested the action. In multi-agent systems this is not automatic: an orchestrating agent asking a sub-agent to approve its own action satisfies a naive "an approval was recorded" check while providing no control at all. Separation of duties has to be enforced by identity rather than by convention.
+
+An approval queue also needs the ordinary properties of a queue that someone is on the hook for: a volume you can staff, a latency target, and an alarm when depth grows. A gate slow enough to block delivery creates pressure to find a path that avoids it, and that pressure is invisible in the gate's own metrics, which will show a healthy approval rate on falling volume. Watch the volume trend, not just the approval rate.
+
+## Where this blueprint stops working
+
+**Streaming responses break the response chokepoint.** If tokens reach the user as they are generated, there is no moment where the complete response exists before delivery. You are left with incremental detection on partial text, which raises false positives, or buffering, which discards the latency benefit that streaming existed to provide. Choose deliberately per surface rather than letting the frontend decide.
+
+**Redaction can be worse than blocking.** Removing a figure from the middle of an otherwise confident answer produces a response that reads as authoritative and is now wrong. For content where partial information misleads, block and explain. Redaction suits identifiers and suits prose poorly.
+
+**Policy volume becomes its own risk.** A policy file with two hundred rules has interactions nobody has reasoned about, and the same conflict-resolution problems as any large rule system. Once ordering and specificity start to matter, you need conflict detection and a documented resolution order, or the file becomes an oracle that only its author can predict.
+
+<Footer3Col
+  fromBook={[
+    { label: "Ch 5: Human-in-the-Loop as Architecture", href: "/book/05-human-in-the-loop/" },
+    { label: "Ch 10: Governance and Auditability", href: "/book/10-governance/" },
+  ]}
+  readNext={{ label: "Back to Architecture", href: "/architecture/" }}
+/>

--- a/src/layouts/ArchitectureLayout.astro
+++ b/src/layouts/ArchitectureLayout.astro
@@ -1,0 +1,212 @@
+---
+/**
+ * ArchitectureLayout — blueprint treatment for the Architecture section.
+ *
+ * Blueprints are reference material, not a feed: they read in `order`, they carry an
+ * `updated` date rather than a publication date, and they lead with the contract
+ * (what this blueprint specifies, what it applies to, what it forces you to decide).
+ *
+ * Anatomy: ArticleHeader → Spot → BlueprintCard → SectionAnchors → MDX body → Sources → PrevNext.
+ */
+import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
+import PageLayout from './PageLayout.astro';
+import Reader from '~/components/layout/Reader.astro';
+import ArticleHeader from '~/components/universal/ArticleHeader.astro';
+import Spot from '~/components/universal/Spot.astro';
+import SectionAnchors from '~/components/universal/SectionAnchors.astro';
+import Sources from '~/components/universal/Sources.astro';
+
+interface Props {
+  entry: CollectionEntry<'architecture'>;
+}
+
+const { entry } = Astro.props;
+const d = entry.data;
+
+const LAYER_LABEL: Record<string, string> = {
+  capability: 'Capability',
+  control: 'Control',
+  evidence: 'Evidence',
+};
+
+// Sequence neighbours, by `order` across the whole section.
+const all = (await getCollection('architecture'))
+  .filter((e) => e.data.status !== 'draft')
+  .sort((a, b) => a.data.order - b.data.order);
+const pos = all.findIndex((e) => e.id === entry.id);
+const prev = pos > 0 ? all[pos - 1] : undefined;
+const next = pos >= 0 && pos < all.length - 1 ? all[pos + 1] : undefined;
+
+const updatedLong = d.updated
+  .toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+  .toUpperCase();
+const byline = ['SUNIL PRAKASH', `UPDATED ${updatedLong}`, `${d.readingTime} MIN`];
+const ogImage = `/assets/banners/${d.id}.png`;
+---
+
+<PageLayout
+  title={`${d.title} — Architecture`}
+  description={d.description}
+  ogImage={ogImage}
+  currentNav="Architecture"
+  articleData={{
+    publishedTime: d.updated.toISOString(),
+    section: 'Architecture',
+    headline: d.title,
+  }}
+>
+  <Reader>
+    <ArticleHeader
+      rubric={`BLUEPRINT · ${d.id.toUpperCase()} · ${LAYER_LABEL[d.layer].toUpperCase()}`}
+      title={d.title}
+      dek={d.dek}
+      byline={byline}
+    />
+
+    {d.spot && <Spot src={d.spot} alt={d.spotCaption ?? ''} caption={d.spotCaption} />}
+
+    <section class="blueprint-card" aria-label="Blueprint summary">
+      <dl class="blueprint-card__list">
+        <div class="blueprint-card__row">
+          <dt>Specifies</dt>
+          <dd>{d.specifies}</dd>
+        </div>
+        <div class="blueprint-card__row">
+          <dt>Applies to</dt>
+          <dd>{d.appliesTo.join(' · ')}</dd>
+        </div>
+        {d.decisions && d.decisions.length > 0 && (
+          <div class="blueprint-card__row">
+            <dt>Forces a decision on</dt>
+            <dd>
+              <ul class="blueprint-card__decisions">
+                {d.decisions.map((x) => <li>{x}</li>)}
+              </ul>
+            </dd>
+          </div>
+        )}
+      </dl>
+    </section>
+
+    {d.anchors && d.anchors.length > 0 && <SectionAnchors items={d.anchors} label="In this blueprint" />}
+
+    <article class="blueprint-body prose prose--dropcap">
+      <slot />
+    </article>
+
+    {d.sources && d.sources.length > 0 && <Sources items={d.sources} />}
+
+    <nav class="blueprint-nav" aria-label="Blueprint navigation">
+      {prev ? (
+        <a href={`/architecture/${prev.id}/`} class="blueprint-nav__link blueprint-nav__link--prev">
+          <span class="blueprint-nav__label">← Previous</span>
+          <span class="blueprint-nav__title">{prev.data.title}</span>
+        </a>
+      ) : (
+        <span class="blueprint-nav__placeholder"></span>
+      )}
+      {next ? (
+        <a href={`/architecture/${next.id}/`} class="blueprint-nav__link blueprint-nav__link--next">
+          <span class="blueprint-nav__label">Next →</span>
+          <span class="blueprint-nav__title">{next.data.title}</span>
+        </a>
+      ) : (
+        <span class="blueprint-nav__placeholder"></span>
+      )}
+    </nav>
+  </Reader>
+</PageLayout>
+
+<style>
+  .blueprint-card {
+    margin: var(--space-5) 0 var(--space-6);
+    padding: var(--space-4) var(--space-5);
+    background: var(--brick-wash);
+    border-left: 3px solid var(--brick);
+  }
+
+  .blueprint-card__list { margin: 0; }
+
+  .blueprint-card__row {
+    display: grid;
+    grid-template-columns: 150px 1fr;
+    gap: var(--space-3);
+    padding: var(--space-2) 0;
+  }
+
+  .blueprint-card__row + .blueprint-card__row {
+    border-top: 1px solid rgba(155, 74, 63, 0.18);
+  }
+
+  .blueprint-card__row dt {
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--brick);
+    padding-top: 3px;
+  }
+
+  .blueprint-card__row dd {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: var(--body-2);
+    line-height: var(--lh-snug);
+    color: var(--fg);
+  }
+
+  .blueprint-card__decisions {
+    margin: 0;
+    padding-left: 1.1em;
+    list-style: disc;
+  }
+
+  .blueprint-card__decisions li { margin: 0 0 2px; }
+  .blueprint-card__decisions li::marker { color: var(--brick); }
+
+  .blueprint-body :global(pre) { margin: var(--space-4) 0; }
+
+  /* Structural diagrams read better slightly tighter than prose code. */
+  .blueprint-body :global(pre code) { line-height: 1.45; }
+
+  .blueprint-nav {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-4);
+    margin: var(--space-7) 0 var(--space-5);
+    padding-top: var(--space-4);
+    border-top: 1px solid var(--fg-faint);
+  }
+
+  .blueprint-nav__link { display: block; }
+  .blueprint-nav__link--next { text-align: right; }
+
+  .blueprint-nav__label {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: var(--meta-3);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--fg-light);
+    margin-bottom: 4px;
+  }
+
+  .blueprint-nav__title {
+    display: block;
+    font-family: var(--font-body);
+    font-style: italic;
+    font-size: var(--body-2);
+    color: var(--fg);
+    border-bottom: 1.5px solid var(--brick);
+    padding-bottom: 2px;
+  }
+
+  .blueprint-nav__link:hover .blueprint-nav__title { color: var(--brick); }
+
+  @media (max-width: 720px) {
+    .blueprint-card__row { grid-template-columns: 1fr; gap: 2px; }
+    .blueprint-nav { grid-template-columns: 1fr; }
+    .blueprint-nav__link--next { text-align: left; }
+  }
+</style>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -76,6 +76,7 @@ const articleSchema = articleData ? {
 } : null;
 
 const SECTION_LABELS: Record<string, string> = {
+  architecture: 'Architecture',
   'field-notes': 'Field Notes',
   signal: 'Signal',
   recipes: 'Recipes',

--- a/src/pages/architecture/[...slug].astro
+++ b/src/pages/architecture/[...slug].astro
@@ -1,0 +1,25 @@
+---
+import { getCollection, render, type CollectionEntry } from 'astro:content';
+import ArchitectureLayout from '~/layouts/ArchitectureLayout.astro';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('architecture');
+  return entries
+    .filter((entry) => entry.data.status !== 'draft')
+    .map((entry) => ({
+      params: { slug: entry.id },
+      props: { entry },
+    }));
+}
+
+interface Props {
+  entry: CollectionEntry<'architecture'>;
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+---
+
+<ArchitectureLayout entry={entry}>
+  <Content />
+</ArchitectureLayout>

--- a/src/pages/architecture/index.astro
+++ b/src/pages/architecture/index.astro
@@ -1,0 +1,220 @@
+---
+import { getCollection } from 'astro:content';
+import PageLayout from '~/layouts/PageLayout.astro';
+import Container from '~/components/layout/Container.astro';
+import ArticleHeader from '~/components/universal/ArticleHeader.astro';
+
+const entries = (await getCollection('architecture'))
+  .filter((e) => e.data.status !== 'draft')
+  .sort((a, b) => a.data.order - b.data.order);
+
+const LAYERS = [
+  {
+    key: 'capability',
+    label: 'Capability',
+    line: 'What the system can do. Models, retrieval, memory, tools, orchestration.',
+  },
+  {
+    key: 'control',
+    label: 'Control',
+    line: 'What the system is allowed to do. Chokepoints, detectors, policy, authority, human gates.',
+  },
+  {
+    key: 'evidence',
+    label: 'Evidence',
+    line: 'How you know what it did. Evaluation, telemetry, tracing, audit.',
+  },
+] as const;
+
+const byLayer = LAYERS.map((l) => ({
+  ...l,
+  items: entries.filter((e) => e.data.layer === l.key),
+}));
+---
+
+<PageLayout
+  title="Architecture — Agent Engineering Lab"
+  description="Architectural blueprints for AI systems. Each one specifies a layer, names the decisions it forces, and says where the pattern breaks."
+  currentNav="Architecture"
+>
+  <Container>
+    <div class="arch-index__header">
+      <ArticleHeader
+        rubric="ARCHITECTURE"
+        title="Architecture"
+        dek="Blueprints, not opinions. Each one pins down a layer of an AI system, names the decisions it forces on you, and says where the pattern stops working."
+      />
+    </div>
+
+    <section class="arch-thesis">
+      <p>
+        Most published AI reference architectures are a capability diagram with a governance
+        box drawn beside it. The capability layer is the part the industry has converged on
+        and the part vendors will sell you. The other two are where systems actually fail
+        in production, and they get a box.
+      </p>
+      <p>
+        This section splits an AI system into three layers and treats each as load-bearing:
+        <strong>what it can do</strong>, <strong>what it is allowed to do</strong>, and
+        <strong>how you know what it did</strong>. Blueprints are written to be read in
+        order within a layer, and revised rather than republished.
+      </p>
+    </section>
+
+    {entries.length === 0 ? (
+      <p class="arch-index__empty">No blueprints published yet.</p>
+    ) : (
+      <div class="arch-layers">
+        {byLayer.map((layer) => layer.items.length > 0 && (
+          <section class="arch-layer">
+            <header class="arch-layer__header">
+              <h2 class="arch-layer__title">{layer.label}</h2>
+              <p class="arch-layer__line">{layer.line}</p>
+            </header>
+            <ol class="arch-list">
+              {layer.items.map((e) => (
+                <li class="arch-list__item">
+                  <a href={`/architecture/${e.id}/`} class="arch-list__link">
+                    <span class="arch-list__num">{e.data.id.toUpperCase()}</span>
+                    <span class="arch-list__body">
+                      <span class="arch-list__title">{e.data.title}</span>
+                      <span class="arch-list__dek">{e.data.dek}</span>
+                      <span class="arch-list__meta">
+                        {e.data.appliesTo.join(' · ')} <span class="arch-list__dot">·</span> {e.data.readingTime} min
+                      </span>
+                    </span>
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </section>
+        ))}
+      </div>
+    )}
+  </Container>
+</PageLayout>
+
+<style>
+  .arch-index__header {
+    margin: 0 0 var(--space-5);
+    text-align: center;
+  }
+
+  .arch-thesis {
+    max-width: var(--reader-max);
+    margin: 0 auto var(--space-7);
+    padding-bottom: var(--space-5);
+    border-bottom: 1px solid var(--fg-faint);
+  }
+
+  .arch-thesis p {
+    font-family: var(--font-body);
+    font-size: var(--body-2);
+    line-height: var(--lh-base);
+    color: var(--fg);
+    margin: 0 0 var(--space-3);
+  }
+
+  .arch-thesis p:last-child { margin-bottom: 0; }
+
+  .arch-layers {
+    max-width: var(--reader-max);
+    margin: 0 auto;
+  }
+
+  .arch-layer { margin: 0 0 var(--space-7); }
+
+  .arch-layer__header {
+    margin: 0 0 var(--space-4);
+    padding-bottom: var(--space-2);
+    border-bottom: 2px solid var(--brick);
+  }
+
+  .arch-layer__title {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: var(--display-2);
+    line-height: var(--lh-tight);
+    color: var(--fg);
+    margin: 0 0 4px;
+  }
+
+  .arch-layer__line {
+    font-family: var(--font-body);
+    font-size: var(--body-3);
+    color: var(--fg-light);
+    margin: 0;
+  }
+
+  .arch-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .arch-list__item + .arch-list__item {
+    border-top: 1px solid var(--fg-faint);
+  }
+
+  .arch-list__link {
+    display: grid;
+    grid-template-columns: 88px 1fr;
+    gap: var(--space-4);
+    padding: var(--space-4) 0;
+    border-bottom: none;
+  }
+
+  .arch-list__link:hover .arch-list__title { color: var(--brick); }
+
+  .arch-list__num {
+    font-family: var(--font-mono);
+    font-size: var(--meta-2);
+    letter-spacing: 0.14em;
+    color: var(--brick);
+    padding-top: 5px;
+  }
+
+  .arch-list__body { display: block; }
+
+  .arch-list__title {
+    display: block;
+    font-family: var(--font-display);
+    font-size: var(--display-3);
+    line-height: var(--lh-snug);
+    color: var(--fg);
+    margin-bottom: 4px;
+    transition: color var(--dur-micro) var(--ease-out);
+  }
+
+  .arch-list__dek {
+    display: block;
+    font-family: var(--font-body);
+    font-size: var(--body-3);
+    line-height: var(--lh-snug);
+    color: var(--fg-light);
+    margin-bottom: 6px;
+  }
+
+  .arch-list__meta {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: var(--meta-3);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--fg-lighter);
+  }
+
+  .arch-list__dot { color: var(--brick); }
+
+  .arch-index__empty {
+    color: var(--fg-light);
+    font-style: italic;
+    margin: var(--space-7) 0;
+    text-align: center;
+  }
+
+  @media (max-width: 720px) {
+    .arch-list__link { grid-template-columns: 1fr; gap: 4px; }
+    .arch-list__num { padding-top: 0; }
+  }
+</style>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -6,12 +6,13 @@ import type { APIContext } from 'astro';
 export async function GET(context: APIContext) {
   const base = (context.site?.toString() ?? 'https://agenticlab.sunilprakash.com/').replace(/\/$/, '');
 
-  const [chapters, fieldNotes, signal, recipes, labs] = await Promise.all([
+  const [chapters, fieldNotes, signal, recipes, labs, architecture] = await Promise.all([
     getCollection('chapters'),
     getCollection('fieldNotes'),
     getCollection('signal'),
     getCollection('recipes'),
     getCollection('labs'),
+    getCollection('architecture'),
   ]);
 
   const byDateDesc = (a: any, b: any) =>
@@ -24,6 +25,11 @@ export async function GET(context: APIContext) {
   const sg = [...signal].sort(byDateDesc).map((e) => line(e, 'signal')).join('\n');
   const rc = [...recipes].map((e) => line(e, 'recipes')).join('\n');
   const lab = [...labs].sort(byDateDesc).map((e) => line(e, 'labs')).join('\n');
+  const arch = [...architecture]
+    .filter((e) => e.data.status !== 'draft')
+    .sort((a, b) => a.data.order - b.data.order)
+    .map((e) => line(e, 'architecture'))
+    .join('\n');
   const ch = [...chapters]
     .sort((a, b) => a.id.localeCompare(b.id))
     .map((e) => `- [${e.data.title}](${base}/book/${e.id}/): ${e.data.description ?? ''}`)
@@ -31,7 +37,7 @@ export async function GET(context: APIContext) {
 
   const body = `# Agent Engineering Lab
 
-> A working publication on building agent systems that survive contact with reality. Field Notes, Signals, Recipes, Lab Notes, and an interactive Bench, grounded in evidence. Written by Sunil Prakash.
+> A working publication on building agent systems that survive contact with reality. Field Notes, Signals, Recipes, Lab Notes, Architecture blueprints, and an interactive Bench, grounded in evidence. Written by Sunil Prakash.
 
 - Site: ${base}/
 - Full text for ingestion: ${base}/llms-full.txt
@@ -41,6 +47,11 @@ export async function GET(context: APIContext) {
 ## What this is
 
 The Lab is a layered editorial system. The book is the canonical reference. Four ongoing streams sit alongside it: Field Notes are observations from inside the work, Signals are commentary on the discourse around agent engineering, Recipes are buildable-in-an-afternoon walkthroughs with verified code, and Lab Notes are empirical experiments with measured results. Evidence, Patterns, and Projects are reference material. The Bench is an interactive, in-browser playground.
+
+## Architecture blueprints
+${arch}
+
+Index: ${base}/architecture/
 
 ## Field Notes
 ${fn}

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -3,11 +3,12 @@ import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
 
 export async function GET(context: APIContext) {
-  const [fieldNotes, signal, recipes, labs] = await Promise.all([
+  const [fieldNotes, signal, recipes, labs, architecture] = await Promise.all([
     getCollection('fieldNotes'),
     getCollection('signal'),
     getCollection('recipes'),
     getCollection('labs'),
+    getCollection('architecture'),
   ]);
 
   const items = [
@@ -39,11 +40,20 @@ export async function GET(context: APIContext) {
       link: `/labs/${e.id}/`,
       categories: ['Labs'],
     })),
+    ...architecture
+      .filter((e) => e.data.status !== 'draft')
+      .map((e) => ({
+        title: `${e.data.id.toUpperCase()}: ${e.data.title}`,
+        pubDate: e.data.updated,
+        description: e.data.description,
+        link: `/architecture/${e.id}/`,
+        categories: ['Architecture'],
+      })),
   ].sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
 
   return rss({
     title: 'Agent Engineering Lab',
-    description: 'Field Notes, Signal, Recipes, and Lab Reports from the agentic AI publication by Sunil Prakash.',
+    description: 'Field Notes, Signal, Recipes, Lab Reports, and Architecture blueprints from the agentic AI publication by Sunil Prakash.',
     site: context.site!,
     items,
     customData: `<language>en-us</language>`,


### PR DESCRIPTION
Adds `/architecture/`, a blueprint reference section, as the Lab's fifth content pillar.

## Why a separate collection

Blueprints have a different reading contract from the editorial streams. They read in `order` rather than by date, carry an `updated` date because they are revised rather than republished, and do not require the `sources` array that Field Notes and Signal enforce.

## What is here

**Machinery**

- `architecture` collection; index groups by a Capability / Control / Evidence spine and hides empty layers
- `ArchitectureLayout` with a blueprint summary card (Specifies / Applies to / Forces a decision on), in-page anchors, and sequence prev/next
- `SectionAnchors` gains an optional `label`, defaulting to the existing "In this Lab" so Lab Notes are untouched
- Wired into TopNav, breadcrumb labels, RSS, and `llms.txt`

**Four Control-layer blueprints**, anchored to OWASP Top 10 for LLM Applications 2025:

| ID | Title |
|---|---|
| ARCH-001 | The Control Plane |
| ARCH-002 | Detector Architecture |
| ARCH-003 | Measuring Detectors |
| ARCH-004 | The Decision Layer |

Capability and Evidence layers are intentionally empty for now.

## Review and validation

Reviewed with codex, which returned "major revisions" on all four and found real technical errors, not just voice issues. Fixed:

- **ARCH-001**: tool execution was classed as action-harm only. A tool call is also an egress path, so it belongs to both families. OWASP table completed from seven entries to all ten, with the three that have no runtime chokepoint named as such.
- **ARCH-002**: taxonomy was non-orthogonal, since a managed safety service is a sourcing choice rather than a fifth technique. `DetectorResult` conflated policy decision with execution state, now split into `execution_status` and `decision` with `abstain`.
- **ARCH-003**: two statistical errors. Accuracy with prevalence does not determine precision, and a precision confidence interval is computed over predicted positives rather than over the whole test set.
- **ARCH-004**: consequence model was internally inconsistent, now rebuilt on three independently declared properties (`reversal_cost`, `exposure`, `blast_radius`). Added policy load and rollback semantics, and removed a bare `default: allow` that silently failed open.

Unsourced prevalence claims scoped or removed throughout.

Validated with originbench: no invisible characters, no house-style violations, and stylistic flags checked against a calibration corpus of prior published prose.

## Checks

- Build green, 74 pages
- All declared in-page anchors resolve to rendered heading ids
- All `/book/` cross-links resolve
- CSS tokens all defined; diagrams fit the reader column without clipping
- Rendered and inspected at desktop and mobile widths
