### PR TITLE
Architecture: eight structural diagrams for the four blueprints

### DIFF
--- a/public/assets/diagrams/arch-001-chokepoints.svg
+++ b/public/assets/diagrams/arch-001-chokepoints.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="632" viewBox="0 0 880 632" role="img" aria-label="The six chokepoints in an AI request path, what each can see, and which harm family it addresses">
+<defs><marker id="a1" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker></defs>
+<rect width="880" height="632" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">The six chokepoints, and what each one can see</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">Placement sets the accuracy ceiling before a single detector is chosen.</text>
+<text x="84" y="78" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" letter-spacing="1.6" fill="#6b6b6b">CHOKEPOINT</text>
+<text x="286" y="78" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" letter-spacing="1.6" fill="#6b6b6b">WHAT IT CAN SEE  /  WHAT IT CANNOT</text>
+<text x="678" y="78" text-anchor="middle" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" letter-spacing="1.4" fill="#6b6b6b">INFO</text>
+<text x="792" y="78" text-anchor="middle" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" letter-spacing="1.4" fill="#6b6b6b">ACTION</text>
+<line x1="84" y1="86" x2="880" y2="86" stroke="#1a1a1a" stroke-width="1"/>
+<rect x="0" y="92" width="40" height="428" fill="#1a1a1a"/>
+<text x="20.0" y="314.0" text-anchor="middle" transform="rotate(-90 20.0 314.0)" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10" letter-spacing="3" fill="#fafaf8">ONE REQUEST PATH</text>
+<line x1="20.0" y1="522" x2="20.0" y2="546" stroke="#1a1a1a" stroke-width="1.4" marker-end="url(#a1)"/>
+<rect x="44" y="94" width="836" height="68" fill="#fafaf8"/>
+<text x="58" y="122" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="15" fill="#1a1a1a">1</text>
+<text x="84" y="122" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12.5" letter-spacing="0.6" fill="#1a1a1a">UPLOAD</text>
+<text x="286" y="118" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">the whole document, unhurried, off the request path</text>
+<text x="286" y="139" font-family="Georgia,'EB Garamond',serif" font-size="12.5" font-style="italic" fill="#6b6b6b">blind to who will retrieve it later, or in what context</text>
+<circle cx="678" cy="118" r="6" fill="#9b4a3f"/>
+<circle cx="792" cy="118" r="6" fill="none" stroke="#e8e8e8" stroke-width="1.4"/>
+<line x1="44" y1="164" x2="880" y2="164" stroke="#e8e8e8" stroke-width="1"/>
+<text x="58" y="196" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="15" fill="#1a1a1a">2</text>
+<text x="84" y="196" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12.5" letter-spacing="0.6" fill="#1a1a1a">RETRIEVAL</text>
+<text x="286" y="192" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">the selected chunks and the requester's identity</text>
+<text x="286" y="213" font-family="Georgia,'EB Garamond',serif" font-size="12.5" font-style="italic" fill="#6b6b6b">blind to what the model will go on to do with them</text>
+<circle cx="678" cy="192" r="6" fill="#9b4a3f"/>
+<circle cx="792" cy="192" r="6" fill="none" stroke="#e8e8e8" stroke-width="1.4"/>
+<line x1="44" y1="238" x2="880" y2="238" stroke="#e8e8e8" stroke-width="1"/>
+<rect x="44" y="242" width="836" height="68" fill="#fafaf8"/>
+<text x="58" y="270" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="15" fill="#1a1a1a">3</text>
+<text x="84" y="270" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12.5" letter-spacing="0.6" fill="#1a1a1a">PROMPT</text>
+<text x="286" y="266" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">the assembled payload: everything, all at once</text>
+<text x="286" y="287" font-family="Georgia,'EB Garamond',serif" font-size="12.5" font-style="italic" fill="#6b6b6b">blind to provenance, unless the assembly step preserved it</text>
+<circle cx="678" cy="266" r="6" fill="none" stroke="#e8e8e8" stroke-width="1.4"/>
+<circle cx="792" cy="266" r="6" fill="none" stroke="#e8e8e8" stroke-width="1.4"/>
+<line x1="44" y1="312" x2="880" y2="312" stroke="#e8e8e8" stroke-width="1"/>
+<text x="58" y="344" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="15" fill="#1a1a1a">4</text>
+<text x="84" y="344" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12.5" letter-spacing="0.6" fill="#1a1a1a">RESPONSE</text>
+<text x="286" y="340" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">what the model produced</text>
+<text x="286" y="361" font-family="Georgia,'EB Garamond',serif" font-size="12.5" font-style="italic" fill="#6b6b6b">blind to intent, and it cannot undo an action already requested</text>
+<circle cx="678" cy="340" r="6" fill="#9b4a3f"/>
+<circle cx="792" cy="340" r="6" fill="none" stroke="#e8e8e8" stroke-width="1.4"/>
+<line x1="44" y1="386" x2="880" y2="386" stroke="#e8e8e8" stroke-width="1"/>
+<rect x="44" y="390" width="836" height="68" fill="#f5ece9"/>
+<rect x="44" y="390" width="3" height="68" fill="#9b4a3f"/>
+<text x="58" y="418" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="15" fill="#9b4a3f">5</text>
+<text x="84" y="418" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12.5" letter-spacing="0.6" fill="#9b4a3f">TOOL EXECUTION</text>
+<text x="286" y="414" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">the function, arguments, target and identity</text>
+<text x="286" y="435" font-family="Georgia,'EB Garamond',serif" font-size="12.5" font-style="italic" fill="#6b6b6b">blind to nothing in the text; only as good as the policy behind it</text>
+<circle cx="678" cy="414" r="6" fill="#9b4a3f"/>
+<circle cx="792" cy="414" r="6" fill="#9b4a3f"/>
+<line x1="44" y1="460" x2="880" y2="460" stroke="#e8e8e8" stroke-width="1"/>
+<text x="58" y="492" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="15" fill="#1a1a1a">6</text>
+<text x="84" y="492" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12.5" letter-spacing="0.6" fill="#1a1a1a">LOGGING</text>
+<text x="286" y="488" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">the whole exchange, after the fact</text>
+<text x="286" y="509" font-family="Georgia,'EB Garamond',serif" font-size="12.5" font-style="italic" fill="#6b6b6b">blind to nothing, and it prevents nothing. a leak surface itself</text>
+<circle cx="678" cy="488" r="6" fill="#9b4a3f"/>
+<circle cx="792" cy="488" r="6" fill="none" stroke="#e8e8e8" stroke-width="1.4"/>
+<line x1="44" y1="534" x2="880" y2="534" stroke="#e8e8e8" stroke-width="1"/>
+<line x1="44" y1="546" x2="880" y2="546" stroke="#1a1a1a" stroke-width="1"/>
+<circle cx="60" cy="563" r="5" fill="#9b4a3f"/>
+<text x="74" y="567" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">addresses this harm family</text>
+<circle cx="290" cy="563" r="5" fill="none" stroke="#e8e8e8" stroke-width="1.4"/>
+<text x="304" y="567" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">does not</text>
+<text x="58" y="592" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">Tool execution is the only chokepoint that can stop an act, and it is an egress path too, so it sits in both families.</text>
+<text x="58" y="612" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">The prompt layer sits in neither: it sees everything and attributes nothing.</text>
+</svg>

--- a/public/assets/diagrams/arch-001-nested-paths.svg
+++ b/public/assets/diagrams/arch-001-nested-paths.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="430" viewBox="0 0 880 430" role="img" aria-label="An agent's tool call opens a second agent's full six-chokepoint path, so the chokepoints nest">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="430" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">Chokepoints nest when one agent calls another</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">A single-pass model misses the case where the unauthorized agent borrows the authorized one.</text>
+<rect x="12" y="86" width="856" height="132" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="26" y="110" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">AGENT B</text>
+<text x="80.2325" y="110" font-family="Georgia,'EB Garamond',serif" font-size="11.5" fill="#6b6b6b">not authorized to transfer funds</text>
+<rect x="26.0" y="120" width="129.66666666666666" height="42" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="90.83333333333333" y="146" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="middle">1 upload</text>
+<rect x="165.66666666666666" y="120" width="129.66666666666666" height="42" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="230.5" y="146" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="middle">2 retrieval</text>
+<rect x="305.3333333333333" y="120" width="129.66666666666666" height="42" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="370.16666666666663" y="146" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="middle">3 prompt</text>
+<rect x="445.0" y="120" width="129.66666666666666" height="42" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="509.8333333333333" y="146" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="middle">4 response</text>
+<rect x="584.6666666666666" y="120" width="129.66666666666666" height="42" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.4"/>
+<text x="649.5" y="146" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#9b4a3f" text-anchor="middle">5 tool exec</text>
+<rect x="724.3333333333333" y="120" width="129.66666666666666" height="42" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="789.1666666666666" y="146" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="middle">6 logging</text>
+<text x="26" y="182" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">Its own six checks all pass. Nothing it does is, on its own, the prohibited act.</text>
+<line x1="649.5" y1="162" x2="649.5" y2="242" stroke="#9b4a3f" stroke-width="1.6" marker-end="url(#arb)"/>
+<text x="661.5" y="206" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#9b4a3f">calls agent A</text>
+<rect x="12" y="252" width="856" height="132" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1"/>
+<text x="26" y="276" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">AGENT A</text>
+<text x="80.2325" y="276" font-family="Georgia,'EB Garamond',serif" font-size="11.5" fill="#6b6b6b">authorized to transfer funds</text>
+<rect x="26.0" y="286" width="129.66666666666666" height="42" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="90.83333333333333" y="312" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="middle">1 upload</text>
+<rect x="165.66666666666666" y="286" width="129.66666666666666" height="42" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="230.5" y="312" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="middle">2 retrieval</text>
+<rect x="305.3333333333333" y="286" width="129.66666666666666" height="42" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="370.16666666666663" y="312" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="middle">3 prompt</text>
+<rect x="445.0" y="286" width="129.66666666666666" height="42" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="509.8333333333333" y="312" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="middle">4 response</text>
+<rect x="584.6666666666666" y="286" width="129.66666666666666" height="42" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.4"/>
+<text x="649.5" y="312" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#9b4a3f" text-anchor="middle">5 tool exec</text>
+<rect x="724.3333333333333" y="286" width="129.66666666666666" height="42" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="789.1666666666666" y="312" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="middle">6 logging</text>
+<text x="26" y="348" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">Its own six checks all pass too. It was asked by a trusted internal caller.</text>
+<line x1="0" y1="400" x2="880" y2="400" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="420" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">Neither path fails. The composition does. This needs identity that survives the hop, not another detector.</text>
+</svg>

--- a/public/assets/diagrams/arch-002-composition.svg
+++ b/public/assets/diagrams/arch-002-composition.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="452" viewBox="0 0 880 452" role="img" aria-label="Score fusion averages incomparable numbers; verdict composition combines verdicts with explicit logic">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="452" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">Verdict composition, not score fusion</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">Two ways to combine three detectors. Only one of them can be explained to a risk function.</text>
+<rect x="0" y="86" width="420.0" height="272" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="16" y="110" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">SCORE FUSION</text>
+<text x="16" y="130" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">average the numbers</text>
+<rect x="16" y="152" width="150" height="32" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="26" y="173" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">rules</text>
+<text x="186" y="173" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="14" fill="#1a1a1a">0.90</text>
+<text x="232" y="173" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">means 1 in 10 wrong</text>
+<rect x="16" y="196" width="150" height="32" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="26" y="217" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">classifier</text>
+<text x="186" y="217" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="14" fill="#1a1a1a">0.90</text>
+<text x="232" y="217" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">means 6 in 10 wrong</text>
+<rect x="16" y="240" width="150" height="32" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="26" y="261" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">judge</text>
+<text x="186" y="261" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="14" fill="#1a1a1a">0.90</text>
+<text x="232" y="261" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">means who knows</text>
+<line x1="16" y1="292" x2="404.0" y2="292" stroke="#e8e8e8"/>
+<text x="16" y="316" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="14" fill="#6b6b6b">mean = 0.90</text>
+<text x="16" y="338" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#9b4a3f">a number with no empirical meaning</text>
+<rect x="460.0" y="86" width="420.0" height="272" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2"/>
+<text x="476.0" y="110" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">VERDICT COMPOSITION</text>
+<text x="476.0" y="130" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">each detector owns its threshold</text>
+<rect x="476.0" y="152" width="150" height="32" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="486.0" y="173" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">rules</text>
+<rect x="640.0" y="152" width="96" height="32" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1"/>
+<text x="688.0" y="173" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f" text-anchor="middle">flagged</text>
+<text x="750.0" y="173" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">own threshold</text>
+<rect x="476.0" y="196" width="150" height="32" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="486.0" y="217" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">classifier</text>
+<rect x="640.0" y="196" width="96" height="32" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="688.0" y="217" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b" text-anchor="middle">clear</text>
+<text x="750.0" y="217" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">own threshold</text>
+<rect x="476.0" y="240" width="150" height="32" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="486.0" y="261" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">judge</text>
+<rect x="640.0" y="240" width="96" height="32" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="688.0" y="261" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b" text-anchor="middle">abstain</text>
+<text x="750.0" y="261" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">own threshold</text>
+<line x1="476.0" y1="292" x2="864.0" y2="292" stroke="#e8e8e8"/>
+<text x="476.0" y="316" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11.5" fill="#1a1a1a">WEIGHTED: fire if a high-precision detector flags</text>
+<text x="476.0" y="338" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">policy you can write down, review and audit</text>
+<rect x="0" y="374" width="880" height="44" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="16" y="392" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">THE RULE THAT MAKES OR BREAKS AN ENSEMBLE</text>
+<text x="16" y="410" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">Independence. Three regex variants over one keyword list are one detector with three names, and their agreement is not evidence.</text>
+<line x1="0" y1="422" x2="880" y2="422" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="442" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">Verdict composition is the default. Score fusion is an optimisation to reach for once the labelled data justifies it, never before.</text>
+</svg>

--- a/public/assets/diagrams/arch-002-techniques.svg
+++ b/public/assets/diagrams/arch-002-techniques.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="436" viewBox="0 0 880 436" role="img" aria-label="Four detection techniques on one axis and two sourcing models on an independent axis">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="436" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">Four techniques, two sourcing models</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">Technique and sourcing are independent axes. A managed service is not a fifth technique.</text>
+<rect x="0.0" y="88" width="209.5" height="236" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2"/>
+<rect x="0.0" y="88" width="209.5" height="30" fill="#1a1a1a"/>
+<text x="104.75" y="108" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#fafaf8" text-anchor="middle" letter-spacing="0.8">RULES</text>
+<text x="12.0" y="138" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">regex, keyword lists,</text>
+<text x="12.0" y="155" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">structural checks</text>
+<text x="12.0" y="182" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">RIGHT FOR</text>
+<text x="12.0" y="199" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">structured, format-defined data:</text>
+<text x="12.0" y="215" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">account numbers, keys, cards</text>
+<text x="12.0" y="241" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">FAILS BY</text>
+<text x="12.0" y="258" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">evadable by anyone who</text>
+<text x="12.0" y="274" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">knows the pattern exists</text>
+<line x1="12.0" y1="294" x2="197.5" y2="294" stroke="#e8e8e8"/>
+<text x="12.0" y="312" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">COST</text>
+<text x="197.5" y="313" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a" text-anchor="end">negligible</text>
+<rect x="223.5" y="88" width="209.5" height="236" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2"/>
+<rect x="223.5" y="88" width="209.5" height="30" fill="#1a1a1a"/>
+<text x="328.25" y="108" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#fafaf8" text-anchor="middle" letter-spacing="0.8">CLASSICAL NLP</text>
+<text x="235.5" y="138" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">NER, part of speech,</text>
+<text x="235.5" y="155" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">corpus similarity</text>
+<text x="235.5" y="182" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">RIGHT FOR</text>
+<text x="235.5" y="199" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">unstructured entities:</text>
+<text x="235.5" y="215" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">names, addresses, dates of birth</text>
+<text x="235.5" y="241" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">FAILS BY</text>
+<text x="235.5" y="258" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">no context. it finds a name,</text>
+<text x="235.5" y="274" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">not whether it is a disclosure</text>
+<line x1="235.5" y1="294" x2="421.0" y2="294" stroke="#e8e8e8"/>
+<text x="235.5" y="312" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">COST</text>
+<text x="421.0" y="313" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a" text-anchor="end">low</text>
+<rect x="447.0" y="88" width="209.5" height="236" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2"/>
+<rect x="447.0" y="88" width="209.5" height="30" fill="#1a1a1a"/>
+<text x="551.75" y="108" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#fafaf8" text-anchor="middle" letter-spacing="0.8">TRAINED CLASSIFIER</text>
+<text x="459.0" y="138" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">small supervised model</text>
+<text x="459.0" y="155" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">on labelled examples</text>
+<text x="459.0" y="182" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">RIGHT FOR</text>
+<text x="459.0" y="199" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">high volume, where you</text>
+<text x="459.0" y="215" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">already have labelled data</text>
+<text x="459.0" y="241" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">FAILS BY</text>
+<text x="459.0" y="258" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">decays as attacks shift;</text>
+<text x="459.0" y="274" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">confident outside its</text>
+<text x="459.0" y="290" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">training distribution</text>
+<line x1="459.0" y1="294" x2="644.5" y2="294" stroke="#e8e8e8"/>
+<text x="459.0" y="312" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">COST</text>
+<text x="644.5" y="313" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a" text-anchor="end">low at inference</text>
+<rect x="670.5" y="88" width="209.5" height="236" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2"/>
+<rect x="670.5" y="88" width="209.5" height="30" fill="#1a1a1a"/>
+<text x="775.25" y="108" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#fafaf8" text-anchor="middle" letter-spacing="0.8">LLM AS JUDGE</text>
+<text x="682.5" y="138" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">a model prompted against</text>
+<text x="682.5" y="155" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">a written policy</text>
+<text x="682.5" y="182" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">RIGHT FOR</text>
+<text x="682.5" y="199" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">nuanced policy that</text>
+<text x="682.5" y="215" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">changes without retraining</text>
+<text x="682.5" y="241" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">FAILS BY</text>
+<text x="682.5" y="258" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">non-deterministic, injectable,</text>
+<text x="682.5" y="274" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">and the most expensive per call</text>
+<line x1="682.5" y1="294" x2="868.0" y2="294" stroke="#e8e8e8"/>
+<text x="682.5" y="312" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">COST</text>
+<text x="868.0" y="313" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a" text-anchor="end">high</text>
+<text x="0" y="76" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">TECHNIQUE  ·  HOW THE JUDGEMENT IS MADE</text>
+<text x="0" y="344" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">SOURCING  ·  WHO RUNS IT  ·  CROSSES ALL FOUR</text>
+<rect x="0" y="354" width="880" height="34" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<line x1="440.0" y1="354" x2="440.0" y2="388" stroke="#e8e8e8"/>
+<text x="220.0" y="376" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a" text-anchor="middle">self-hosted: you own the technique, the tuning and the audit</text>
+<text x="660.0" y="376" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#9b4a3f" text-anchor="middle">managed service: a technique you did not choose, behind an API</text>
+<line x1="104.75" y1="324" x2="104.75" y2="350" stroke="#e8e8e8" stroke-width="1" stroke-dasharray="3 3"/>
+<line x1="328.25" y1="324" x2="328.25" y2="350" stroke="#e8e8e8" stroke-width="1" stroke-dasharray="3 3"/>
+<line x1="551.75" y1="324" x2="551.75" y2="350" stroke="#e8e8e8" stroke-width="1" stroke-dasharray="3 3"/>
+<line x1="775.25" y1="324" x2="775.25" y2="350" stroke="#e8e8e8" stroke-width="1" stroke-dasharray="3 3"/>
+<line x1="0" y1="406" x2="880" y2="406" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="426" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">Choose the technique from the question, then choose sourcing separately on residency, auditability and differentiation.</text>
+</svg>

--- a/public/assets/diagrams/arch-003-base-rate.svg
+++ b/public/assets/diagrams/arch-003-base-rate.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="450" viewBox="0 0 880 450" role="img" aria-label="Base rate arithmetic: a 95 percent recall detector with a 1 percent false positive rate is 8.7 percent precise against a rare attack">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="450" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">Why a good detector is wrong nine times out of ten</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">95% recall, 1% false positive rate, one attack per thousand requests. Figures stipulated, not measured.</text>
+<text x="0" y="78" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">100,000 REQUESTS</text>
+<rect x="0" y="88" width="880" height="34" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<rect x="0" y="88" width="4" height="34" fill="#9b4a3f"/>
+<text x="14" y="110" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">99,900 benign</text>
+<line x1="2.0" y1="122" x2="2.0" y2="138" stroke="#9b4a3f" stroke-width="1.2"/>
+<text x="4" y="152" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#9b4a3f">100 actual attacks  (0.1% base rate)</text>
+<text x="0" y="180" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">caught</text>
+<text x="120" y="180" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12.5" fill="#6b6b6b">100 x 0.95</text>
+<text x="250" y="180" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13" fill="#9b4a3f">= 95</text>
+<text x="320" y="180" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b" font-style="italic">true positives</text>
+<text x="0" y="214" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">false alarms</text>
+<text x="120" y="214" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12.5" fill="#6b6b6b">99,900 x 0.01</text>
+<text x="250" y="214" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13" fill="#1a1a1a">= 999</text>
+<text x="320" y="214" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b" font-style="italic">false positives</text>
+<text x="0" y="246" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">WHAT REACHES THE REVIEW QUEUE  ·  1,094 ALERTS</text>
+<rect x="0" y="258" width="880" height="46" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<rect x="0" y="258" width="76.41681901279708" height="46" fill="#9b4a3f"/>
+<text x="90.41681901279708" y="278" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">999 false positives</text>
+<text x="90.41681901279708" y="296" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b" font-style="italic">91% of everything this detector flags is wrong</text>
+<line x1="38.20840950639854" y1="304" x2="38.20840950639854" y2="318" stroke="#9b4a3f" stroke-width="1.2"/>
+<text x="0" y="332" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#9b4a3f">95 real</text>
+<rect x="0" y="356" width="880" height="52" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.2"/>
+<text x="18" y="378" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="14" fill="#9b4a3f">precision = 95 / (95 + 999) = 8.7%</text>
+<text x="18" y="398" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">About 33 hours of review work per 100,000 requests to find 95 real events.</text>
+<line x1="0" y1="420" x2="880" y2="420" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="440" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">Precision is not a property of the detector. It is a property of the detector meeting your traffic.</text>
+</svg>

--- a/public/assets/diagrams/arch-003-threshold.svg
+++ b/public/assets/diagrams/arch-003-threshold.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="470" viewBox="0 0 880 470" role="img" aria-label="A threshold is a statement of how much worse a missed attack is than a false alarm, and it differs per category">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="470" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">The threshold is a cost decision, not a tuning parameter</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">Two categories, cost ratios four orders of magnitude apart. Ratios illustrative; yours are the ones that count.</text>
+<rect x="0.0" y="92" width="420.0" height="266" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2"/>
+<rect x="0.0" y="92" width="420.0" height="28" fill="#1a1a1a"/>
+<text x="14.0" y="111" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11.5" fill="#fafaf8">pii_in_response</text>
+<text x="14.0" y="142" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">COST OF A MISS</text>
+<text x="14.0" y="158" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">regulatory disclosure,</text>
+<text x="14.0" y="174" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">reportable</text>
+<text x="14.0" y="198" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">COST OF A FALSE ALARM</text>
+<text x="14.0" y="214" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">one redacted field,</text>
+<text x="14.0" y="230" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">user re-asks</text>
+<text x="14.0" y="260" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">ratio</text>
+<text x="64.0" y="261" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="15" fill="#9b4a3f">~500:1</text>
+<line x1="14.0" y1="284" x2="406.0" y2="284" stroke="#e8e8e8" stroke-width="3"/>
+<line x1="100.24" y1="273" x2="100.24" y2="295" stroke="#9b4a3f" stroke-width="2.4"/>
+<text x="14.0" y="308" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b">low threshold</text>
+<text x="406.0" y="308" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="end">high threshold</text>
+<text x="14.0" y="342" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11.5" fill="#9b4a3f">tune for RECALL</text>
+<rect x="460.0" y="92" width="420.0" height="266" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2"/>
+<rect x="460.0" y="92" width="420.0" height="28" fill="#1a1a1a"/>
+<text x="474.0" y="111" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11.5" fill="#fafaf8">block_user_request</text>
+<text x="474.0" y="142" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">COST OF A MISS</text>
+<text x="474.0" y="158" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">one attack proceeds</text>
+<text x="474.0" y="174" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">to the next control</text>
+<text x="474.0" y="198" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">COST OF A FALSE ALARM</text>
+<text x="474.0" y="214" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">legitimate user blocked,</text>
+<text x="474.0" y="230" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">trust damage</text>
+<text x="474.0" y="260" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">ratio</text>
+<text x="524.0" y="261" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="15" fill="#9b4a3f">~1:20</text>
+<line x1="474.0" y1="284" x2="866.0" y2="284" stroke="#e8e8e8" stroke-width="3"/>
+<line x1="787.6" y1="273" x2="787.6" y2="295" stroke="#9b4a3f" stroke-width="2.4"/>
+<text x="474.0" y="308" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b">low threshold</text>
+<text x="866.0" y="308" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#6b6b6b" text-anchor="end">high threshold</text>
+<text x="474.0" y="342" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11.5" fill="#9b4a3f">tune for PRECISION</text>
+<rect x="0" y="378" width="880" height="44" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="16" y="396" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">ONE THRESHOLD PER CATEGORY, NEVER ONE PER SYSTEM</text>
+<text x="16" y="414" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">A single global dial forces the same cost ratio onto a redaction and a hard block. Such systems end up tuned for whoever complained last.</text>
+<line x1="0" y1="440" x2="880" y2="440" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="460" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">The ratio gives you the objective. Turning it into a number needs the prevalence and a measured precision-recall curve on that population.</text>
+</svg>

--- a/public/assets/diagrams/arch-004-action-grid.svg
+++ b/public/assets/diagrams/arch-004-action-grid.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="506" viewBox="0 0 880 506" role="img" aria-label="The action grid: reversal cost against confidence band, with exposure promoting a cell downward">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="506" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">Choosing the action by consequence, not by detector</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">The same verdict on a chat response and on a funds transfer are different decisions.</text>
+<text x="0" y="74" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">REVERSAL COST</text>
+<text x="214" y="74" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">CONFIDENCE BAND</text>
+<text x="367.0" y="96" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b" text-anchor="middle">near threshold</text>
+<text x="673.0" y="96" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b" text-anchor="middle">above threshold</text>
+<line x1="214" y1="104" x2="826" y2="104" stroke="#1a1a1a"/>
+<text x="0" y="146" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13.5" fill="#1a1a1a">free</text>
+<text x="0" y="166" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b" font-style="italic">chat response</text>
+<rect x="214.0" y="120" width="296.0" height="74" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="230.0" y="150" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13.5" fill="#1a1a1a">allow + record</text>
+<text x="230.0" y="170" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">monitor, do not interrupt</text>
+<rect x="520.0" y="120" width="296.0" height="74" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="536.0" y="150" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13.5" fill="#1a1a1a">redact or mask</text>
+<text x="536.0" y="170" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">fix it silently, log it</text>
+<text x="0" y="242" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13.5" fill="#1a1a1a">expensive</text>
+<text x="0" y="262" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b" font-style="italic">shared doc, downstream sync</text>
+<rect x="214.0" y="216" width="296.0" height="74" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="230.0" y="246" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13.5" fill="#1a1a1a">mask + record</text>
+<text x="230.0" y="266" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">keep the flow, flag it</text>
+<rect x="520.0" y="216" width="296.0" height="74" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="536.0" y="246" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13.5" fill="#1a1a1a">escalate for review</text>
+<text x="536.0" y="266" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">async, the task resumes</text>
+<text x="0" y="338" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13.5" fill="#1a1a1a">impossible</text>
+<text x="0" y="358" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b" font-style="italic">payment, delete</text>
+<rect x="214.0" y="312" width="296.0" height="74" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.2"/>
+<text x="230.0" y="342" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13.5" fill="#9b4a3f">require approval</text>
+<text x="230.0" y="362" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">a human in the path</text>
+<rect x="520.0" y="312" width="296.0" height="74" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.2"/>
+<text x="536.0" y="342" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13.5" fill="#9b4a3f">block</text>
+<text x="536.0" y="362" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">refuse, and escalate</text>
+<line x1="864" y1="130" x2="864" y2="376" stroke="#9b4a3f" stroke-width="1.4" marker-end="url(#arb)"/>
+<text transform="rotate(-90 856 256.0)" x="856" y="256.0" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10" fill="#9b4a3f" text-anchor="middle" letter-spacing="1.4">EXPOSURE PROMOTES</text>
+<rect x="0" y="408" width="880" height="50" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="16" y="429" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">No cell blocks a free-to-reverse operation at low confidence: that is the most user pain for the least risk reduction.</text>
+<text x="16" y="448" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">Human approval sits where the act cannot be undone and the system is genuinely unsure, which is the only place a human's time is well spent.</text>
+<line x1="0" y1="476" x2="880" y2="476" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="496" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">Reversal cost, exposure and blast radius are declared in the tool registry. None can be recovered from the text at runtime.</text>
+</svg>

--- a/public/assets/diagrams/arch-004-decision-service.svg
+++ b/public/assets/diagrams/arch-004-decision-service.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="440" viewBox="0 0 880 440" role="img" aria-label="The decision service: verdicts in, versioned policy loaded as data, one action out, one decision record written">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="440" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">Policy is data the service loads, not conditionals compiled into it</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">It changes more often than the code, is reviewed by people who do not read code, and needs an audit history.</text>
+<text x="0" y="90" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">VERDICTS IN</text>
+<rect x="0" y="100" width="140" height="30" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="12" y="120" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">rules</text>
+<rect x="0" y="140" width="140" height="30" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="12" y="160" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">classifier</text>
+<rect x="0" y="180" width="140" height="30" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="12" y="200" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">judge</text>
+<line x1="146" y1="155" x2="192" y2="155" stroke="#6b6b6b" stroke-width="1.3" marker-end="url(#arg)"/>
+<rect x="200" y="94" width="300" height="142" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.4"/>
+<rect x="200" y="94" width="300" height="28" fill="#1a1a1a"/>
+<text x="214" y="113" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#fafaf8" letter-spacing="1">DECISION SERVICE</text>
+<text x="214" y="144" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">category + band + tool properties</text>
+<text x="214" y="164" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">resolved against the loaded policy</text>
+<text x="214" y="192" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">most specific rule wins</text>
+<text x="214" y="212" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">ties are an error at validation time</text>
+<rect x="540" y="94" width="340" height="142" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="554" y="114" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">POLICY AS VERSIONED DATA</text>
+<text x="554" y="138" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f">validate</text>
+<text x="626" y="138" font-family="Georgia,'EB Garamond',serif" font-size="11.5" fill="#1a1a1a">schema + conflicts, in CI</text>
+<text x="554" y="162" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f">rollout</text>
+<text x="626" y="162" font-family="Georgia,'EB Garamond',serif" font-size="11.5" fill="#1a1a1a">atomic, one version per request</text>
+<text x="554" y="186" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f">rollback</text>
+<text x="626" y="186" font-family="Georgia,'EB Garamond',serif" font-size="11.5" fill="#1a1a1a">a pointer change, not an edit</text>
+<text x="554" y="210" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f">on failure</text>
+<text x="626" y="210" font-family="Georgia,'EB Garamond',serif" font-size="11.5" fill="#1a1a1a">last-known-good, never empty</text>
+<line x1="534" y1="164" x2="508" y2="164" stroke="#9b4a3f" stroke-width="1.3" marker-end="url(#arb)"/>
+<text x="0" y="260" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">ONE ACTION OUT</text>
+<rect x="0.0" y="272" width="138.33333333333334" height="34" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="69.16666666666667" y="294" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#1a1a1a" text-anchor="middle">allow</text>
+<rect x="148.33333333333334" y="272" width="138.33333333333334" height="34" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="217.5" y="294" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#1a1a1a" text-anchor="middle">block</text>
+<rect x="296.6666666666667" y="272" width="138.33333333333334" height="34" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="365.83333333333337" y="294" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#1a1a1a" text-anchor="middle">redact</text>
+<rect x="445.0" y="272" width="138.33333333333334" height="34" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="514.1666666666666" y="294" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#1a1a1a" text-anchor="middle">mask</text>
+<rect x="593.3333333333334" y="272" width="138.33333333333334" height="34" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="662.5" y="294" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#1a1a1a" text-anchor="middle">escalate</text>
+<rect x="741.6666666666667" y="272" width="138.33333333333334" height="34" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="810.8333333333334" y="294" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#1a1a1a" text-anchor="middle">require approval</text>
+<text x="0" y="324" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#6b6b6b">Allow and block get built first because they need no product design. The middle four are the ones that repay it.</text>
+<rect x="0" y="344" width="880" height="66" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.2"/>
+<text x="16" y="364" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">AND ONE DECISION RECORD, ALWAYS</text>
+<text x="16" y="384" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">request_id  ·  chokepoint  ·  principal  ·  detectors_run and versions  ·  verdicts  ·  policy_version</text>
+<text x="16" y="400" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">action  ·  degraded  ·  latency_ms  ·  outcome  ·  override: who, when, stated reason</text>
+<line x1="0" y1="416" x2="880" y2="416" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="434" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">A service that starts with no policy because the config store was unreachable is an open gate that reports itself healthy.</text>
+</svg>

--- a/src/ch09_metacognition/__init__.py
+++ b/src/ch09_metacognition/__init__.py
@@ -1,0 +1,5 @@
+"""Chapter 9: Metacognition and Self-Reflection.
+
+Introspection (detecting problems) and adaptation (responding to them),
+built as independently testable components that wrap an existing agent loop.
+"""

--- a/src/ch09_metacognition/adaptive_agent.py
+++ b/src/ch09_metacognition/adaptive_agent.py
@@ -1,0 +1,204 @@
+"""The AdaptiveAgent: observe, think, act, reflect.
+
+The reflect step consults the monitor and the budget tracker. Based on the
+assessment the agent continues, switches strategy, stops early, or (after the
+loop) self-corrects once and escalates if that fails.
+
+The metacognitive machinery wraps existing agent logic. You do not rewrite the
+agent -- you add a monitor, define strategies, add a budget tracker, and insert
+the reflect step.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from src.ch09_metacognition.monitor import BudgetTracker, MetacognitiveMonitor, StepAssessment
+from src.shared.model_client import ModelClient
+from src.shared.types import AgentResponse, Citation, CompletionRequest, Message, Role
+
+CORRECTION_PROMPT = """Your previous answer scored low on evidence grounding.
+Rewrite so that every factual claim directly references the evidence.
+If the evidence does not support a claim, remove it or note the gap."""
+
+ANTI_SYCOPHANCY_PROMPT = """If your evidence supports your original answer, say so clearly.
+Do not add information that is not in the evidence just because
+you were asked to reconsider."""
+
+
+@dataclass
+class Strategy:
+    """A named retrieval approach the router can select."""
+
+    name: str
+    search: Callable[[str], list[Citation]]
+
+
+@dataclass
+class StrategyRouter:
+    """Bounded exploration: the agent selects from a ranked list the engineer defined.
+
+    An agent that invents strategies is unpredictable. An agent that selects
+    from a ranked list is auditable.
+    """
+
+    strategies: list[Strategy]
+    index: int = 0
+    switches: list[str] = field(default_factory=list)
+
+    @property
+    def current(self) -> Strategy:
+        return self.strategies[self.index]
+
+    @property
+    def exhausted(self) -> bool:
+        return self.index >= len(self.strategies) - 1
+
+    def switch(self) -> Strategy | None:
+        """Advance to the next untried strategy, or None if all are exhausted."""
+        if self.exhausted:
+            return None
+        self.index += 1
+        self.switches.append(self.current.name)
+        return self.current
+
+    def reset(self) -> None:
+        self.index = 0
+        self.switches.clear()
+
+
+def should_stop_early(
+    assessment: StepAssessment,
+    steps_remaining: int,
+    min_quality: float = 0.5,
+    estimated_step_cost: float = 1500.0,
+) -> bool:
+    """Stop when further steps would cost tokens without improving the answer.
+
+    `steps_remaining` matters. On step 4 of 5 one more step is cheap. On step 2
+    of 10, eight unnecessary steps are expensive.
+    """
+    # Near-zero gain with many steps left = pure waste
+    if assessment.marginal_gain < 0.05 and steps_remaining > 2:
+        return True
+    # Good-enough quality + low gain = done
+    if assessment.quality_score >= min_quality and assessment.marginal_gain < 0.1:
+        return True
+    # Budget too low for another productive step
+    if not assessment.budget_remaining > estimated_step_cost:
+        return True
+    return False
+
+
+class AdaptiveAgent:
+    """An agent whose loop has four steps: observe, think, act, reflect."""
+
+    def __init__(
+        self,
+        client: ModelClient,
+        router: StrategyRouter,
+        monitor: MetacognitiveMonitor | None = None,
+        budget: BudgetTracker | None = None,
+        max_steps: int = 5,
+        min_quality: float = 0.5,
+    ) -> None:
+        self.client = client
+        self.router = router
+        self.budget = budget or BudgetTracker(total_budget_tokens=20_000)
+        self.monitor = monitor or MetacognitiveMonitor(budget=self.budget, max_steps=max_steps)
+        self.monitor.budget = self.budget
+        self.max_steps = max_steps
+        self.min_quality = min_quality
+        self.assessments: list[StepAssessment] = []
+        self.stop_reason: str = ""
+
+    async def run(self, query: str) -> AgentResponse:
+        citations: list[Citation] = []
+        answer = ""
+        steps = 0
+        self.stop_reason = "completed"
+
+        for step in range(1, self.max_steps + 1):
+            steps = step
+            strategy = self.router.current
+
+            # observe
+            citations = strategy.search(query)
+            observation = " ".join(c.text for c in citations)
+
+            # think + act
+            answer = await self._draft(query, citations)
+
+            # reflect
+            assessment = self.monitor.assess(
+                step=step,
+                tool=strategy.name,
+                arguments={"query": query},
+                observation=observation,
+                reasoning=answer,
+                answer=answer,
+                citations=citations,
+            )
+            self.assessments.append(assessment)
+
+            if assessment.is_looping:
+                if self.router.switch() is not None:
+                    self.monitor.detector.reset()
+                    continue
+                self.stop_reason = "all strategies exhausted"
+                break
+
+            steps_remaining = self.max_steps - step
+            if should_stop_early(assessment, steps_remaining, self.min_quality):
+                self.stop_reason = "early stop: " + assessment.reason
+                break
+            if not assessment.should_continue:
+                self.stop_reason = assessment.reason
+                break
+
+        report = self.monitor.quality(answer, citations)
+
+        # One self-correction attempt, never a loop.
+        if report.score < self.min_quality and citations:
+            answer = await self._correct(query, citations, answer)
+            report = self.monitor.quality(answer, citations)
+
+        escalated = report.score < self.min_quality
+        return AgentResponse(
+            answer=answer,
+            citations=citations,
+            confidence=round(min(max(report.score, 0.0), 1.0), 4),
+            escalated=escalated,
+            escalation_reason=("quality below threshold after correction" if escalated else None),
+            steps_taken=steps,
+            latency_ms=0.0,
+        )
+
+    async def _draft(self, query: str, citations: list[Citation]) -> str:
+        messages = [
+            Message(role=Role.SYSTEM, content=self.budget.budget_summary()),
+            Message(role=Role.USER, content=self._prompt(query, citations)),
+        ]
+        response = await self.client.complete(CompletionRequest(messages=messages))
+        self._charge(response)
+        return response.content or ""
+
+    async def _correct(self, query: str, citations: list[Citation], previous: str) -> str:
+        messages = [
+            Message(role=Role.SYSTEM, content=CORRECTION_PROMPT),
+            Message(role=Role.USER, content=f"{self._prompt(query, citations)}\n\n{previous}"),
+        ]
+        response = await self.client.complete(CompletionRequest(messages=messages, temperature=0.0))
+        self._charge(response)
+        return response.content or previous
+
+    def _charge(self, response) -> None:
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            self.budget.consume(usage.total_tokens or 0)
+
+    @staticmethod
+    def _prompt(query: str, citations: list[Citation]) -> str:
+        evidence = "\n".join(f"[{i + 1}] {c.text}" for i, c in enumerate(citations))
+        return f"Question: {query}\n\nEvidence:\n{evidence}\n\nAnswer using only the evidence."

--- a/src/ch09_metacognition/monitor.py
+++ b/src/ch09_metacognition/monitor.py
@@ -1,0 +1,149 @@
+"""The MetacognitiveMonitor and the budget tracker it consults.
+
+The monitor combines the detectors into one `StepAssessment` per step. It is a
+composition of simple parts: each detector is independently testable, and
+adding a new one (latency, model error rate) is adding a component and wiring
+it in.
+
+One design rule worth stating out loud: the quality checker does not feed the
+`should_continue` decision. Quality is an output property, not a loop-control
+signal. A low quality score means "try to improve the output," not "stop
+looping." Introspection detects; adaptation decides.
+
+`StepAssessment` and `BudgetTracker` are dataclasses here to match the form
+printed in the book. The other types in this package are Pydantic models,
+following the rest of the repository.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.ch09_metacognition.progress_tracker import ProgressTracker
+from src.ch09_metacognition.quality_checker import OutputQualityChecker, QualityReport
+from src.ch09_metacognition.repetition_detector import RepetitionDetector, StepRecord
+from src.shared.types import Citation
+
+
+@dataclass
+class StepAssessment:
+    step: int
+    is_looping: bool
+    quality_score: float
+    marginal_gain: float
+    budget_remaining: float  # tokens or cost remaining
+    should_continue: bool
+    reason: str
+
+
+@dataclass
+class BudgetTracker:
+    total_budget_tokens: int
+    consumed_tokens: int = 0
+    total_budget_usd: float = 0.10
+    consumed_usd: float = 0.0
+
+    @property
+    def remaining_tokens(self) -> int:
+        return self.total_budget_tokens - self.consumed_tokens
+
+    @property
+    def remaining_usd(self) -> float:
+        return self.total_budget_usd - self.consumed_usd
+
+    def can_afford_step(self, estimated_step_tokens: int) -> bool:
+        return self.remaining_tokens > estimated_step_tokens
+
+    def consume(self, tokens: int, usd: float = 0.0) -> None:
+        self.consumed_tokens += tokens
+        self.consumed_usd += usd
+
+    def budget_summary(self) -> str:
+        """Inject this into the agent's context each step."""
+        return (
+            f"Budget: {self.remaining_tokens} tokens remaining "
+            f"(${self.remaining_usd:.3f} of ${self.total_budget_usd:.2f}). "
+            f"Use remaining budget wisely."
+        )
+
+
+@dataclass
+class MetacognitiveMonitor:
+    """Runs every detector after each step and returns one assessment."""
+
+    detector: RepetitionDetector = field(default_factory=RepetitionDetector)
+    tracker: ProgressTracker = field(default_factory=ProgressTracker)
+    checker: OutputQualityChecker = field(default_factory=OutputQualityChecker)
+    budget: BudgetTracker | None = None
+    max_steps: int = 5
+    estimated_step_tokens: int = 1500
+
+    def assess(
+        self,
+        step: int,
+        tool: str,
+        arguments: dict,
+        observation: str = "",
+        reasoning: str = "",
+        answer: str = "",
+        citations: list[Citation] | None = None,
+    ) -> StepAssessment:
+        verdict = self.detector.record(
+            StepRecord(
+                tool=tool,
+                arguments=arguments,
+                observation=observation,
+                reasoning=reasoning,
+                answer=answer,
+            )
+        )
+        gain = self.tracker.record(observation or answer).gain
+        quality = self.quality(answer, citations)
+
+        remaining = float(self.budget.remaining_tokens) if self.budget else float("inf")
+        affordable = (
+            self.budget.can_afford_step(self.estimated_step_tokens) if self.budget else True
+        )
+
+        if verdict.is_looping:
+            return StepAssessment(
+                step, True, quality.score, gain, remaining, False, f"looping: {verdict.detail}"
+            )
+        if not affordable:
+            return StepAssessment(
+                step,
+                False,
+                quality.score,
+                gain,
+                remaining,
+                False,
+                "budget exhausted for another step",
+            )
+        if step >= self.max_steps:
+            return StepAssessment(
+                step,
+                False,
+                quality.score,
+                gain,
+                remaining,
+                False,
+                f"step limit {self.max_steps} reached",
+            )
+        if self.tracker.is_stale():
+            return StepAssessment(
+                step,
+                False,
+                quality.score,
+                gain,
+                remaining,
+                False,
+                f"marginal gain {gain:.2f} below threshold",
+            )
+        return StepAssessment(step, False, quality.score, gain, remaining, True, "progressing")
+
+    def quality(self, answer: str, citations: list[Citation] | None = None) -> QualityReport:
+        return self.checker.check(answer, citations or [])
+
+    def reset(self) -> None:
+        self.detector.reset()
+        self.tracker.reset()

--- a/src/ch09_metacognition/progress_tracker.py
+++ b/src/ch09_metacognition/progress_tracker.py
@@ -1,0 +1,105 @@
+"""Diminishing-returns detection.
+
+Counts how many words in each step's output have not appeared in any previous
+step. When the ratio of new words to total words falls below the threshold,
+the step is stale: it cost a full model call and added nothing.
+
+The gain curve is worth keeping. If it flattens after step 2 and your budget
+is 5, you are paying for three steps you do not need.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+STOP_WORDS = frozenset(
+    """a an and are as at be by for from has have in is it its of on or that the
+    this to was were will with""".split()
+)
+
+
+def record_step(seen_content: set[str], new_content: str, threshold: float = 0.1):
+    """The version printed in the book -- state passed in, tuple returned."""
+    words = set(new_content.lower().split())
+    new_words = words - seen_content
+    gain = len(new_words) / len(words) if words else 0.0
+    seen_content.update(words)
+    return gain, gain < threshold  # (gain_value, is_stale)
+
+
+class StepGain(BaseModel):
+    """Marginal information gain for a single step."""
+
+    step: int
+    gain: float
+    is_stale: bool
+    new_words: int
+    total_words: int
+
+
+class ProgressTracker:
+    """Stateful wrapper around `record_step` that keeps the gain curve."""
+
+    def __init__(self, threshold: float = 0.1, ignore_stop_words: bool = True) -> None:
+        self.threshold = threshold
+        self.ignore_stop_words = ignore_stop_words
+        self.seen: set[str] = set()
+        self.gains: list[StepGain] = []
+
+    def reset(self) -> None:
+        self.seen.clear()
+        self.gains.clear()
+
+    def _tokenize(self, content: str) -> set[str]:
+        words = {w.strip(".,;:!?()[]\"'") for w in content.lower().split()}
+        words.discard("")
+        if self.ignore_stop_words:
+            words -= STOP_WORDS
+        return words
+
+    def record(self, content: str) -> StepGain:
+        words = self._tokenize(content)
+        new_words = words - self.seen
+        gain = len(new_words) / len(words) if words else 0.0
+        self.seen.update(words)
+        entry = StepGain(
+            step=len(self.gains) + 1,
+            gain=gain,
+            is_stale=gain < self.threshold,
+            new_words=len(new_words),
+            total_words=len(words),
+        )
+        self.gains.append(entry)
+        return entry
+
+    @property
+    def total_gain_curve(self) -> list[float]:
+        return [g.gain for g in self.gains]
+
+    @property
+    def last_gain(self) -> float:
+        return self.gains[-1].gain if self.gains else 1.0
+
+    def is_stale(self, window: int = 1) -> bool:
+        """True when the last `window` steps all fell below the threshold."""
+        if len(self.gains) < window:
+            return False
+        return all(g.is_stale for g in self.gains[-window:])
+
+    def suggested_step_budget(self) -> int:
+        """The step after which the curve flattened -- calibrate your budget here."""
+        for entry in self.gains:
+            if entry.is_stale:
+                return max(1, entry.step - 1)
+        return len(self.gains)
+
+
+class GainCurve(BaseModel):
+    """Serializable view of a tracker, for logging alongside a trace."""
+
+    threshold: float
+    gains: list[StepGain] = Field(default_factory=list)
+
+    @classmethod
+    def from_tracker(cls, tracker: ProgressTracker) -> GainCurve:
+        return cls(threshold=tracker.threshold, gains=list(tracker.gains))

--- a/src/ch09_metacognition/quality_checker.py
+++ b/src/ch09_metacognition/quality_checker.py
@@ -1,0 +1,136 @@
+"""Heuristic output-quality scoring, run per request.
+
+Three dimensions:
+
+* citation coverage -- what share of factual sentences carry a citation
+* evidence overlap  -- what share of the answer's content words appear in the
+  retrieved evidence
+* hedging           -- whether the answer hedges when the evidence is thin,
+  and commits when the evidence is solid
+
+This is the cheap screen that runs on every request. It catches the obvious
+cases: fluent answers built from training data rather than from the evidence
+in front of them. It is not a grounding oracle. Layer a sampled evaluation
+harness behind it, and inference-time detection in front of it if you control
+the serving layer.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, Field
+
+from src.shared.types import Citation
+
+HEDGE_TERMS = frozenset(
+    [
+        "may",
+        "might",
+        "could",
+        "appears",
+        "suggests",
+        "likely",
+        "unclear",
+        "possibly",
+        "seems",
+        "insufficient",
+        "cannot determine",
+        "not stated",
+        "no evidence",
+    ]
+)
+
+CITATION_PATTERN = re.compile(r"\[\s*(?:\d+|[Dd]oc\s*\d+|[Ss]ource\s*\d+)\s*\]")
+
+STOP_WORDS = frozenset(
+    """a an and are as at be by for from has have in is it its of on or that the
+    this to was were will with we you they i""".split()
+)
+
+
+class QualityReport(BaseModel):
+    """Per-request quality assessment."""
+
+    score: float = 0.0
+    citation_coverage: float = 0.0
+    evidence_overlap: float = 0.0
+    hedging: float = 0.0
+    issues: list[str] = Field(default_factory=list)
+
+    @property
+    def is_grounded(self) -> bool:
+        return not self.issues
+
+
+def _sentences(text: str) -> list[str]:
+    parts = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()]
+    return parts
+
+
+def _content_words(text: str) -> set[str]:
+    words = {w.strip(".,;:!?()[]\"'").lower() for w in text.split()}
+    words.discard("")
+    return {w for w in words if w not in STOP_WORDS}
+
+
+class OutputQualityChecker:
+    """Scores an answer against the evidence that was supposed to support it."""
+
+    def __init__(
+        self,
+        coverage_weight: float = 0.45,
+        overlap_weight: float = 0.45,
+        hedging_weight: float = 0.10,
+        overlap_floor: float = 0.5,
+    ) -> None:
+        self.coverage_weight = coverage_weight
+        self.overlap_weight = overlap_weight
+        self.hedging_weight = hedging_weight
+        self.overlap_floor = overlap_floor
+
+    def check(self, answer: str, citations: list[Citation] | None = None) -> QualityReport:
+        citations = citations or []
+        sentences = _sentences(answer)
+        issues: list[str] = []
+
+        if not sentences:
+            return QualityReport(issues=["empty answer"])
+
+        cited = sum(1 for s in sentences if CITATION_PATTERN.search(s))
+        coverage = cited / len(sentences)
+
+        evidence_words: set[str] = set()
+        for c in citations:
+            evidence_words |= _content_words(c.text)
+        answer_words = _content_words(CITATION_PATTERN.sub("", answer))
+        overlap = len(answer_words & evidence_words) / len(answer_words) if answer_words else 0.0
+
+        hedged = sum(1 for s in sentences if any(t in s.lower() for t in HEDGE_TERMS))
+        hedging = hedged / len(sentences)
+
+        # Hedge when the evidence is thin; commit when it is solid.
+        thin_evidence = overlap < self.overlap_floor
+        appropriate = 1.0 if (thin_evidence and hedging > 0) or (not thin_evidence) else 0.0
+
+        if not citations:
+            issues.append("no evidence attached")
+        if coverage < 0.5:
+            issues.append(f"citation coverage {coverage:.2f} below 0.50")
+        if thin_evidence:
+            issues.append(f"evidence overlap {overlap:.2f} below {self.overlap_floor:.2f}")
+        if thin_evidence and hedging == 0.0:
+            issues.append("confident claims on thin evidence")
+
+        score = (
+            self.coverage_weight * coverage
+            + self.overlap_weight * overlap
+            + self.hedging_weight * appropriate
+        )
+        return QualityReport(
+            score=round(score, 4),
+            citation_coverage=round(coverage, 4),
+            evidence_overlap=round(overlap, 4),
+            hedging=round(hedging, 4),
+            issues=issues,
+        )

--- a/src/ch09_metacognition/repetition_detector.py
+++ b/src/ch09_metacognition/repetition_detector.py
@@ -1,0 +1,165 @@
+"""Loop detection for agent execution.
+
+Four layers, cheapest first:
+
+1. Exact match on (tool, arguments) -- catches the most expensive pattern.
+2. Action-sequence fingerprinting -- catches A/B alternation without progress.
+3. Semantic similarity between consecutive reasoning traces -- catches the
+   same question asked in different words.
+4. Output convergence -- the proposed answer has stopped changing.
+
+Layers 1 and 2 are pure hashing and run by default at near-zero cost.
+Layers 3 and 4 need an embedding function or answer text and only pay for
+themselves on agents running five or more steps.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def is_looping(history: Sequence[Any], threshold: int = 2) -> bool:
+    """Layer 1 in its smallest form -- the version printed in the book."""
+    if len(history) < threshold:
+        return False
+    recent = history[-threshold:]
+    return len(set(recent)) == 1  # all identical
+
+
+class StepRecord(BaseModel):
+    """One observed agent step, as seen by the detector."""
+
+    tool: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    observation: str = ""
+    reasoning: str = ""
+    answer: str = ""
+
+
+class RepetitionVerdict(BaseModel):
+    """Why the detector did or did not flag a loop."""
+
+    is_looping: bool = False
+    layer: str | None = None
+    detail: str = ""
+
+
+def fingerprint(tool: str, arguments: dict[str, Any]) -> str:
+    """Stable hash of a tool call. Argument order must not matter."""
+    payload = json.dumps({"tool": tool, "args": arguments}, sort_keys=True, default=str)
+    return hashlib.sha1(payload.encode()).hexdigest()[:12]
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
+    norm_a = sum(x * x for x in a) ** 0.5
+    norm_b = sum(y * y for y in b) ** 0.5
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return float(dot / (norm_a * norm_b))
+
+
+def _normalize_answer(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().lower())
+
+
+class RepetitionDetector:
+    """Layered loop detection over a running agent.
+
+    Feed every step to `record`. The returned verdict names the layer that
+    fired, which is what you want in a trace when you are explaining a
+    terminated run to somebody at 3 AM.
+    """
+
+    def __init__(
+        self,
+        exact_threshold: int = 2,
+        sequence_length: int = 2,
+        similarity_threshold: float = 0.93,
+        convergence_window: int = 2,
+        embed: Callable[[str], Sequence[float]] | None = None,
+    ) -> None:
+        self.exact_threshold = exact_threshold
+        self.sequence_length = sequence_length
+        self.similarity_threshold = similarity_threshold
+        self.convergence_window = convergence_window
+        self.embed = embed
+        self.steps: list[StepRecord] = []
+        self.fingerprints: list[str] = []
+
+    def reset(self) -> None:
+        self.steps.clear()
+        self.fingerprints.clear()
+
+    def record(self, step: StepRecord) -> RepetitionVerdict:
+        self.steps.append(step)
+        self.fingerprints.append(fingerprint(step.tool, step.arguments))
+        return self.check()
+
+    def check(self) -> RepetitionVerdict:
+        for layer in (
+            self._exact_match,
+            self._sequence_match,
+            self._semantic_match,
+            self._output_convergence,
+        ):
+            verdict = layer()
+            if verdict.is_looping:
+                return verdict
+        return RepetitionVerdict(detail="no repetition detected")
+
+    def _exact_match(self) -> RepetitionVerdict:
+        if is_looping(self.fingerprints, self.exact_threshold):
+            return RepetitionVerdict(
+                is_looping=True,
+                layer="exact_match",
+                detail=f"last {self.exact_threshold} tool calls identical",
+            )
+        return RepetitionVerdict()
+
+    def _sequence_match(self) -> RepetitionVerdict:
+        n = self.sequence_length
+        if len(self.fingerprints) < 2 * n:
+            return RepetitionVerdict()
+        tail = self.fingerprints[-2 * n :]
+        if tail[:n] == tail[n:] and len(set(tail)) > 1:
+            return RepetitionVerdict(
+                is_looping=True,
+                layer="sequence_fingerprint",
+                detail=f"{n}-step action sequence repeated without progress",
+            )
+        return RepetitionVerdict()
+
+    def _semantic_match(self) -> RepetitionVerdict:
+        if self.embed is None or len(self.steps) < 2:
+            return RepetitionVerdict()
+        previous, current = self.steps[-2].reasoning, self.steps[-1].reasoning
+        if not previous or not current:
+            return RepetitionVerdict()
+        similarity = cosine_similarity(self.embed(previous), self.embed(current))
+        if similarity >= self.similarity_threshold:
+            return RepetitionVerdict(
+                is_looping=True,
+                layer="semantic_similarity",
+                detail=f"consecutive reasoning similarity {similarity:.3f}",
+            )
+        return RepetitionVerdict()
+
+    def _output_convergence(self) -> RepetitionVerdict:
+        window = self.convergence_window + 1
+        answers = [s.answer for s in self.steps[-window:] if s.answer]
+        if len(answers) < window:
+            return RepetitionVerdict()
+        if len({_normalize_answer(a) for a in answers}) == 1:
+            return RepetitionVerdict(
+                is_looping=True,
+                layer="output_convergence",
+                detail=f"answer unchanged across {window} steps",
+            )
+        return RepetitionVerdict()

--- a/src/components/universal/ArchitectureDiagram.astro
+++ b/src/components/universal/ArchitectureDiagram.astro
@@ -8,12 +8,14 @@ interface Props {
   alt: string;
   caption?: string;
   traceIn?: boolean;
+  /** Break out past the reader column. Structural diagrams need the width. */
+  wide?: boolean;
 }
 
-const { src, alt, caption, traceIn = true } = Astro.props;
+const { src, alt, caption, traceIn = true, wide = false } = Astro.props;
 ---
 
-<figure class:list={['architecture', traceIn && 'architecture--trace-in']}>
+<figure class:list={['architecture', wide && 'architecture--wide', traceIn && 'architecture--trace-in']}>
   <img src={src} alt={alt} class="architecture__svg" loading="lazy" />
   {caption && <figcaption class="architecture__caption">{caption}</figcaption>}
 </figure>
@@ -27,6 +29,29 @@ const { src, alt, caption, traceIn = true } = Astro.props;
     border-radius: var(--radius-md);
   }
 
+  /* Breaks out symmetrically past the reader column; collapses back on narrow
+     viewports, where the width available is less than the column itself. */
+  .architecture--wide {
+    --wide: min(880px, calc(100vw - 3rem));
+    width: var(--wide);
+    margin-left: calc((100% - var(--wide)) / 2);
+  }
+
+  /* Below roughly 800px the diagram would scale down far enough to make its
+     labels unreadable, so let it keep a legible size and pan inside the frame
+     instead. The page itself never scrolls sideways. */
+  .architecture--wide {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+  }
+
+  .architecture--wide .architecture__svg { min-width: 720px; }
+
+  @media (max-width: 720px) {
+    .architecture--wide { padding: var(--space-3); }
+  }
+
   .architecture__svg {
     width: 100%;
     height: auto;
@@ -34,6 +59,8 @@ const { src, alt, caption, traceIn = true } = Astro.props;
   }
 
   .architecture__caption {
+    position: sticky;
+    left: 0;
     margin-top: var(--space-3);
     text-align: center;
     font-family: var(--font-mono);

--- a/src/content/architecture/001-the-control-plane.mdx
+++ b/src/content/architecture/001-the-control-plane.mdx
@@ -41,6 +41,7 @@ sources:
 ---
 
 import Callout from '~/components/universal/Callout.astro';
+import ArchitectureDiagram from '~/components/universal/ArchitectureDiagram.astro';
 import PullQuote from '~/components/universal/PullQuote.astro';
 import Footer3Col from '~/components/universal/Footer3Col.astro';
 
@@ -84,7 +85,6 @@ A chokepoint is a stage where the request is fully materialised and execution ca
  5  TOOL EXECUTION  a requested action, before it happens
  6  LOGGING         what gets written down, and who can read it
 ```
-
 Everything in the control layer is a choice about which of these you instrument, what you put there, and what you do when it fires. A system with controls only at 3 and 4 is a common starting configuration, and it is the one that leaves both retrieval-borne injection and tool-mediated harm uninstrumented.
 
 <Callout type="tip" label="The placement test">
@@ -94,6 +94,13 @@ For any control you are about to build, ask: is the evidence this detector needs
 ## What each chokepoint can see
 
 This is the part that decides your architecture. Each chokepoint has a different view of the truth, and the differences are not subtle.
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-001-chokepoints.svg"
+  alt="Six chokepoints down a single request path. Each row gives what that chokepoint can see and what it is blind to, with markers for whether it addresses information harm, action harm, both, or neither."
+  caption="Tool execution is the only chokepoint in both harm families. The prompt layer is in neither."
+/>
 
 **Upload** sees the full document, unhurried. This is the only chokepoint with no latency pressure, because ingestion is asynchronous. It is therefore the correct home for anything expensive: full-document classification, entity extraction across the whole text, structural analysis, a slow model. What it cannot see is who will eventually retrieve this document, or in what context. A document that is harmless for the team that uploaded it may be a leak the moment it is retrievable by another business unit.
 
@@ -172,6 +179,14 @@ Three honest limits.
 **The chokepoint model assumes a request path.** Batch pipelines, streaming ingestion, and background agents that run on a schedule do not have a clean request boundary, and the "principal" in whose name the work happens is often a service account with no meaningful entitlement. Those systems need the authority question answered at design time instead, because there is no runtime moment where a user's permissions are available to check against.
 
 **Six chokepoints is a simplification of multi-agent systems.** When one agent calls another, the second agent has its own full path, and the calling agent's output is the called agent's input. The chokepoints nest. A single-pass mental model will miss the case where agent A is authorized for an action, agent B is not, and B accomplishes it by asking A. That is the delegation problem, and it needs identity that survives the hop rather than a detector.
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-001-nested-paths.svg"
+  alt="An unauthorized agent's tool call opens an authorized agent's own six-chokepoint path, so the two sets of checks nest and each passes on its own."
+  caption="Each agent's six checks pass. The composition is what fails."
+/>
+
 
 **Placement improves the ceiling, not the floor.** Putting a detector at the right chokepoint means the evidence is present in its input. It does not mean the detector is any good. That is a measurement question, and measurement is where most guardrail programmes actually fail.
 

--- a/src/content/architecture/002-detector-architecture.mdx
+++ b/src/content/architecture/002-detector-architecture.mdx
@@ -37,6 +37,7 @@ sources:
 ---
 
 import Callout from '~/components/universal/Callout.astro';
+import ArchitectureDiagram from '~/components/universal/ArchitectureDiagram.astro';
 import PullQuote from '~/components/universal/PullQuote.astro';
 import Footer3Col from '~/components/universal/Footer3Col.astro';
 
@@ -59,6 +60,14 @@ Four techniques, each with a distinct cost profile and a distinct failure mode.
 **LLM-as-judge.** A model prompted to evaluate the input against a written policy. The slowest and most expensive per call, and the most flexible in one specific sense: you can express a nuanced policy in a paragraph and change it without retraining. Three weaknesses that matter. It is non-deterministic, so the same input can produce different verdicts. It is itself susceptible to injection, because you are feeding attacker-controlled text to a model and asking it a question. And it is expensive enough that you cannot run it on every request at the prompt layer without a latency conversation.
 
 Then the sourcing axis. **Managed safety services** from cloud and model vendors package one or more of the four techniques behind an API: good coverage of the commodity categories, maintained by someone else, and a real reduction in work. The costs are a network hop in the request path, a data-residency question that is not optional in a regulated environment, a model you cannot audit or tune, and a version that can change underneath you. The technique inside is usually undisclosed, which means you inherit its failure mode without being able to name it. Treat a managed service as a technique you did not choose rather than as a category of its own.
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-002-techniques.svg"
+  alt="Four detection techniques as columns with what each is right for, how each fails, and its cost, above a sourcing band that crosses all four."
+  caption="Technique and sourcing are independent. A managed service is one of the four with the sourcing decision already taken."
+/>
+
 
 <Callout type="tip" label="Matching technique to question">
 Structured and format-defined, use rules. Unstructured entities, use NLP. High volume with labelled data, train a classifier. Nuanced policy that changes often, use a judge. Then decide sourcing separately, on residency, auditability, and whether the category is one you need to differentiate on. The judge is the easiest to prototype and the most expensive to run on every request, so it is worth pricing at the design stage rather than after the first month's bill.
@@ -123,6 +132,14 @@ Two ways out, and you should pick one deliberately.
 **Verdict composition.** Do not combine scores at all. Give each detector its own threshold, tuned on its own data, and let it emit a verdict. Combine verdicts with explicit logic. This is weaker statistically and much easier to reason about, audit, and explain to a risk function.
 
 Verdict composition is the correct default. Score fusion is an optimisation to reach for once you have the labelled data to justify it, and never before.
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-002-composition.svg"
+  alt="Three detectors each scoring 0.90 where the number means something different in each case, contrasted with the same three emitting verdicts against their own thresholds."
+  caption="Three 0.90s that do not mean the same thing average to a number with no empirical meaning."
+/>
+
 
 ## Composing detectors
 

--- a/src/content/architecture/003-measuring-detectors.mdx
+++ b/src/content/architecture/003-measuring-detectors.mdx
@@ -35,6 +35,7 @@ patterns: [eval-loop, failure-buckets]
 ---
 
 import Callout from '~/components/universal/Callout.astro';
+import ArchitectureDiagram from '~/components/universal/ArchitectureDiagram.astro';
 import PullQuote from '~/components/universal/PullQuote.astro';
 import Footer3Col from '~/components/universal/Footer3Col.astro';
 
@@ -67,6 +68,14 @@ Take a hypothetical detector with numbers most teams would be pleased with: 95 p
 
   precision = 95 / (95 + 999) = 8.7%
 ```
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-003-base-rate.svg"
+  alt="A population bar where actual attacks are a sliver against benign traffic, and a review queue bar where 95 true positives sit against 999 false ones."
+  caption="The sliver is the attacks. The queue is what a reviewer actually sees."
+/>
+
 
 Ninety-one percent of everything this detector flags is wrong. If each alert costs a reviewer two minutes, this detector generates about 33 hours of review work per 100,000 requests to find 95 real events.
 
@@ -104,7 +113,15 @@ Write it down in that form:
                          never the only control
 ```
 
-Both ratios above are illustrative, not benchmarks; the numbers that belong there are your own, and writing them down is the exercise. The ratio on its own does not give you a threshold. It gives you the objective. Turning it into a number needs two more things: the prevalence in the population the detector will run against, and a measured precision-recall curve for that detector on that population. With all three you can pick the operating point that minimises expected cost, and revisit it when the business context changes rather than when someone complains.
+Both ratios above are illustrative, not benchmarks; the numbers that belong there are your own, and writing them down is the exercise.
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-003-threshold.svg"
+  alt="Two categories side by side with their cost of a miss, cost of a false alarm, ratio, and a threshold slider set at opposite ends of its range."
+  caption="Two categories, ratios four orders of magnitude apart, thresholds at opposite ends."
+/>
+ The ratio on its own does not give you a threshold. It gives you the objective. Turning it into a number needs two more things: the prevalence in the population the detector will run against, and a measured precision-recall curve for that detector on that population. With all three you can pick the operating point that minimises expected cost, and revisit it when the business context changes rather than when someone complains.
 
 <Callout type="tip" label="One threshold per category, never one per system">
 A single global sensitivity setting forces the same cost ratio onto a PII redaction and a hard block. Those two decisions have ratios that differ by four orders of magnitude. Systems with one dial end up tuned for whichever category complained most recently.

--- a/src/content/architecture/004-the-decision-layer.mdx
+++ b/src/content/architecture/004-the-decision-layer.mdx
@@ -33,6 +33,7 @@ patterns: [approval-gate, escalation-path]
 ---
 
 import Callout from '~/components/universal/Callout.astro';
+import ArchitectureDiagram from '~/components/universal/ArchitectureDiagram.astro';
 import PullQuote from '~/components/universal/PullQuote.astro';
 import Footer3Col from '~/components/universal/Footer3Col.astro';
 
@@ -85,6 +86,14 @@ The action grid is keyed on reversal cost and confidence band, and exposure then
   impossible         require approval            block
   (payment, delete)  human in the path         refuse, escalate
 ```
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-004-action-grid.svg"
+  alt="A three by two grid of reversal cost against confidence band, each cell naming an action, with a rail on the right showing that exposure promotes a cell downward."
+  caption="The action belongs to the consequence, not to the detector."
+/>
+
 
 **Exposure promotes.** Any operation with external exposure is evaluated one row lower than its reversal cost alone would place it. A `send_email` call is free to reverse in the sense that the draft can be deleted, and impossible to reverse in the sense that matters. Blast radius promotes on the same rule once it crosses a threshold you set per environment.
 
@@ -176,6 +185,14 @@ Policy is data, so it needs the operational discipline of data that gates produc
 ```
 
 The load-failure line is the one that gets written last and matters most. A decision service that starts with no policy because the config store was unreachable is an open gate that reports itself healthy.
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-004-decision-service.svg"
+  alt="Detector verdicts entering a decision service that loads versioned policy as data, emitting one of six actions and always writing a decision record."
+  caption="Policy is data the service loads. Every decision leaves a record."
+/>
+
 
 <Callout type="tip" label="Test the policy, not just the detectors">
 Policy files need their own test suite: a set of synthetic verdicts with expected actions, run in CI. A policy edit that accidentally widens a default from redact to allow is invisible in review and obvious in a test.

--- a/tests/unit/test_metacognition.py
+++ b/tests/unit/test_metacognition.py
@@ -1,0 +1,311 @@
+"""Tests for the metacognition layer: introspection and adaptation."""
+
+from src.ch09_metacognition.adaptive_agent import (
+    AdaptiveAgent,
+    Strategy,
+    StrategyRouter,
+    should_stop_early,
+)
+from src.ch09_metacognition.monitor import BudgetTracker, MetacognitiveMonitor, StepAssessment
+from src.ch09_metacognition.progress_tracker import ProgressTracker, record_step
+from src.ch09_metacognition.quality_checker import OutputQualityChecker
+from src.ch09_metacognition.repetition_detector import (
+    RepetitionDetector,
+    StepRecord,
+    is_looping,
+)
+from src.shared.model_client import MockClient
+from src.shared.types import Citation, CompletionResponse
+
+SEARCH = "search"
+QUERY = {"query": "quarterly revenue 2024"}
+
+
+# --- Layer 1: exact match -------------------------------------------------
+
+
+def test_book_is_looping_helper():
+    assert is_looping(["a", "a"]) is True
+    assert is_looping(["a", "b"]) is False
+    assert is_looping(["a"]) is False
+
+
+def test_identical_tool_calls_flagged():
+    d = RepetitionDetector()
+    d.record(StepRecord(tool=SEARCH, arguments=QUERY))
+    verdict = d.record(StepRecord(tool=SEARCH, arguments=QUERY))
+    assert verdict.is_looping
+    assert verdict.layer == "exact_match"
+
+
+def test_argument_order_does_not_defeat_detection():
+    d = RepetitionDetector()
+    d.record(StepRecord(tool=SEARCH, arguments={"q": "x", "k": 3}))
+    verdict = d.record(StepRecord(tool=SEARCH, arguments={"k": 3, "q": "x"}))
+    assert verdict.is_looping
+
+
+def test_varied_calls_not_flagged():
+    d = RepetitionDetector()
+    d.record(StepRecord(tool=SEARCH, arguments={"query": "a"}))
+    verdict = d.record(StepRecord(tool=SEARCH, arguments={"query": "b"}))
+    assert not verdict.is_looping
+
+
+# --- Layer 2: action-sequence fingerprinting ------------------------------
+
+
+def test_alternating_sequence_flagged():
+    d = RepetitionDetector()
+    for query in ["a", "b", "a", "b"]:
+        verdict = d.record(StepRecord(tool=SEARCH, arguments={"query": query}))
+    assert verdict.is_looping
+    assert verdict.layer == "sequence_fingerprint"
+
+
+# --- Layer 3: semantic similarity -----------------------------------------
+
+
+def test_semantic_similarity_flagged():
+    vectors = {
+        "What was Q3 revenue?": [1.0, 0.0, 0.1],
+        "How much revenue in the third quarter?": [0.99, 0.0, 0.12],
+    }
+    d = RepetitionDetector(embed=lambda text: vectors[text])
+    d.record(StepRecord(tool=SEARCH, arguments={"query": "a"}, reasoning="What was Q3 revenue?"))
+    verdict = d.record(
+        StepRecord(
+            tool=SEARCH,
+            arguments={"query": "b"},
+            reasoning="How much revenue in the third quarter?",
+        )
+    )
+    assert verdict.is_looping
+    assert verdict.layer == "semantic_similarity"
+
+
+# --- Layer 4: output convergence ------------------------------------------
+
+
+def test_output_convergence_flagged():
+    d = RepetitionDetector()
+    for i in range(3):
+        verdict = d.record(
+            StepRecord(tool=SEARCH, arguments={"query": f"q{i}"}, answer="Revenue was $4.2M.")
+        )
+    assert verdict.is_looping
+    assert verdict.layer == "output_convergence"
+
+
+# --- Progress tracking ----------------------------------------------------
+
+
+def test_record_step_book_form():
+    seen: set[str] = set()
+    gain, stale = record_step(seen, "alpha beta gamma")
+    assert gain == 1.0 and stale is False
+    gain, stale = record_step(seen, "alpha beta gamma")
+    assert gain == 0.0 and stale is True
+
+
+def test_gain_curve_flattens():
+    t = ProgressTracker()
+    t.record("the retry policy uses exponential backoff")
+    t.record("the retry policy uses exponential backoff")
+    assert t.total_gain_curve[0] == 1.0
+    assert t.total_gain_curve[1] == 0.0
+    assert t.is_stale() is True
+
+
+def test_suggested_step_budget_marks_flattening_point():
+    t = ProgressTracker()
+    t.record("alpha beta gamma")
+    t.record("delta epsilon zeta")
+    t.record("alpha beta gamma")
+    assert t.suggested_step_budget() == 2
+
+
+def test_stop_words_ignored():
+    t = ProgressTracker()
+    first = t.record("the agent is in the loop")
+    assert first.total_words == 2  # agent, loop
+
+
+# --- Quality checking -----------------------------------------------------
+
+
+GOOD_EVIDENCE = [
+    Citation(source="runbook.pdf", text="The retry policy uses exponential backoff."),
+    Citation(source="runbook.pdf", text="Jitter prevents thundering herd effects."),
+]
+
+
+def test_grounded_answer_scores_above_ungrounded():
+    checker = OutputQualityChecker()
+    grounded = checker.check(
+        "The retry policy uses exponential backoff [1]. Jitter prevents thundering herd [2].",
+        GOOD_EVIDENCE,
+    )
+    ungrounded = checker.check("Revenue grew significantly last quarter.", GOOD_EVIDENCE)
+    assert grounded.score > ungrounded.score
+    assert grounded.is_grounded
+    assert not ungrounded.is_grounded
+
+
+def test_confident_claims_on_thin_evidence_flagged():
+    checker = OutputQualityChecker()
+    report = checker.check("Revenue was exactly $4.2M [1].", GOOD_EVIDENCE)
+    assert "confident claims on thin evidence" in report.issues
+
+
+def test_hedging_on_thin_evidence_is_not_penalized_the_same():
+    checker = OutputQualityChecker()
+    confident = checker.check("Revenue was exactly $4.2M [1].", GOOD_EVIDENCE)
+    hedged = checker.check("The evidence is insufficient to state revenue [1].", GOOD_EVIDENCE)
+    assert hedged.score > confident.score
+
+
+def test_empty_answer_reports_issue():
+    assert OutputQualityChecker().check("", GOOD_EVIDENCE).issues == ["empty answer"]
+
+
+# --- Budget ---------------------------------------------------------------
+
+
+def test_budget_tracker_afford_and_summary():
+    b = BudgetTracker(total_budget_tokens=2000, total_budget_usd=0.10)
+    assert b.can_afford_step(1500) is True
+    b.consume(1800, 0.05)
+    assert b.can_afford_step(1500) is False
+    assert "200 tokens remaining" in b.budget_summary()
+
+
+# --- Monitor --------------------------------------------------------------
+
+
+def test_monitor_stops_on_loop():
+    m = MetacognitiveMonitor(max_steps=5)
+    m.assess(step=1, tool=SEARCH, arguments=QUERY, observation="three documents found")
+    a = m.assess(step=2, tool=SEARCH, arguments=QUERY, observation="three documents found")
+    assert a.is_looping is True
+    assert a.should_continue is False
+    assert "looping" in a.reason
+
+
+def test_monitor_ignores_quality_in_continue_decision():
+    m = MetacognitiveMonitor(max_steps=5)
+    a = m.assess(
+        step=1,
+        tool=SEARCH,
+        arguments=QUERY,
+        observation="entirely new material about backoff and jitter",
+        answer="Ungrounded claim with no citation.",
+    )
+    assert a.quality_score < 0.5
+    assert a.should_continue is True
+
+
+def test_monitor_stops_when_budget_exhausted():
+    m = MetacognitiveMonitor(budget=BudgetTracker(total_budget_tokens=100), max_steps=5)
+    a = m.assess(step=1, tool=SEARCH, arguments=QUERY, observation="new material")
+    assert a.should_continue is False
+    assert "budget" in a.reason
+
+
+def test_monitor_stops_at_step_limit():
+    m = MetacognitiveMonitor(max_steps=2)
+    m.assess(step=1, tool=SEARCH, arguments={"query": "a"}, observation="alpha beta")
+    a = m.assess(step=2, tool=SEARCH, arguments={"query": "b"}, observation="gamma delta")
+    assert a.should_continue is False
+    assert "step limit" in a.reason
+
+
+# --- Adaptation -----------------------------------------------------------
+
+
+def _assessment(**kw) -> StepAssessment:
+    defaults = dict(
+        step=1,
+        is_looping=False,
+        quality_score=0.8,
+        marginal_gain=0.5,
+        budget_remaining=10_000.0,
+        should_continue=True,
+        reason="",
+    )
+    defaults.update(kw)
+    return StepAssessment(**defaults)
+
+
+def test_should_stop_early_on_near_zero_gain():
+    assert should_stop_early(_assessment(marginal_gain=0.01), steps_remaining=3) is True
+
+
+def test_should_stop_early_on_good_enough_answer():
+    assert should_stop_early(_assessment(quality_score=0.7, marginal_gain=0.05), 1) is True
+
+
+def test_should_stop_early_when_budget_too_low():
+    assert should_stop_early(_assessment(budget_remaining=100.0), steps_remaining=1) is True
+
+
+def test_should_not_stop_while_still_learning():
+    assert should_stop_early(_assessment(quality_score=0.2, marginal_gain=0.6), 1) is False
+
+
+def test_strategy_router_switches_then_exhausts():
+    router = StrategyRouter(
+        strategies=[
+            Strategy(name="semantic", search=lambda q: []),
+            Strategy(name="keyword", search=lambda q: []),
+        ]
+    )
+    assert router.current.name == "semantic"
+    assert router.switch().name == "keyword"
+    assert router.switch() is None
+    assert router.switches == ["keyword"]
+
+
+async def test_adaptive_agent_recovers_from_loop_by_switching_strategy():
+    thin = [Citation(source="hiring.pdf", text="Unrelated document about hiring policy.")]
+    router = StrategyRouter(
+        strategies=[
+            Strategy(name="semantic_search", search=lambda q: thin),
+            Strategy(name="keyword_search", search=lambda q: GOOD_EVIDENCE),
+        ]
+    )
+    client = MockClient(
+        responses=[
+            CompletionResponse(content="Revenue grew significantly last quarter."),
+            CompletionResponse(content="Revenue grew significantly last quarter."),
+            CompletionResponse(
+                content=(
+                    "The retry policy uses exponential backoff [1]. "
+                    "Jitter prevents thundering herd [2]."
+                )
+            ),
+        ]
+    )
+    agent = AdaptiveAgent(client=client, router=router, max_steps=3)
+
+    response = await agent.run("retry strategy")
+
+    assert router.switches == ["keyword_search"]
+    assert agent.assessments[1].is_looping is True
+    assert response.steps_taken == 3
+    assert response.escalated is False
+    assert response.confidence > 0.5
+
+
+async def test_adaptive_agent_escalates_when_correction_fails():
+    thin = [Citation(source="hiring.pdf", text="Unrelated document about hiring policy.")]
+    router = StrategyRouter(strategies=[Strategy(name="semantic_search", search=lambda q: thin)])
+    client = MockClient(
+        responses=[CompletionResponse(content="Revenue grew significantly last quarter.")] * 4
+    )
+    agent = AdaptiveAgent(client=client, router=router, max_steps=2)
+
+    response = await agent.run("quarterly revenue")
+
+    assert response.escalated is True
+    assert response.escalation_reason == "quality below threshold after correction"


### PR DESCRIPTION
The blueprint pillar had no diagrams. Everything structural was monospace text in code fences, which is thin for a section that claims to specify architecture, and thin next to the [EDA target-state blueprint](https://sunilprakash.com/enterprise-data-architecture/blueprints/target-state/).

## Palette

The site already has 52 hand-crafted SVGs under `public/assets/diagrams/`, but they are in a pre-rebrand blue (`#1a3a5c` / `#3d7ab5` / `#7eb3d8`, IBM Plex Sans on white). These eight use the Lab's own brand instead: paper ground, `#1a1a1a` linework, `#6b6b6b` secondary, brick `#9b4a3f` as the single accent, mono labels, serif description. Same structural register as the EDA blueprint: layered bands, a cross-cutting rail, hairline rules, restrained arrowheads.

## The eight

| file | what it argues |
|---|---|
| `arch-001-chokepoints` | six chokepoints down one request path, what each sees and is blind to, and which harm family it addresses. Tool execution is the only row in both; the prompt layer is in neither |
| `arch-001-nested-paths` | an unauthorized agent borrowing an authorized one. Each path's six checks pass; the composition is what fails |
| `arch-002-techniques` | four techniques as columns above a sourcing band that crosses all four, so sourcing reads as the independent axis it is |
| `arch-002-composition` | three detectors each scoring 0.90 where the number means something different, against the same three emitting verdicts |
| `arch-003-base-rate` | the attack sliver against benign traffic, then the queue a reviewer actually sees: 95 real against 999 false |
| `arch-003-threshold` | two categories with cost ratios four orders of magnitude apart, thresholds at opposite ends of the slider |
| `arch-004-action-grid` | reversal cost against confidence band, six actions, and a rail showing exposure promoting a cell |
| `arch-004-decision-service` | verdicts in, versioned policy loaded as data, one action out, one decision record always |

## Layout

`ArchitectureDiagram` gains a `wide` variant. The reader column is 612px, too narrow for structural work, so wide figures break out to 880px. Below that they keep a legible 720px and pan inside their own frame, because scaling to fit a 390px viewport put the labels at roughly 4px. The page itself never scrolls sideways, and the caption is sticky so it stays put while the diagram pans.

## Scope

Additive only. No prose and no code fence was removed. The fences still serve mobile readers and copy-paste, and the reviewed text is untouched. The one placement change: the ARCH-001 hero sits under "What each chokepoint can see" rather than directly beneath the fence listing the same six items.

## Verification

- `npm run build` green, `astro check` 0 errors, `vitest` 21/21
- All eight files present and referenced by the right pages
- Measured in-browser at 1280, 1024, 768 and 390: no page overflow, no figure off-screen, breakout resolving to 880 / 880 / 720 / 720(panned)
- Overflow assertions in the generators caught four text-fitting bugs before render; four more (text crossing a panel border, a label collision, a rail drawn under a column, collapsed mono alignment) were caught by screenshotting each diagram and fixed
- No em dashes

## Follow-up, not done here

The 52 chapter diagrams under `/book/` remain blue. Worth deciding whether they get rebranded, since the two pillars now look different.
