### PR TITLE
Architecture: the governance half, ARCH-005 to ARCH-008

### DIFF
--- a/public/assets/diagrams/arch-005-decision-rights.svg
+++ b/public/assets/diagrams/arch-005-decision-rights.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="548" viewBox="0 0 880 548" role="img" aria-label="Five decisions inside one guardrail, each with its owner, the evidence it produces and its review cadence">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="548" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">Five decisions inside one guardrail</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">The platform team builds all five. It is accountable for one.</text>
+<text x="0" y="90" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">THE DECISION</text>
+<text x="270" y="90" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">ACCOUNTABLE</text>
+<text x="430" y="90" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">EVIDENCE IT PRODUCES</text>
+<text x="700" y="90" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">REVIEWED</text>
+<line x1="0" y1="98" x2="880" y2="98" stroke="#1a1a1a"/>
+<rect x="0" y="106" width="880" height="58" fill="#fafaf8"/>
+<text x="12" y="130" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#1a1a1a" letter-spacing="0.5">WHAT WE DETECT</text>
+<text x="12" y="149" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">which categories are in scope at all</text>
+<text x="270" y="130" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">second line</text>
+<text x="430" y="130" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">the category list, per tier</text>
+<text x="700" y="130" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b">on system change</text>
+<line x1="0" y1="166" x2="880" y2="166" stroke="#e8e8e8"/>
+<rect x="0" y="170" width="880" height="58" fill="#f5ece9"/>
+<rect x="0" y="170" width="3" height="58" fill="#9b4a3f"/>
+<text x="12" y="194" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#9b4a3f" letter-spacing="0.5">HOW WE DETECT</text>
+<text x="12" y="213" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">technique, sourcing, composition</text>
+<text x="270" y="194" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#9b4a3f">first line</text>
+<text x="430" y="194" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">detector + eval set version</text>
+<text x="700" y="194" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b">every change</text>
+<line x1="0" y1="230" x2="880" y2="230" stroke="#e8e8e8"/>
+<rect x="0" y="234" width="880" height="58" fill="#fafaf8"/>
+<text x="12" y="258" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#1a1a1a" letter-spacing="0.5">HOW HARD</text>
+<text x="12" y="277" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">the threshold, as an explicit cost ratio</text>
+<text x="270" y="258" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">second line</text>
+<text x="430" y="258" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">signed ratio + traffic assumption</text>
+<text x="700" y="258" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b">semi-annual</text>
+<line x1="0" y1="294" x2="880" y2="294" stroke="#e8e8e8"/>
+<text x="12" y="322" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#1a1a1a" letter-spacing="0.5">WHAT HAPPENS</text>
+<text x="12" y="341" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">allow, block, redact, mask, escalate</text>
+<text x="270" y="322" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">product + risk</text>
+<text x="430" y="322" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">policy version</text>
+<text x="700" y="322" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b">on policy edit</text>
+<line x1="0" y1="358" x2="880" y2="358" stroke="#e8e8e8"/>
+<rect x="0" y="362" width="880" height="58" fill="#fafaf8"/>
+<text x="12" y="386" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#1a1a1a" letter-spacing="0.5">WHO LOOKS</text>
+<text x="12" y="405" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">queue design, staffing, escalation path</text>
+<text x="270" y="386" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">operations</text>
+<text x="430" y="386" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#1a1a1a">review findings + SLA</text>
+<text x="700" y="386" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b">monthly</text>
+<line x1="0" y1="422" x2="880" y2="422" stroke="#e8e8e8"/>
+<rect x="0" y="440" width="880" height="54" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2"/>
+<text x="16" y="460" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">THE THREE LINES MODEL, APPLIED</text>
+<text x="16" y="480" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">First line owns and operates the control.  Second line sets the standard and challenges.  Third line asks for the decision record.</text>
+<line x1="0" y1="518" x2="880" y2="518" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="538" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">Conflating these five is what produces the unowned threshold, and an engineer defending a risk appetite in an audit.</text>
+</svg>

--- a/public/assets/diagrams/arch-006-lifecycle.svg
+++ b/public/assets/diagrams/arch-006-lifecycle.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="450" viewBox="0 0 880 450" role="img" aria-label="Eight lifecycle gates from intake to retirement, marking which of them block a release">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="450" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">The guardrail lifecycle</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">Three gates block a release. The rest record. Revalidation is a loop, not an end.</text>
+<text x="0" y="76" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">BLOCKS THE RELEASE</text>
+<rect x="0.0" y="116" width="101.25" height="54" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="50.625" y="139" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13" fill="#6b6b6b" text-anchor="middle">1</text>
+<text x="50.625" y="158" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10" fill="#1a1a1a" text-anchor="middle">INTAKE</text>
+<line x1="102.25" y1="143" x2="109.25" y2="143" stroke="#6b6b6b" stroke-width="1.1" marker-end="url(#arg)"/>
+<rect x="156.875" y="84" width="10" height="10" fill="#9b4a3f"/>
+<rect x="111.25" y="116" width="101.25" height="54" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.4"/>
+<text x="161.875" y="139" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13" fill="#9b4a3f" text-anchor="middle">2</text>
+<text x="161.875" y="158" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10" fill="#1a1a1a" text-anchor="middle">TIERING</text>
+<line x1="213.5" y1="143" x2="220.5" y2="143" stroke="#6b6b6b" stroke-width="1.1" marker-end="url(#arg)"/>
+<rect x="222.5" y="116" width="101.25" height="54" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="273.125" y="139" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13" fill="#6b6b6b" text-anchor="middle">3</text>
+<text x="273.125" y="158" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10" fill="#1a1a1a" text-anchor="middle">BUILD</text>
+<line x1="324.75" y1="143" x2="331.75" y2="143" stroke="#6b6b6b" stroke-width="1.1" marker-end="url(#arg)"/>
+<rect x="333.75" y="116" width="101.25" height="54" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="384.375" y="139" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13" fill="#6b6b6b" text-anchor="middle">4</text>
+<text x="384.375" y="158" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10" fill="#1a1a1a" text-anchor="middle">RED TEAM</text>
+<line x1="436.0" y1="143" x2="443.0" y2="143" stroke="#6b6b6b" stroke-width="1.1" marker-end="url(#arg)"/>
+<rect x="490.625" y="84" width="10" height="10" fill="#9b4a3f"/>
+<rect x="445.0" y="116" width="101.25" height="54" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.4"/>
+<text x="495.625" y="139" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13" fill="#9b4a3f" text-anchor="middle">5</text>
+<text x="495.625" y="158" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10" fill="#1a1a1a" text-anchor="middle">SHADOW</text>
+<line x1="547.25" y1="143" x2="554.25" y2="143" stroke="#6b6b6b" stroke-width="1.1" marker-end="url(#arg)"/>
+<rect x="556.25" y="116" width="101.25" height="54" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="606.875" y="139" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13" fill="#6b6b6b" text-anchor="middle">6</text>
+<text x="606.875" y="158" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10" fill="#1a1a1a" text-anchor="middle">CANARY</text>
+<line x1="658.5" y1="143" x2="665.5" y2="143" stroke="#6b6b6b" stroke-width="1.1" marker-end="url(#arg)"/>
+<rect x="713.125" y="84" width="10" height="10" fill="#9b4a3f"/>
+<rect x="667.5" y="116" width="101.25" height="54" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.4"/>
+<text x="718.125" y="139" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13" fill="#9b4a3f" text-anchor="middle">7</text>
+<text x="718.125" y="158" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10" fill="#1a1a1a" text-anchor="middle">ENFORCE</text>
+<line x1="769.75" y1="143" x2="776.75" y2="143" stroke="#6b6b6b" stroke-width="1.1" marker-end="url(#arg)"/>
+<rect x="778.75" y="116" width="101.25" height="54" rx="2" fill="#ffffff" stroke="#e8e8e8" stroke-width="1"/>
+<text x="829.375" y="139" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="13" fill="#6b6b6b" text-anchor="middle">8</text>
+<text x="829.375" y="158" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10" fill="#1a1a1a" text-anchor="middle">MONITOR</text>
+<path d="M829.375,170 L829.375,196 L273.125,196 L273.125,172" fill="none" stroke="#9b4a3f" stroke-width="1.3" marker-end="url(#arb)"/>
+<text x="551.25" y="213" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#9b4a3f" text-anchor="middle">revalidate: quarterly, semi-annual or annual by tier, and on material change</text>
+<text x="0.0" y="236" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b">1</text>
+<text x="16.0" y="236" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">INTAKE</text>
+<text x="100.0" y="236" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">what harm, which chokepoint, and who is asking</text>
+<text x="0.0" y="258" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f">2</text>
+<text x="16.0" y="258" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">TIERING</text>
+<text x="100.0" y="258" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">the tier sets every gate downstream</text>
+<text x="0.0" y="280" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b">3</text>
+<text x="16.0" y="280" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">BUILD</text>
+<text x="100.0" y="280" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">technique, interface contract, versioned eval set</text>
+<text x="0.0" y="302" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b">4</text>
+<text x="16.0" y="302" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">RED TEAM</text>
+<text x="100.0" y="302" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">someone who is not the author tries to break it</text>
+<text x="460.0" y="236" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f">5</text>
+<text x="476.0" y="236" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">SHADOW</text>
+<text x="560.0" y="236" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">runs on real traffic, takes no action</text>
+<text x="460.0" y="258" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b">6</text>
+<text x="476.0" y="258" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">CANARY</text>
+<text x="560.0" y="258" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">enforces on a bounded slice</text>
+<text x="460.0" y="280" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f">7</text>
+<text x="476.0" y="280" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">ENFORCE</text>
+<text x="560.0" y="280" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">needs the go-live pack signed</text>
+<text x="460.0" y="302" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b">8</text>
+<text x="476.0" y="302" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">MONITOR</text>
+<text x="560.0" y="302" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b">evidence on a cadence, revalidation booked</text>
+<rect x="0" y="334" width="880" height="50" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="16" y="354" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">RETIREMENT, THE GATE NOBODY REACHES</text>
+<text x="16" y="372" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">Report per-detector true positive counts on the same cadence as accuracy, or the pipeline only ever grows.</text>
+<line x1="0" y1="420" x2="880" y2="420" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="440" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">Shadow is where you measure the population the detector will actually meet. It costs nothing but patience.</text>
+</svg>

--- a/public/assets/diagrams/arch-007-three-logs.svg
+++ b/public/assets/diagrams/arch-007-three-logs.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="478" viewBox="0 0 880 478" role="img" aria-label="Three separate log stores with different contents, retention, access and audience">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="478" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">Three kinds of log, not one</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">Different contents, different retention, different readers. One store cannot serve all three.</text>
+<rect x="0.0" y="100" width="280.0" height="222" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.1"/>
+<rect x="0.0" y="100" width="280.0" height="30" fill="#1a1a1a"/>
+<text x="140.0" y="120" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#fafaf8" text-anchor="middle" letter-spacing="0.6">OPERATIONAL TELEMETRY</text>
+<text x="14.0" y="152" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">counters, latencies, error rates,</text>
+<text x="14.0" y="169" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">detector availability, queue depth</text>
+<text x="14.0" y="194" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">no content</text>
+<text x="14.0" y="210" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">no identifiers beyond request_id</text>
+<text x="14.0" y="238" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">RETENTION</text>
+<text x="266.0" y="239" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#1a1a1a" text-anchor="end">days</text>
+<text x="14.0" y="260" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">ACCESS</text>
+<text x="266.0" y="261" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#1a1a1a" text-anchor="end">wide</text>
+<line x1="14.0" y1="296" x2="266.0" y2="296" stroke="#e8e8e8"/>
+<text x="14.0" y="314" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">the on-call engineer</text>
+<rect x="300.0" y="100" width="280.0" height="222" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.4"/>
+<rect x="300.0" y="100" width="280.0" height="30" fill="#9b4a3f"/>
+<text x="440.0" y="120" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#fafaf8" text-anchor="middle" letter-spacing="0.6">THE DECISION RECORD</text>
+<text x="314.0" y="152" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">detectors and versions, verdicts,</text>
+<text x="314.0" y="169" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">policy version, action, degraded</text>
+<text x="314.0" y="194" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">no prompts</text>
+<text x="314.0" y="210" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">no responses</text>
+<text x="314.0" y="238" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">RETENTION</text>
+<text x="566.0" y="239" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#9b4a3f" text-anchor="end">years</text>
+<text x="314.0" y="260" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">ACCESS</text>
+<text x="566.0" y="261" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#9b4a3f" text-anchor="end">narrow</text>
+<line x1="314.0" y1="296" x2="566.0" y2="296" stroke="#e8e8e8"/>
+<text x="314.0" y="314" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">assurance, and audit</text>
+<rect x="600.0" y="100" width="280.0" height="222" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.1"/>
+<rect x="600.0" y="100" width="280.0" height="30" fill="#1a1a1a"/>
+<text x="740.0" y="120" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="10.5" fill="#fafaf8" text-anchor="middle" letter-spacing="0.6">THE CONTENT ARCHIVE</text>
+<text x="614.0" y="152" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">the prompts, retrieved chunks</text>
+<text x="614.0" y="169" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">and responses themselves</text>
+<text x="614.0" y="194" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">the sensitive text</text>
+<text x="614.0" y="210" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">itself</text>
+<text x="614.0" y="238" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">RETENTION</text>
+<text x="866.0" y="239" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#1a1a1a" text-anchor="end">weeks</text>
+<text x="614.0" y="260" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#6b6b6b" letter-spacing="1.6">ACCESS</text>
+<text x="866.0" y="261" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="12" fill="#1a1a1a" text-anchor="end">break-glass</text>
+<line x1="614.0" y1="296" x2="866.0" y2="296" stroke="#e8e8e8"/>
+<text x="614.0" y="314" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">incident review only</text>
+<line x1="440.0" y1="336" x2="740.0" y2="336" stroke="#9b4a3f" stroke-width="1.3" stroke-dasharray="4 3" marker-end="url(#arb)"/>
+<text x="590.0" y="358" font-family="Georgia,'EB Garamond',serif" font-size="11.5" fill="#9b4a3f" text-anchor="middle">by reference, never embedded</text>
+<rect x="0" y="376" width="880" height="50" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="16" y="396" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">WHY THE REFERENCE MATTERS</text>
+<text x="16" y="414" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">When the archive expires the decision record survives, so you can still prove a control ran without holding the sensitive text forever.</text>
+<line x1="0" y1="448" x2="880" y2="448" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="468" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">Keep the fact that a decision was made for years. Keep the text it was about for weeks.</text>
+</svg>

--- a/public/assets/diagrams/arch-008-tiered-pipeline.svg
+++ b/public/assets/diagrams/arch-008-tiered-pipeline.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="450" viewBox="0 0 880 450" role="img" aria-label="A tiered detector pipeline where cheap detectors run in parallel and only the ambiguous band reaches an expensive judge">
+<defs><marker id="ar" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#1a1a1a"/></marker><marker id="arb" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#9b4a3f"/></marker><marker id="arg" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0,0 L9,3.5 L0,7 Z" fill="#6b6b6b"/></marker></defs>
+<rect width="880" height="450" fill="#ffffff"/>
+<text x="0" y="24" font-family="Georgia,'EB Garamond',serif" font-size="19" fill="#1a1a1a">Parallel first, then tiered</text>
+<text x="0" y="46" font-family="Georgia,'EB Garamond',serif" font-size="13.5" fill="#6b6b6b">The judge sees the ambiguous band, not the traffic. That ratio is the whole cost model.</text>
+<text x="0" y="96" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">EVERY REQUEST</text>
+<rect x="0" y="108" width="120" height="120" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="60" y="164" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="17" fill="#1a1a1a" text-anchor="middle">100%</text>
+<text x="60" y="184" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" text-anchor="middle">of traffic</text>
+<line x1="126" y1="168" x2="162" y2="168" stroke="#6b6b6b" stroke-width="1.3" marker-end="url(#arg)"/>
+<text x="170" y="96" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">CHEAP TIER, IN PARALLEL</text>
+<rect x="170" y="108" width="250" height="120" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2"/>
+<rect x="182" y="126" width="226" height="26" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="192" y="144" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">rules</text>
+<text x="398" y="144" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b" text-anchor="end">5 ms</text>
+<rect x="182" y="160" width="226" height="26" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="192" y="178" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">classical NLP</text>
+<text x="398" y="178" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b" text-anchor="end">25 ms</text>
+<rect x="182" y="194" width="226" height="26" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="192" y="212" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">trained classifier</text>
+<text x="398" y="212" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#6b6b6b" text-anchor="end">60 ms</text>
+<text x="182" y="242" font-family="Georgia,'EB Garamond',serif" font-size="12" fill="#6b6b6b" font-style="italic">cost = the slowest, not the sum</text>
+<line x1="426" y1="168" x2="460" y2="168" stroke="#6b6b6b" stroke-width="1.3"/>
+<rect x="466" y="106" width="200" height="52" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="480" y="128" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="14" fill="#1a1a1a">~55%</text>
+<text x="536" y="128" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">clear</text>
+<text x="480" y="146" font-family="Georgia,'EB Garamond',serif" font-size="11.5" fill="#6b6b6b">resolves here, no judge</text>
+<rect x="466" y="164" width="200" height="52" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.4"/>
+<text x="480" y="186" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="14" fill="#9b4a3f">~10%</text>
+<text x="536" y="186" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">ambiguous</text>
+<text x="480" y="204" font-family="Georgia,'EB Garamond',serif" font-size="11.5" fill="#6b6b6b">escalates</text>
+<rect x="466" y="222" width="200" height="52" rx="2" fill="#fafaf8" stroke="#e8e8e8" stroke-width="1"/>
+<text x="480" y="244" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="14" fill="#1a1a1a">~35%</text>
+<text x="536" y="244" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#1a1a1a">above threshold</text>
+<text x="480" y="262" font-family="Georgia,'EB Garamond',serif" font-size="11.5" fill="#6b6b6b">resolves here, no judge</text>
+<line x1="460" y1="168" x2="462" y2="132" stroke="#6b6b6b" stroke-width="1"/>
+<line x1="460" y1="168" x2="462" y2="190" stroke="#6b6b6b" stroke-width="1"/>
+<line x1="460" y1="168" x2="462" y2="248" stroke="#6b6b6b" stroke-width="1"/>
+<line x1="668" y1="190" x2="674" y2="190" stroke="#9b4a3f" stroke-width="1.4" marker-end="url(#arb)"/>
+<text x="680" y="96" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">EXPENSIVE TIER</text>
+<rect x="680" y="158" width="200" height="64" rx="2" fill="#f5ece9" stroke="#9b4a3f" stroke-width="1.4"/>
+<text x="694" y="182" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11.5" fill="#9b4a3f">LLM judge</text>
+<text x="694" y="202" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11.5" fill="#6b6b6b">400 ms deadline</text>
+<rect x="0" y="288" width="880" height="50" rx="2" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2"/>
+<text x="16" y="308" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#9b4a3f" letter-spacing="1.6">THE MEASUREMENT TRAP THIS CREATES</text>
+<text x="16" y="326" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">A judge that sees only the ambiguous band runs on a population enriched for hard cases. Measure it on tiered traffic.</text>
+<text x="0" y="350" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="9.5" fill="#1a1a1a" letter-spacing="1.6">TIMEOUT ISOLATION</text>
+<text x="0" y="368" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f">per detector</text>
+<text x="118" y="368" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">sized to the detector, never one shared deadline</text>
+<text x="0" y="387" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f">per pipeline</text>
+<text x="118" y="387" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">less than the remaining request budget; missing detectors are timeout, not clear</text>
+<text x="0" y="406" font-family="'IBM Plex Mono','SF Mono',Menlo,Consolas,monospace" font-size="11" fill="#9b4a3f">circuit breaker</text>
+<text x="118" y="406" font-family="Georgia,'EB Garamond',serif" font-size="12.5" fill="#1a1a1a">per detector, not per pipeline</text>
+<line x1="0" y1="426" x2="880" y2="426" stroke="#1a1a1a" stroke-width="1"/>
+<text x="0" y="444" font-family="Georgia,'EB Garamond',serif" font-size="13" fill="#1a1a1a">Detection you cannot afford at p95 is detection you will turn off during the first incident.</text>
+</svg>

--- a/src/content/architecture/005-ownership-and-decision-rights.mdx
+++ b/src/content/architecture/005-ownership-and-decision-rights.mdx
@@ -1,0 +1,213 @@
+---
+id: arch-005
+title: Ownership and Decision Rights
+dek: A guardrail has five separable decisions inside it, and they do not all belong to the same team. Most programmes stall because the threshold and the alert queue ended up owned by whoever built the classifier.
+description: "Who owns detectors, thresholds, policy, the alert queue and the exception, mapped onto the Three Lines Model. Includes a control-to-owner-to-evidence table, the decision rights that cannot be delegated to the platform team, and a worked ownership record for PII detection on an enterprise RAG assistant."
+layer: evidence
+order: 5
+readingTime: 12
+updated: 2026-08-19
+specifies: The decision rights inside a guardrail programme and the evidence each owner produces
+appliesTo: [RAG platform, Coding assistant, Agent system]
+decisions:
+  - Which decisions the platform team owns and which it only implements
+  - Who signs a threshold, and what they are signing
+  - Where an exception lives, and when it expires
+anchors:
+  - label: Five decisions
+    anchor: five-decisions-inside-one-guardrail
+  - label: Three lines
+    anchor: mapping-onto-the-three-lines-model
+  - label: The ownership table
+    anchor: the-control-to-evidence-table
+  - label: Exceptions
+    anchor: the-exception-is-the-control
+  - label: Worked example
+    anchor: worked-example-pii-in-responses
+  - label: Where it breaks
+    anchor: where-this-blueprint-stops-working
+references: [ch-10, ch-06]
+patterns: [approval-gate, escalation-path]
+sources:
+  - title: "The IIA's Three Lines Model: An Update of the Three Lines of Defense"
+    url: https://www.theiia.org/globalassets/site/communication/2020/three-lines-model-updated.pdf
+    authors: [Institute of Internal Auditors]
+    year: 2020
+  - title: "Artificial Intelligence Risk Management Framework (AI RMF 1.0), NIST AI 100-1"
+    url: https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-1.pdf
+    authors: [National Institute of Standards and Technology]
+    year: 2023
+  - title: "Artificial Intelligence Risk Management Framework: Generative Artificial Intelligence Profile, NIST AI 600-1"
+    url: https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf
+    authors: [National Institute of Standards and Technology]
+    year: 2024
+  - title: "OWASP Top 10 for LLM Applications 2025"
+    url: https://genai.owasp.org/llm-top-10/
+    year: 2025
+---
+
+import Callout from '~/components/universal/Callout.astro';
+import ArchitectureDiagram from '~/components/universal/ArchitectureDiagram.astro';
+import PullQuote from '~/components/universal/PullQuote.astro';
+import Footer3Col from '~/components/universal/Footer3Col.astro';
+
+A platform team ships a detector, picks a threshold because someone had to, inherits the alert queue because they built the dashboard, and six months later is being asked in an audit to justify a risk appetite decision it was never authorised to make.
+
+The machinery in the previous four blueprints can all be correct and still produce that outcome, because a guardrail is not one decision owned by one team. It is five, and they have different owners, different evidence and different review cadences.
+
+## Five decisions inside one guardrail
+
+Separate them, because conflating them is what produces the unowned threshold.
+
+**What we detect.** Which risk categories are in scope at all: prompt injection, PII, harmful content, system prompt leakage, policy violations, tool-use risk. This is a risk decision, not an engineering one. It follows from what the system does and what regulation applies to it.
+
+**How we detect it.** Technique, sourcing, composition, the interface contract. This is genuinely the platform team's, and it is the only one of the five where the platform team should have the final word. ARCH-002 is entirely inside this box.
+
+**How hard we detect.** The threshold. As ARCH-003 sets out, a threshold is a statement about how much worse a missed attack is than a false alarm. Someone has to own that ratio, and it cannot be the person optimising the model, because they are measured on a different thing.
+
+**What happens when it fires.** The action: allow, block, redact, mask, escalate, require approval. The choice trades user harm against system harm, so product proposes and the risk owner approves. One approver, not a committee, because an action that two functions jointly own is one nobody can change on the day it is wrong.
+
+**Who looks at the output.** The alert queue, the review workflow, the escalation path, and what happens when nobody looks for a week. This is an operations decision with a staffing cost attached, and it is the one most often left implicit.
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-005-decision-rights.svg"
+  alt="Five decisions inside a guardrail, each with its accountable owner, the evidence it produces, and its review cadence, with the platform team owning only the technique decision outright."
+  caption="The platform team builds all five. It owns one."
+/>
+
+<PullQuote>The platform team implements five decisions and is accountable for one. Every programme that inverts that ends up with an engineer defending a risk appetite in an audit.</PullQuote>
+
+## Mapping onto the Three Lines Model
+
+Regulated organisations already have a structure for this, and guardrails should use it rather than invent a parallel one. The Institute of Internal Auditors replaced the older Three Lines of Defence with the Three Lines Model in 2020, dropping "defence" to stop the framing being purely protective.
+
+Two things the model actually says, because they are routinely misquoted. Second line roles "provide assistance with managing risk", supplying "complementary expertise, support, monitoring, and challenge" to the first line. And responsibility for managing risk "remains a part of first line roles and within the scope of management". The model does not hand the second line approval authority over anything.
+
+So the mapping below is a recommended design, not something the IIA prescribes. It is the assignment that has held up in regulated environments, and the reason to write it down is that the model deliberately leaves it open.
+
+**First line owns and operates the control.** The product team and the platform team that build the AI system also build, run and monitor its guardrails. They pick techniques, write detectors, run the pipeline, hold the error budget, and respond first when something fires. This is the line that produces almost all the evidence.
+
+**Second line sets the standard and challenges the first.** Risk, compliance, model risk management, and the AI governance function. In this design they define which categories are mandatory for which tier of system, hold approval on thresholds, own the policy that maps verdicts to actions, and review the false negative analysis with an independent eye. They do not build detectors. Note that this is an assignment of approval authority the organisation makes; under the model itself, the first line still carries responsibility for the risk whether or not the second line signed the threshold.
+
+**Third line provides independent assurance.** Internal audit tests whether the first two lines did what they said. Their question is never "is the detector accurate", it is "can you show me the decision record for a blocked request in March, who approved this threshold, and when it was last revalidated". Design for that question and the audit is uneventful.
+
+<Callout type="warn" label="The anti-pattern that survives every reorg">
+Second line writing detector requirements at the level of "the model must be 95 percent accurate". That is an unownable requirement, because as ARCH-003 shows, accuracy against a rare attack is dominated by the easy negatives, and precision depends on traffic the second line does not control. The reviewable second-line requirement is a cost ratio and a category list, not a metric target.
+</Callout>
+
+The governing body sits above all three and, in practice, owns exactly one thing here: the statement of risk appetite that makes the cost ratios decidable. If nobody has written that down, every threshold argument becomes a negotiation between two teams with no tiebreaker.
+
+## The control-to-evidence table
+
+The artefact that makes ownership real is a table with five columns, maintained per control rather than per system. Anything less than five columns has a gap someone will fall through.
+
+| Column | What it holds | Failure if missing |
+|---|---|---|
+| Control | The specific check, at a specific chokepoint | Two teams argue about a "PII control" that means different things at retrieval and response |
+| Accountable owner | One named role, never a team | Shared ownership resolves to nobody at 2am |
+| Evidence | The artefact that proves it ran and worked | Assurance becomes an interview rather than a review |
+| Frequency | How often the evidence is produced and reviewed | Controls decay silently between annual audits |
+| Escalation | Who is told, how fast, when it fails or is bypassed | The first escalation path gets designed during the incident |
+
+This is the same shape a control library takes in any mature risk function, which is the point. Guardrails are not a new governance object. They are a new control type inside an existing governance object, and presenting them as something exotic is how programmes end up outside the process that would have resourced them.
+
+## The exception is the control
+
+Every guardrail programme generates exception requests, and they arrive early: a team that needs enforcement relaxed for a launch, a category that produces too many false positives for one workflow, a tool that cannot pass the approval gate on the current timeline.
+
+Exceptions are not a governance failure. Refusing to design for them is, because the alternative is not fewer exceptions, it is undocumented ones. An exception record needs a bounded scope, a justification, a compensating control that addresses the same harm, a named second-line approver, and an expiry. The values below are illustrative; the fields are the point.
+
+```yaml
+exception:
+  id: EXC-2026-0143
+  control: pii_in_response.mask        # the action this system actually applies
+  scope:                               # never "global"
+    system: rag-assistant-eu
+    surface: internal_research_desk
+  justification: >
+    Masking rewrites account identifiers inside quoted source passages,
+    which breaks the citation renderer and makes the quoted document
+    unverifiable against the original.
+  compensating_control: >
+    Retrieval-layer entitlement filtering stays enforcing on this surface,
+    so a requester can only receive passages from documents they are
+    already entitled to read. The residual risk is onward sharing rather
+    than disclosure to an unentitled party. Every response on this surface
+    writes a decision record, and a sample is reviewed monthly.
+  residual_risk_accepted_by: risk.director.markets
+  approved_by: risk.director.markets    # second line, not first
+  granted: 2026-08-19
+  expires: 2026-11-19                   # required field
+  review_owner: platform.guardrails
+```
+
+Two properties carry the weight. The expiry, because an exception without one is a permanent silent change to the control environment made by whoever was in the room, and expiry forces the conversation to happen again once the pressure that produced it has passed. Set a maximum life for exceptions in your standard rather than per request.
+
+And the compensating control, which has to address the same harm as the control it replaces. This is where most exception records are weak: entitlement filtering compensates for a relaxed response-side PII control precisely because it bounds who could have received the content in the first place. Sampling after the fact does not compensate for anything, because the disclosure has already happened. Sampling is detection of control failure, not mitigation of it.
+
+<Callout type="tip" label="The exception register is your best risk report">
+The list of live exceptions, sorted by age, is a more honest picture of a guardrail programme than any dashboard of detector accuracy. If the same exception keeps being renewed, the control is wrong, not the requester.
+</Callout>
+
+## Worked example: PII in responses
+
+One control, filled in completely, for an enterprise RAG assistant that answers questions over internal documents. The system is illustrative and so are its numbers; the shape of the record is what transfers.
+
+**The control.** Detect personally identifiable information in generated responses, at the response chokepoint, before text reaches the user.
+
+**The five decisions, assigned:**
+
+| Decision | Owner | What they actually decide |
+|---|---|---|
+| What we detect | Second line: privacy office | Which PII categories are in scope for this jurisdiction and system tier |
+| How we detect it | First line: platform guardrails team | NER for unstructured entities, rules for structured identifiers, composed by verdict |
+| How hard | Second line: privacy office, with first-line analysis | A cost ratio that puts a missed disclosure far above a false mask, so tune for recall and mitigate automatically |
+| What happens | Product and risk, jointly | Mask rather than block, because the task should still complete |
+| Who looks | First line: platform operations | Sampled review queue, not an alert per event, given the precision this ratio implies |
+
+**The ownership record:**
+
+| Field | Value |
+|---|---|
+| Control | `pii_in_response` at the response chokepoint |
+| Accountable owner | Head of AI Platform (first line) |
+| Standard owner | Data Privacy Officer (second line) |
+| Evidence | Weekly detector regression report; monthly sampled-review findings; decision records for every masked response |
+| Frequency | Regression weekly and on every detector change; sampled review monthly; threshold revalidation twice a year or on material traffic change |
+| Escalation | Detector unavailable beyond the agreed outage threshold, or a confirmed unmasked disclosure, pages the platform on-call and notifies the privacy office inside the notification window the privacy standard sets |
+
+**What the evidence pack actually contains**, because "evidence" without a contents list is where this gets vague:
+
+```
+evidence/pii_in_response/2026-08/
+  regression-2026-08-12.json      detector version, test set version,
+                                  precision and recall with intervals
+  threshold-approval.pdf          signed cost ratio, approver, date,
+                                  the traffic assumption it rests on
+  sampled-review-2026-08.csv      sampled masked responses, reviewer
+                                  verdicts, inter-reviewer disagreement
+  decision-records/               one per masked response, per ARCH-004
+  exceptions.yaml                 live exceptions against this control
+  incident/                       empty this period
+```
+
+None of those artefacts contains a prompt or a response. The decision records carry identifiers, detector and policy versions, verdicts and outcomes, and they point at the content archive by reference rather than embedding it. ARCH-007 specifies why that separation is what makes long retention affordable.
+
+**What this buys you in an audit.** Third line asks why a customer saw a masked account number in March. The decision record names the detector version, the threshold version, the policy version and the action. The threshold approval names who accepted the cost ratio and on what traffic assumption. The regression report shows the detector was performing within its measured interval that week. That is a complete answer in four artefacts, and none of them were written for the audit.
+
+## Where this blueprint stops working
+
+**Small organisations do not have three lines.** In a company where the same person owns product and risk, the model collapses into a checklist rather than a structure. It still helps to keep the five decisions separate and to write down who made each one, because the value was never the org chart. It was the separation of the threshold decision from the model decision.
+
+**Ownership does not survive a reorg on its own.** A control-to-evidence table with a named role in it is stale the moment that role changes hands. The table needs an owner too, and the only durable answer is to attach the control to a role that appears in the system of record rather than to a person, then review the mapping on the same cadence as the controls.
+
+**Decision rights say nothing about competence.** Assigning threshold approval to a second-line function that has no statistical support will produce approvals that are formally correct and empirically meaningless. The blueprint gives you the shape; a second line that can read a precision interval is what gives you the substance, and that capability is usually the real constraint.
+
+<Footer3Col
+  fromBook={[
+    { label: "Ch 10: Governance", href: "/book/10-governance/" },
+    { label: "Ch 6: Evaluating and Hardening Agents", href: "/book/06-evaluating-and-hardening/" },
+  ]}
+  readNext={{ label: "ARCH-006: The Guardrail Lifecycle", href: "/architecture/006-the-guardrail-lifecycle/" }}
+/>

--- a/src/content/architecture/006-the-guardrail-lifecycle.mdx
+++ b/src/content/architecture/006-the-guardrail-lifecycle.mdx
@@ -1,0 +1,218 @@
+---
+id: arch-006
+title: The Guardrail Lifecycle
+dek: "A detector goes from proposal to production through eight gates, and the two that matter most are the two teams skip: shadow mode before enforcement, and a revalidation date set on the day it ships."
+description: "The lifecycle a guardrail moves through from intake and tiering to red team, shadow, canary, enforcement, monitoring, revalidation and retirement. Includes the gate criteria, the go-live pack contents, a CI regression gate that blocks a release, and a worked lifecycle for a prompt injection detector."
+layer: evidence
+order: 6
+readingTime: 12
+updated: 2026-08-19
+specifies: The gates a guardrail passes through and the artefact each gate produces
+appliesTo: [RAG platform, Coding assistant, Agent system]
+decisions:
+  - Which gate blocks a release and which only records
+  - How long a detector runs in shadow before it enforces
+  - What makes a detector eligible for retirement
+anchors:
+  - label: Eight gates
+    anchor: eight-gates
+  - label: Tiering
+    anchor: tiering-decides-the-rest
+  - label: Shadow and canary
+    anchor: shadow-then-canary-then-enforce
+  - label: The go-live pack
+    anchor: the-go-live-pack
+  - label: The CI gate
+    anchor: the-regression-gate-that-blocks-a-release
+  - label: Worked example
+    anchor: worked-example-a-prompt-injection-detector
+  - label: Where it breaks
+    anchor: where-this-blueprint-stops-working
+references: [ch-06, ch-09]
+patterns: [eval-loop, verifier-loop]
+sources:
+  - title: "Artificial Intelligence Risk Management Framework: Generative Artificial Intelligence Profile, NIST AI 600-1"
+    url: https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf
+    authors: [National Institute of Standards and Technology]
+    year: 2024
+  - title: "OWASP Top 10 for LLM Applications 2025"
+    url: https://genai.owasp.org/llm-top-10/
+    year: 2025
+---
+
+import Callout from '~/components/universal/Callout.astro';
+import ArchitectureDiagram from '~/components/universal/ArchitectureDiagram.astro';
+import PullQuote from '~/components/universal/PullQuote.astro';
+import Footer3Col from '~/components/universal/Footer3Col.astro';
+
+A detector is not a feature that ships once. It is a control with a lifespan, and the mistake that produces most guardrail incidents is treating the first deployment as the end of the work rather than the middle of it.
+
+This blueprint specifies the path from proposal to retirement, what each gate requires, and which gates are allowed to block. ARCH-005 said who owns the decisions. This one says when they get made.
+
+## Eight gates
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-006-lifecycle.svg"
+  alt="Eight lifecycle gates from intake through tiering, build, red team, shadow, canary, enforce and monitor, with revalidation looping back and retirement as an exit, marking which gates block a release."
+  caption="Three gates can stop a release outright. Every gate has an exit criterion."
+/>
+
+**1. Intake.** Someone proposes a control, usually because of an incident, a regulation, a red-team finding, or a new system going live. The intake record captures what harm this addresses, which chokepoint it would sit at, and who is asking. Cheap and fast; the point is that controls have a front door rather than arriving as a ticket in a sprint.
+
+**2. Tiering.** The system this control protects gets a tier, and the tier sets everything downstream. This gate blocks: an untiered system cannot proceed, and a tier assigned by the delivery team without second-line sight is not a tier.
+
+**3. Build.** Technique, interface, composition, per ARCH-002. First line owns this outright. The output is a detector that satisfies the interface contract and a test set that is honest about its size.
+
+**4. Red team.** Someone whose job is to break it, tries. Not the author. Exit criterion: every bypass found is either fixed, routed to a control at a different chokepoint, or accepted in writing by the threshold owner. An open bypass with no disposition holds the gate.
+
+**5. Shadow.** The detector runs against real production traffic and records what it would have done. It takes no action. Exit criteria: the observed base rate is measured rather than assumed, the projected daily alert volume is inside what the review workflow is staffed for, and added latency at p95 is inside the budget from ARCH-008. Failing any of the three sends the threshold or the pipeline back, not the release forward.
+
+**6. Canary.** The detector enforces, on a bounded slice: one surface, one user group, or a percentage of traffic. Blast radius is the point. Exit criteria: the support and override volume is understood and attributable, and no unexplained class of false positive remains open.
+
+**7. Enforce.** Full traffic, enforcing. This gate blocks: it needs the go-live pack.
+
+**8. Monitor, then revalidate or retire.** The control is live and generating evidence on a cadence. Revalidation is scheduled at go-live, not triggered by memory.
+
+## Tiering decides the rest
+
+Every organisation that runs this well has a tier model, and every one that struggles has the same argument repeatedly about how much process a given system deserves. Tier once, at intake, and inherit.
+
+Tier on three properties, scored independently, then take the highest. **Authority**: can the system only read, or can it write to systems of record and take actions in the world. **Data sensitivity**: what the worst document it can retrieve would cost if disclosed. **Exposure**: internal users, or customers and the public. Collapsing these into a single "is it customer-facing" question is what puts a read-only public FAQ bot in the same tier as an agent that can move money, and that mistake discredits the model with the teams you need to apply it.
+
+| | Tier 3: contained | Tier 2: elevated | Tier 1: critical |
+|---|---|---|---|
+| Authority, data, exposure | Read-only, no restricted data, internal | Read-only or proposal-only, restricted data in scope, internal or contained | Writes to a system of record or acts externally, or restricted data with public exposure |
+| Typical system | Internal drafting aid, no retrieval of restricted data | Enterprise RAG over internal corpora, coding assistant with repo access | An agent that can move money or change records, or a public assistant over restricted data |
+| Mandatory categories | Content safety | Content safety, PII, prompt injection, system prompt leakage | All of Tier 2, plus tool-use authority controls and data leakage |
+| Red team | Optional | Required before enforce | Required before enforce, and repeated on material change |
+| Shadow period | Not required | Two weeks or 10,000 requests, whichever is later | Four weeks or 50,000 requests, whichever is later |
+| Threshold approval | First line | Second line | Second line, with governing-body-approved appetite |
+| Revalidation | Annual | Semi-annual | Quarterly, and on material traffic change |
+| Human review | None | Sampled | Sampled, plus a queue for the high-precision band |
+
+Every number in that table is illustrative. Neither the NIST Generative AI Profile nor the OWASP list sets review frequencies or shadow durations; those are yours to choose, and no external source will settle them for you. What matters is that they exist before the first system needs them, because a tier model negotiated during a launch is a tier model that reflects the launch date.
+
+<Callout type="warn" label="Tier the system, not the model">
+Tiering by model capability produces nonsense: the same model is a Tier 3 drafting aid and a Tier 1 payment agent depending on what you connected it to. The tier belongs to the deployed system and its authority, which is why it can change without the model changing.
+</Callout>
+
+## Shadow, then canary, then enforce
+
+This is the sequence teams compress, and compressing it is the single most reliable way to lose the mandate for a guardrail programme.
+
+**Shadow answers questions your test set cannot.** ARCH-003 shows that precision depends on the population. Shadow mode is where you measure that population. You learn the real base rate, the real false positive volume per day, and the real latency at production concurrency. A detector that looked fine at 0.91 precision offline routinely produces a four-figure daily alert volume in shadow, and it is much cheaper to discover that before it is blocking anything.
+
+Shadow requires the full decision path to run and record, taking no action. If shadow mode is implemented as "log the score", it will not surface the policy and action bugs, which are the ones that break users.
+
+**Canary bounds the blast radius of being wrong.** Enforcement changes user experience. Pick a slice where the population resembles production, where you have a feedback channel, and where you can revert in minutes. Two weeks of canary tells you what the support ticket volume looks like.
+
+**Enforcement is a decision, not a deployment step.** It needs the go-live pack, and the person who signs it is the threshold owner from ARCH-005, not the engineer merging the change.
+
+<PullQuote>Shadow mode is not a testing phase. It is the only place you get to measure the population your detector will actually meet, and it costs nothing but patience.</PullQuote>
+
+## The go-live pack
+
+The artefact that the enforce gate requires. Keeping it to one page is deliberate: a pack that takes a week to assemble will be assembled once and never updated.
+
+```
+GO-LIVE PACK  ·  <control id>  ·  <system>  ·  <tier>
+
+1  What this control detects, and the harm it prevents
+2  Chokepoint, technique, composition rule
+3  Offline results: precision and recall, with intervals, and
+   the size of the flagged set they rest on
+4  Shadow results: duration, request volume, observed base rate,
+   daily alert volume, p95 added latency
+5  Red-team summary: attempts, bypasses found, fixed vs accepted
+6  Threshold: the cost ratio, the approver, the traffic assumption
+7  Action on fire, and action on detector failure
+8  Review workflow: who sees what, at what volume, and the
+   staffing that assumes
+9  Rollback: the exact change that reverts to shadow, and who
+   can make it without an approval
+10 Revalidation date, and what would trigger it early
+```
+
+Item 9 is the one that gets waved through and matters most under pressure. If reverting to shadow requires a code deploy and a change advisory board, the actual rollback procedure during an incident will be someone disabling the control entirely.
+
+## The regression gate that blocks a release
+
+Guardrails need the same CI discipline as any other production dependency, and this is where policy-as-code stops being a slogan. Two gates belong in the pipeline.
+
+```yaml
+# .github/workflows/guardrail-gates.yml
+name: guardrail-gates
+on: [pull_request]
+
+jobs:
+  policy-validation:
+    # Gate 1: policy is data, so it compiles or it does not ship.
+    steps:
+      - run: guardrail policy validate policies/
+        # schema check, conflict detection, precedence ties are
+        # errors here rather than resolution rules at runtime
+      - run: guardrail policy test policies/ --cases tests/policy-cases.yaml
+        # synthetic verdicts with expected actions. catches the
+        # edit that quietly widens a default from redact to allow
+
+  detector-regression:
+    # Gate 2: no silent accuracy loss.
+    steps:
+      - run: >
+          guardrail eval run
+            --detector pii_in_response
+            --set eval/pii-v7.jsonl
+            --baseline baselines/pii_in_response.json
+            --floor baselines/pii_in_response.floor.json
+            --fail-on recall_drop=0.02,precision_drop=0.03,
+                      alert_volume_increase=0.15,latency_p95_increase=15ms
+      - run: guardrail eval report --format markdown >> $GITHUB_STEP_SUMMARY
+```
+
+Three design notes.
+
+The gate fails on a *drop against the last accepted baseline*, because absolute targets get lowered until they pass. But a per-change tolerance alone permits cumulative decay: twenty changes each losing 1.9 percent of recall all pass, and the detector has quietly lost a third of its recall. So the gate also carries a **floor**, set at go-live and changeable only with the same approval as the original threshold. Baseline catches the bad change; floor catches the slow slide.
+
+It fails on precision and projected alert volume, not just recall. A change that improves recall while doubling false positives has not improved the control, it has moved the cost onto the review queue, and per ARCH-003 that is the failure mode that ends guardrail programmes socially.
+
+And it fails on latency, because a detector that became 40ms slower has spent someone else's budget whether or not anyone noticed.
+
+<Callout type="tip" label="Version the eval set like code">
+`eval/pii-v7.jsonl` is versioned deliberately. When a regression fires, the first question is always whether the detector got worse or the test set got harder, and that is unanswerable if the set is mutable. Changing the set is a reviewed change with its own approval.
+</Callout>
+
+## Worked example: a prompt injection detector
+
+An enterprise RAG assistant over internal documents, Tier 2. Injection arrives inside retrieved content, which is the case ARCH-001 says the prompt layer cannot attribute. This walkthrough is a constructed example, not a report of a specific deployment; the figures show the shape of what each gate produces.
+
+| Gate | What happened | Artefact produced |
+|---|---|---|
+| Intake | Red-team exercise on a sibling system planted instructions in a shared document and got the assistant to summarise a restricted file | Intake record naming retrieval as the chokepoint |
+| Tiering | Internal corpus, no write access, restricted documents in scope: Tier 2 | Tier record, inherited by every later gate |
+| Build | Rules for known patterns, plus a trained classifier over retrieved chunks. Verdict composition, weighted | Detector at interface contract, eval set v1 at 1,200 labelled chunks |
+| Red team | 40 attempts, 9 bypasses. 6 fixed, 3 accepted as out of scope for this technique and routed to the retrieval entitlement control instead | Red-team report, three accepted risks with reasons |
+| Shadow | 3 weeks, 68,000 requests. Observed base rate far below the test set. Daily alert volume at the proposed threshold: 340 | Shadow report; threshold revised upward before enforcement |
+| Canary | One business unit, 2 weeks. 11 support tickets, 9 of them one false positive pattern in a template document | Canary report; one rule narrowed |
+| Enforce | Go-live pack signed by the second-line owner | Go-live pack, threshold approval |
+| Monitor | Weekly regression, monthly sampled review, quarterly revalidation booked at go-live | Evidence pack per ARCH-005 |
+
+The two things this example is meant to show. Shadow changed the threshold, which means shipping straight from offline results would have produced 340 alerts a day into a queue staffed for a fraction of that. And red team found nine bypasses, three of which were correctly *not* fixed in this detector, because the right control for them lived at a different chokepoint. A programme that treats every red-team finding as a defect in the detector under test will build one enormous detector that does everything badly.
+
+## Where this blueprint stops working
+
+**The lifecycle assumes a stable definition of the thing you detect.** Prompt injection in 2026 is not what it was in 2024, and a detector that passes revalidation against a 2024 test set is measuring the wrong thing accurately. Test set refresh has to be its own scheduled work, owned by whoever owns the threat model, or revalidation becomes a ritual that always passes.
+
+**Shadow mode has a real cost.** Running every detector against full production traffic while taking no action doubles the detection compute for the shadow period, and for an LLM judge that is not a rounding error. Tier 3 systems will not justify it. Say that explicitly rather than letting teams quietly skip the gate.
+
+**Retirement almost never happens.** Controls accumulate, each one adding latency and false positives, and no team is rewarded for removing one. Without a forcing function the pipeline only grows.
+
+Resist the obvious proxy. "It has not fired a true positive in a year" is not evidence a control is unnecessary: the attack may be rare rather than absent, the control may be deterring the attempt, or it may be failing to detect what is happening. A defensible retirement case needs three things instead. The harm it addresses is now prevented deterministically somewhere else, usually by an authorization control that made the classification question moot. Its true positives over the period are attributable to that other control on replay. And the threat model that motivated it has been reviewed and still says the same thing. Absent those, the honest answer is that the control stays and its cost is the price of the risk.
+
+<Footer3Col
+  fromBook={[
+    { label: "Ch 6: Evaluating and Hardening Agents", href: "/book/06-evaluating-and-hardening/" },
+    { label: "Ch 9: Deployment", href: "/book/09-deployment/" },
+  ]}
+  readNext={{ label: "ARCH-007: Telemetry, Audit and the Review Loop", href: "/architecture/007-telemetry-audit-and-review/" }}
+/>

--- a/src/content/architecture/007-telemetry-audit-and-review.mdx
+++ b/src/content/architecture/007-telemetry-audit-and-review.mdx
@@ -1,0 +1,195 @@
+---
+id: arch-007
+title: Telemetry, Audit and the Review Loop
+dek: The control plane produces three different things people call logs, with three different retention rules and three different audiences. Merging them is how a system ends up unable to answer a regulator and full of sensitive data at the same time.
+description: "What an AI control plane emits, how a decision is traced across six chokepoints, why the audit trail is itself a leak surface, how to design a review queue reviewers keep taking seriously, and the loop that turns a red-team finding or an incident into a detector change. Includes a worked example for system prompt leakage."
+layer: evidence
+order: 7
+readingTime: 11
+updated: 2026-08-19
+specifies: The telemetry, audit and human review machinery around an AI control plane
+appliesTo: [RAG platform, Coding assistant, Agent system]
+decisions:
+  - Which of the three log types each fact belongs in
+  - What a reviewer sees, and how much of it
+  - How a red-team finding becomes a threshold or detector change
+anchors:
+  - label: Three kinds of log
+    anchor: three-kinds-of-log
+  - label: Tracing a decision
+    anchor: tracing-one-decision-across-six-chokepoints
+  - label: The audit trail leaks
+    anchor: the-audit-trail-is-a-leak-surface
+  - label: The review queue
+    anchor: designing-a-queue-people-keep-reading
+  - label: The feedback loop
+    anchor: the-loop-from-finding-to-change
+  - label: Worked example
+    anchor: worked-example-system-prompt-leakage
+  - label: Where it breaks
+    anchor: where-this-blueprint-stops-working
+references: [ch-10, ch-11]
+patterns: [trace-the-truth, failure-buckets]
+sources:
+  - title: "OWASP Top 10 for LLM Applications 2025"
+    url: https://genai.owasp.org/llm-top-10/
+    year: 2025
+  - title: "Artificial Intelligence Risk Management Framework: Generative Artificial Intelligence Profile, NIST AI 600-1"
+    url: https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf
+    authors: [National Institute of Standards and Technology]
+    year: 2024
+  - title: "OpenTelemetry Tracing API specification"
+    url: https://opentelemetry.io/docs/specs/otel/trace/api/
+    authors: [OpenTelemetry Authors]
+---
+
+import Callout from '~/components/universal/Callout.astro';
+import ArchitectureDiagram from '~/components/universal/ArchitectureDiagram.astro';
+import PullQuote from '~/components/universal/PullQuote.astro';
+import Footer3Col from '~/components/universal/Footer3Col.astro';
+
+The observability layer of an AI system is where two requirements collide head on. Assurance wants to reconstruct any decision months later: which detectors ran, what they said, what the system did. Privacy wants the prompts and responses gone, because they are the same sensitive material the controls exist to protect. Both are right, and a single log store cannot satisfy both.
+
+The resolution is not a compromise on retention. It is recognising that what teams call "the logs" is three separate stores. ARCH-001 made the related point that logging prevents nothing and is itself a leak surface; this blueprint is what follows from taking that seriously.
+
+## Three kinds of log
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-007-three-logs.svg"
+  alt="Three log stores side by side: operational telemetry, the decision record, and the content archive, each with its own contents, retention period, access control and audience."
+  caption="Different contents, different retention, different readers. One store cannot serve all three."
+/>
+
+**Operational telemetry.** Counters, latencies, error rates, detector availability, queue depth. No content, no identifiers beyond a request id. Short retention, wide access, and it is what the on-call engineer looks at. This is the only one of the three that can be sampled without an argument.
+
+**The decision record.** One per decision, per ARCH-004: which detectors ran and at which versions, what they returned, which policy version applied, what action was taken, whether anything was degraded, who overrode it. Long retention, narrow access. It contains no prompts and no responses, only identifiers, versions, verdict metadata and content hashes, and that constraint is what makes long retention affordable.
+
+A record only carries weight in an audit if it cannot have been edited afterwards. Append-only storage, a hash chain over the sequence, and write credentials separate from the application's own are the minimum; without them you have a log that asserts a control ran, not evidence that it did.
+
+**The content archive.** The actual prompts, retrieved chunks and responses. This is the only store that answers "what exactly did the user see", and it is the one that is itself a disclosure risk. Short retention by default, access on a break-glass basis, encrypted separately. Where a detector has already located the sensitive span, the archive holds the masked form plus offsets rather than the raw value; the raw text survives only where a defensible purpose requires it and only for as long as that purpose lasts.
+
+The decision record references the content archive by id rather than embedding it. When the archive expires, the decision record survives, and you can still prove that a control ran and what it did without holding the sensitive text forever.
+
+<PullQuote>Keep the fact that a decision was made for years. Keep the text that decision was about for weeks. Conflating those two is how audit requirements turn into a data protection finding.</PullQuote>
+
+## Tracing one decision across six chokepoints
+
+A single user question can touch retrieval, prompt, response and one or more tool calls, each with its own detectors. Assurance questions are almost never about one chokepoint. They are about one request.
+
+That makes correlation the most load-bearing part of the whole design. A single flat id is not enough once anything runs concurrently or asynchronously: parallel detectors, a fan-out to three tools, and a nested agent call all need to be distinguishable and orderable afterwards. Use the trace model everyone else already uses, rather than inventing one. A `trace_id` for the request, a `span_id` per operation with its parent, and explicit links where a later operation was caused by an earlier one across a queue boundary. The OpenTelemetry trace API defines these, and reusing it means your control-plane evidence lands in the same tooling as the rest of your traces.
+
+```
+request_id: 8f2a...     ← minted at the edge, never regenerated
+  ├─ retrieval    12 chunks considered, 3 filtered by entitlement
+  │                detectors: injection_scan → clear
+  ├─ prompt       assembled, provenance preserved
+  │                detectors: injection_scan → abstain
+  ├─ response     detectors: pii_scan → flagged (band: above)
+  │                policy 2026-08-18.3 → mask
+  ├─ tool  send_email   BLOCKED
+  │                reversal_cost impossible via exposure promotion
+  │                decision: require_approval → not granted, expired
+  └─ logging      content archived, id c4d1..., retention 30d
+```
+
+Three things this makes answerable that a per-detector log cannot. Whether a control was present but silent versus absent entirely, which is the difference between a tuning problem and a coverage gap. Whether the retrieval filter did work that the response detector then got credit for. And whether the blocked tool call came from the same request as the flagged response, which is the difference between one incident and two.
+
+<Callout type="warn" label="The abstain that reads as clear">
+In the trace above, `injection_scan` abstained at the prompt layer. A dashboard that counts "detectors that did not flag" will show that request as clean twice. Abstentions need their own series, because a rising abstention rate is the earliest signal that traffic has moved away from what the detector was trained on.
+</Callout>
+
+## The audit trail is a leak surface
+
+The store that proves your controls worked is full of the exact material those controls exist to protect. Four rules keep that from becoming its own incident.
+
+**Redact on write, not on read.** If the content archive holds raw PII and access control is the only protection, then every future integration, export and backup is a new copy of the problem. Where the detector already found the span, store the masked form and the span offsets.
+
+**Access to the archive is itself a logged decision.** Break-glass reads produce their own records: who, when, which request, stated reason. If reading the archive is easier than filing a ticket, it will become routine.
+
+**Separate the encryption boundary.** The decision record and the content archive should not be readable with the same credential. The most common realistic breach here is not an attacker, it is an overly broad internal analytics grant.
+
+**Set each store's retention from its own obligation, and reconcile them deliberately.** Teams default to the longest period any stakeholder mentions, applied to everything, because deleting feels risky. Split the question instead. The decision record is evidence, so its retention follows whatever records-retention rule governs control evidence in your jurisdiction and sector. The content archive is personal data, so its retention follows the data protection principle that you keep it no longer than the purpose requires. Those two obligations point in opposite directions, which is exactly why they cannot live in one store. Where they genuinely conflict, that is a decision for legal and the privacy office to make and record, not for a platform default.
+
+## Designing a queue people keep reading
+
+ARCH-003 established that a good detector against a rare attack can be wrong nine times out of ten. That arithmetic has an organisational consequence: an alert queue fed by raw detector output will be abandoned, and the abandonment is rational.
+
+Four design rules follow.
+
+**Route by precision band, not by severity.** The high-precision band goes to humans. The low-precision band goes to an automatic mitigation that is cheap to be wrong about, such as masking or an extra verification pass. Severity decides the action; precision decides who looks.
+
+**Show the reviewer the evidence, not the score.** A reviewer cannot act on "0.87". They can act on the matched span, the surrounding text, the category, and what the system did about it. The `evidence` field in the detector contract exists for this.
+
+**Give the queue a service level and staff to it.** A queue with no target response time and no headcount attached is a backlog with a dashboard. If the volume implied by your threshold exceeds what you can staff, the threshold is wrong, not the reviewers.
+
+**Measure the reviewers.** Sample agreement between reviewers on the same items. A queue where two reviewers disagree half the time is not producing labels you can tune against, and that disagreement is also the ceiling on your test set quality, per ARCH-003.
+
+## The loop from finding to change
+
+Red teaming and incidents both produce the same raw material: a case the current controls handled wrongly. Without a defined path, those findings become a slide deck.
+
+| Stage | Owner | Output | Cadence |
+|---|---|---|---|
+| Finding | Red team, incident review, or a reviewer disagreement | A reproducible case with expected and actual behaviour | Continuous |
+| Triage | First line, guardrails team | Which chokepoint should have caught it, and which control | Weekly |
+| Disposition | Threshold owner with first line | Fix detector, move threshold, change policy, add a control, or accept | Weekly |
+| Test set | First line | The case is added to the versioned eval set, labelled | With the change |
+| Verify | Regression gate in CI, per ARCH-006 | The case passes, and nothing else regressed | On merge |
+| Close | Second line for Tier 1 and 2 | Finding closed with the change that closed it | Monthly review |
+
+The step teams skip is the fourth. A fix that does not add the case to the eval set is a fix that will be regressed by the next model change, silently. Every closed finding should leave behind a permanent test.
+
+## Worked example: system prompt leakage
+
+A coding assistant with a system prompt containing internal tool names and repository conventions. OWASP lists system prompt leakage as LLM07, and ARCH-001 puts the response layer as the only chokepoint where the leak is observable.
+
+**What each store holds for one leak event:**
+
+```
+operational telemetry
+  detector.sysprompt_leak.fired  +1     (no content)
+  detector.sysprompt_leak.p95_ms 42
+  action.block                   +1
+
+decision record  (retention per your evidence rule; no content)
+  request_id        8f2a...
+  chokepoint        response
+  principal         svc:code-assist / user:1042
+  detectors_run     sysprompt_leak@2026-07-02, pii_scan@2026-06-11
+  verdicts          sysprompt_leak: flagged, band above,
+                    categories [system_prompt_fragment],
+                    evidence_ref ev:9931
+  policy_version    2026-08-18.3
+  action            block
+  outcome           blocked
+  degraded          false
+
+content archive  (short retention, break-glass, separately encrypted)
+  ev:9931   the matched span, masked, with offsets
+  c4d1...   full prompt and response, encrypted
+```
+
+**The review path.** This detector is high precision, so it goes to a human queue rather than to sampling. The reviewer sees the masked span, the category and the action, not the raw system prompt.
+
+**The loop, on this case.** The record above is a true positive: the detector fired and the response was blocked, so nothing leaked. It still enters the loop, because a reviewer confirms the classification and the case becomes a labelled example.
+
+The loop matters more in the other direction. In the same period a red-team exercise finds a phrasing family that gets a fragment of the system prompt out *without* firing this detector. That is a genuine false negative, and it has no decision record showing a flag, which is precisely why red teaming and not the queue is what surfaces it. Triage puts it at the response chokepoint, correctly. Disposition is to extend the detector's rules rather than lower the threshold, because precision is already good and the gap is coverage, and lowering the threshold would buy recall by flooding the queue. The case joins `eval/sysprompt-v4.jsonl` with its label, the regression gate proves it now passes and that precision did not drop, and second line closes the finding at the monthly review.
+
+**What this costs.** Measure your own per-event review time and write it down, because a programme that cannot state that number cannot tell whether a threshold change is affordable. It is the multiplier that turns a change in false positive rate into a headcount conversation, and it is the number missing from most threshold proposals.
+
+## Where this blueprint stops working
+
+**Three stores is more infrastructure than a small deployment will accept.** For a Tier 3 system the honest answer is one store with short retention and tight access, and an explicit acceptance that you will not be able to reconstruct a decision from six months ago. Say it, rather than discovering it during an audit.
+
+**Traces do not survive every architecture.** Batch pipelines, asynchronous agents and anything queue-driven will break naive correlation id propagation, and a partial trace is worse than none because it looks complete. If the id cannot survive a hop, record the discontinuity explicitly at the boundary.
+
+**Review capacity is the real constraint, and it does not scale with traffic.** Every threshold conversation is implicitly a staffing conversation, and the queue is the first thing to degrade under cost pressure. A control whose design assumes human review, in an organisation that will not fund human review, is a control that will silently become allow-and-log.
+
+<Footer3Col
+  fromBook={[
+    { label: "Ch 10: Governance", href: "/book/10-governance/" },
+    { label: "Ch 11: Security Deep Dive", href: "/book/11-security/" },
+  ]}
+  readNext={{ label: "ARCH-008: Production Execution", href: "/architecture/008-production-execution/" }}
+/>

--- a/src/content/architecture/008-production-execution.mdx
+++ b/src/content/architecture/008-production-execution.mdx
@@ -1,0 +1,210 @@
+---
+id: arch-008
+title: Production Execution
+dek: Detection is work you added to a request that a user is waiting on. The latency budget, not the accuracy target, is what decides how many detectors you can actually run and in what order.
+description: "The runtime engineering of a guardrail pipeline: the latency budget, parallel execution, tiered detection that reserves expensive detectors for an ambiguous band, timeout isolation, graceful degradation that does not silently fail open, and rollout as a config change rather than a deploy. Includes a worked budget for tool-use risk control on a coding assistant."
+layer: control
+order: 8
+readingTime: 11
+updated: 2026-08-19
+specifies: The runtime execution, performance and failure behaviour of a detector pipeline
+appliesTo: [RAG platform, Coding assistant, Agent system]
+decisions:
+  - What share of the request budget detection may consume
+  - Which detectors run on every request and which run on a band
+  - What the system does when a detector is slow rather than wrong
+anchors:
+  - label: The latency budget
+    anchor: start-from-the-latency-budget
+  - label: Parallel and tiered
+    anchor: parallel-first-then-tiered
+  - label: Timeout isolation
+    anchor: timeout-isolation
+  - label: Degradation
+    anchor: degradation-that-does-not-fail-open
+  - label: Rollout
+    anchor: rollout-is-a-config-change
+  - label: Worked example
+    anchor: worked-example-tool-use-control-on-a-coding-assistant
+  - label: Where it breaks
+    anchor: where-this-blueprint-stops-working
+references: [ch-09, ch-11]
+patterns: [tool-registry, workflow-first]
+sources:
+  - title: "OWASP Top 10 for LLM Applications 2025"
+    url: https://genai.owasp.org/llm-top-10/
+    year: 2025
+---
+
+import Callout from '~/components/universal/Callout.astro';
+import ArchitectureDiagram from '~/components/universal/ArchitectureDiagram.astro';
+import PullQuote from '~/components/universal/PullQuote.astro';
+import Footer3Col from '~/components/universal/Footer3Col.astro';
+
+Every detector in ARCH-002 is correct in isolation and expensive in aggregate. A pipeline assembled by adding one well-justified control at a time, each approved on its merits, arrives at a system where detection costs more than inference and the product team is asking to turn it off.
+
+This blueprint is the runtime half of the control layer: what the pipeline costs, how it is ordered, and what it does when a component is slow rather than wrong. It is where guardrails stop being a safety topic and become an ordinary distributed systems problem.
+
+## Start from the latency budget
+
+The budget is the design input. Decide it before choosing detectors, because it is what makes the choice decidable.
+
+Two properties matter. Detection latency is *added* latency, on top of retrieval and inference, so users experience it directly. And it lands differently at each chokepoint: work at upload is asynchronous and effectively free, work at the prompt layer is fully on the critical path, and work at the response layer is on the path but can sometimes overlap with streaming.
+
+```
+budget for a synchronous assistant turn      p95 2,500 ms
+(illustrative allocation, not a benchmark)
+
+  retrieval                                   250 ms
+  inference (streamed)                      1,700 ms
+  ─────────────────────────────────────────────────
+  remaining for all detection                 550 ms   (22%)
+
+  allocated
+    prompt-layer detectors, parallel           120 ms
+    response-layer detectors, parallel         180 ms
+    tool-call policy decision, per call         40 ms
+    reserve for retries and jitter             210 ms
+```
+
+The reserve is the part teams omit. A budget spent to the last millisecond at p95 has no room for the day a dependency is slow, and the failure mode is timeouts across the whole pipeline at once.
+
+<PullQuote>Detection you cannot afford at p95 is detection you will turn off during the first incident. Budget it like capacity, not like correctness.</PullQuote>
+
+## Parallel first, then tiered
+
+Two independent techniques, and the order in which you apply them matters.
+
+**Parallel execution is the cheap one, in latency.** Detectors at the same chokepoint are independent by construction, per ARCH-002. Run them concurrently and the chokepoint costs the slowest detector rather than the sum. Any pipeline still running detectors in sequence is paying a bill it does not owe.
+
+It is not free in any other currency. The compute, the connections, the rate limit against a managed service and the load on every shared dependency are unchanged, and they now all arrive at once instead of spread out. Two second-order effects follow. Concurrency raises peak resource demand at exactly the moment traffic peaks. And the latency of a maximum over several distributions is worse than any single one of them: with enough parallel detectors, the chance that at least one is in its own tail approaches certainty, so a chokepoint of six detectors has a worse tail than its slowest detector measured alone. Parallelism buys you the mean and costs you a little of the tail.
+
+The composition rule also needs all the verdicts before it decides, so the chokepoint cost is bounded below by your slowest detector. That is what makes a single LLM judge in the parallel set so expensive: it sets the floor for everything.
+
+**Tiering is how you afford the expensive one.** Rather than running the judge on every request, run the cheap deterministic detectors first and reserve the judge for the band where the cheap ones are ambiguous.
+
+<ArchitectureDiagram
+  wide
+  src="/assets/diagrams/arch-008-tiered-pipeline.svg"
+  alt="A tiered detector pipeline: cheap deterministic detectors run in parallel on every request, clear and above-threshold verdicts resolve immediately, and only the ambiguous middle band escalates to an expensive judge with its own timeout."
+  caption="The judge sees the ambiguous band, not the traffic. That ratio is the whole cost model."
+/>
+
+The economics are worth doing properly, because the usual hand-wave is wrong. Amortising cost is straightforward: a judge that runs on a tenth of traffic costs a tenth as much. Amortising *latency* is not, and this is where budgets get broken.
+
+A percentile is a position in a sorted distribution. If a fraction `f` of requests escalate to the judge, and every escalated request is slower than every non-escalated one, then the judge shows up in your p95 whenever `f` is greater than 5 percent. Escalate a tenth of traffic and your p95 *is* a judge call, no matter how fast the cheap tier is.
+
+```
+  escalation rate f      what sets p95        what sets p99
+  ─────────────────────────────────────────────────────────
+  f = 10%                the judge            the judge
+  f =  5%                the boundary         the judge
+  f =  2%                the cheap tier       the judge
+```
+
+Three consequences. The fraction reaching the judge has to be smaller than the tail you are protecting, or the judge is your p95. Reporting p95 alone hides an expensive tier entirely, so report the percentile above your escalation rate too. And if the ambiguous band is genuinely 10 percent of traffic, the answer is not a faster judge; it is to stop waiting on it, either by routing that band to an action that does not need the judge's answer now, such as `require_approval`, or by narrowing the band.
+
+<Callout type="warn" label="Tiering changes what your measurements mean">
+A judge that only ever sees the ambiguous band is running against a population deliberately enriched for hard cases. Its precision on that population is not comparable to its precision on a balanced test set, and per ARCH-003 it is the population that decides. Measure the tiered judge on tiered traffic, or the number is fiction.
+</Callout>
+
+## Timeout isolation
+
+Every detector gets its own timeout, and no detector's timeout is the request's timeout. This sounds obvious and is routinely violated by pipelines that await the whole detector set with one deadline.
+
+Three rules.
+
+**Per-detector deadlines, sized to the detector.** A regex has a 5ms deadline; a judge has 400ms. A shared deadline means the fast detectors inherit the slow one's tail.
+
+**A pipeline deadline that is less than the remaining request budget.** When it expires, the pipeline returns what it has, with the missing detectors marked `execution_status: timeout` rather than absent. ARCH-002 keeps `execution_status` separate from `decision` precisely so this case is representable.
+
+**Circuit breakers per detector, not per pipeline.** A detector failing 80 percent of calls should be taken out of the parallel set entirely for a cool-down, marked degraded, and reported. Continuing to call it costs the whole pipeline its timeout on every request for no verdicts.
+
+## Degradation that does not fail open
+
+ARCH-002 said a timeout is not a verdict. Here is what that means at runtime. The tiers are the ones from ARCH-006, in one line: Tier 3 is read-only, internal, no restricted data; Tier 2 handles restricted data or proposes changes; Tier 1 can write to a system of record or act externally.
+
+| Situation | Tier 3 | Tier 2 | Tier 1 |
+|---|---|---|---|
+| One cheap detector times out | Proceed, mark degraded | Proceed, mark degraded | Proceed, mark degraded, alert |
+| The judge times out | Proceed on cheap-tier verdicts | Fall back to the cheap tier's conservative band | Fail closed for irreversible actions, proceed for read-only |
+| Policy store unreachable | Last-known-good policy | Last-known-good policy, alert | Last-known-good; if none loadable, fail closed |
+| Whole detection pipeline down | Proceed, mark degraded, alert | Fail closed at tool execution, proceed elsewhere | Fail closed at tool execution and response |
+
+The row that decides whether this design is honest is the last one. A system that proceeds normally with its entire detection pipeline down has not degraded gracefully; it has turned the controls off and kept serving.
+
+There is a tempting shortcut here, and it is wrong: that information-harm chokepoints can fail open because only actions are irreversible. You cannot un-disclose. A response that emits credentials, personal data or a restricted document is as irreversible as a payment, and in a regulated setting it is reportable. Reversibility is a property of the specific harm, not of the harm family, which is the same correction ARCH-004 applies to the action grid.
+
+The defensible rule is by exposure and sensitivity rather than by family. Fail open with a record where the content is low sensitivity and the exposure is contained, which is most Tier 3 internal traffic. Fail closed wherever the chokepoint can emit restricted data, wherever the exposure crosses a trust boundary, and always at tool execution, because per ARCH-001 that is the only place an act can still be stopped. A system whose only fail-closed chokepoint is tool execution has decided, usually without noticing, that disclosure is recoverable.
+
+Two invariants regardless of tier. Every degraded request is marked degraded in its decision record, so the period is reconstructable afterwards. And degradation is time-boxed with an alert, because a system that has been quietly degraded for four hours is one that will describe itself as healthy in the incident review.
+
+<Callout type="tip" label="Test degradation the way you test detection">
+Fault injection belongs in the guardrail test suite: kill a detector, slow it past its deadline, make the policy store unreachable, and assert the resulting action and the decision record. The generic try/except that returns a passing result from ARCH-002 is only findable this way.
+</Callout>
+
+## Rollout is a config change
+
+The lifecycle in ARCH-006 needs shadow, canary and enforce to be states the running system can be moved between without a deploy. If changing enforcement requires shipping code, then shadow is a branch nobody maintains and rollback during an incident is a release.
+
+```yaml
+# per control, per system: the runtime state machine
+control: prompt_injection.retrieval
+system: rag-assistant-eu
+mode: canary                 # off | shadow | canary | enforce
+canary:
+  slice: business_unit=markets
+  percentage: 100
+timeouts:
+  cheap_tier_ms: 60
+  judge_ms: 400
+  pipeline_ms: 500
+degradation:
+  on_timeout: proceed_marked_degraded
+  on_pipeline_down: fail_closed_at_tool_execution
+rollback:
+  to: shadow
+  authorised: [platform.oncall, platform.guardrails]
+  requires_approval: false      # deliberately
+```
+
+`requires_approval: false` on rollback is the important line and the one that will attract governance objections. The argument for it: moving a control from enforce back to shadow reduces user impact and is fully recorded. Requiring an approval to do it means the real rollback during an incident will be someone disabling detection entirely, which is strictly worse and less visible.
+
+## Worked example: tool-use control on a coding assistant
+
+A coding assistant that can read a repository, propose changes, and run a small set of tools. The control in question is the tool-execution policy decision from ARCH-004, the only chokepoint that can prevent action harm.
+
+**Budget.** Tool calls are not on the streaming path; the user is waiting on a discrete action. Budget: 120ms p95 for the policy decision, which is generous because it is deterministic work.
+
+**Pipeline, per tool call:**
+
+| Stage | Technique | Deadline | Runs on |
+|---|---|---|---|
+| Tool registry lookup | Static config | 5 ms | Every call |
+| Authority check | Deterministic policy: actor, action, resource | 20 ms | Every call |
+| Argument scan | Rules over arguments for secrets and paths outside the workspace | 15 ms | Every call |
+| Judge on intent | LLM evaluator against the written policy | 400 ms | Only `reversal_cost: impossible` calls in the near band |
+
+Reading it from the bottom: the judge only ever sees calls that are both irreversible and ambiguous. In an assistant whose traffic is dominated by reads, that is a small share of calls, and the rule from the previous section applies directly. Measure that share. If it sits below the tail you are budgeting, the deterministic tiers set your p95 and the judge shows up only in p99. If it does not, the judge is your p95 and the design has to change rather than the number being explained away.
+
+**Degradation.** If the registry or authority check is unavailable, fail closed: no tool call proceeds without an authority decision, because there is no safe default for "may this actor do this". If only the judge is unavailable, calls with `reversal_cost: impossible` in the near band route to `require_approval` instead of proceeding, which converts a detection outage into a human wait rather than an unchecked action.
+
+**What the rollout looks like.** This is a constructed example rather than a report of a specific deployment. Shadow, for the period the tier requires, recording what would have been blocked. The finding worth anticipating: a widely used internal tool registered with the wrong `exposure`, which would have blocked a normal workflow on day one of enforcement. Registry data quality, not detector quality, is the usual reason a tool-use control cannot be switched on. Then canary on one team, then enforce, with rollback to shadow available to on-call without approval.
+
+**The point of this example.** The expensive, model-based part of the control is the smallest part of the design. The load is carried by a registry lookup and a deterministic authority check, which is the same conclusion ARCH-001 reached from a different direction: the highest-value controls are usually authorization questions rather than classification ones.
+
+## Where this blueprint stops working
+
+**Budgets assume a synchronous request.** Long-running agents that work for minutes have no user waiting on a p95, and their constraint is cumulative cost and the blast radius of many actions rather than added latency. The tiering logic still applies; the budget framing does not.
+
+**Tiering leaks information about the tiers.** An attacker who can tell which requests took 400ms has learned which inputs reach the judge, and that is a usable signal for probing the cheap tier's boundary. Where that matters, add jitter or pad the fast path, and accept the cost.
+
+**Fail closed is not free, and sometimes not right.** A system that fails closed at tool execution during a detector outage stops doing useful work, and for some workloads that outage is more damaging than the risk it prevents. That is a legitimate business decision, and it belongs to the threshold owner from ARCH-005 with an explicit acceptance, not to the engineer choosing a default in a config file.
+
+<Footer3Col
+  fromBook={[
+    { label: "Ch 9: Deployment", href: "/book/09-deployment/" },
+    { label: "Ch 11: Security Deep Dive", href: "/book/11-security/" },
+  ]}
+  readNext={{ label: "ARCH-001: The Control Plane", href: "/architecture/001-the-control-plane/" }}
+/>


### PR DESCRIPTION
ARCH-001 to 004 specify machinery: where controls sit, what a detector returns, how to measure it, what the decision layer does. None of them say who owns the threshold, what gates a release, what the audit trail holds, or what the pipeline does at p95. That is the organizational half, and it fills the Evidence layer that has been empty since the pillar shipped.

## The four

| | |
|---|---|
| **ARCH-005 Ownership and Decision Rights** (Evidence) | Five separable decisions inside one guardrail, each with a different owner. The Three Lines Model applied as a recommended assignment. The control → owner → evidence → frequency → escalation table. Exception records with a mandatory expiry and a compensating control that addresses the same harm. |
| **ARCH-006 The Guardrail Lifecycle** (Evidence) | Eight gates, each with an exit criterion, three of which can stop a release. A tier model scored on authority, data sensitivity and exposure independently. The go-live pack. A CI gate carrying both a baseline and a floor. |
| **ARCH-007 Telemetry, Audit and the Review Loop** (Evidence) | Three log stores with different contents, retention, access and readers. Trace and span correlation rather than one flat id. Tamper evidence. Queue design that survives the base-rate arithmetic. The finding-to-change loop. |
| **ARCH-008 Production Execution** (Control) | The latency budget as the design input. Why an escalation rate above your tail makes the judge set your p95. Timeout isolation, circuit breakers, degradation keyed on exposure, and rollout as a config change. |

Each carries a worked example with its artifacts: PII in responses on a RAG assistant, a prompt injection detector through all eight gates, system prompt leakage on a coding assistant, and tool-use control on a coding assistant. Shippable artifacts include an exception record, a go-live pack contents list, a CI workflow, an evidence pack layout, a decision record, and a runtime control config.

Four diagrams in the system established by PR #29. `ArchitectureDiagram` unchanged.

## Codex review

Run over all four, as with ARCH-001..004. It returned **major revisions on all four**, and the criticism was substantive rather than stylistic. Fixed:

- **Source accuracy.** The IIA Three Lines Model does not grant the second line approval authority, and states that responsibility for managing risk "remains a part of first line roles". Verified against the primary PDF. The mapping is now presented as a recommended design, with that constraint stated.
- **A safety error.** ARCH-008 claimed information-harm chokepoints can fail open with a record. You cannot un-disclose; a response emitting credentials or restricted data is as irreversible as a payment. Degradation is now keyed on exposure and sensitivity, not on harm family.
- **A maths error.** The p95 argument was asserted. If a fraction `f` of requests escalate to the judge and `f` exceeds 5 percent, the judge *is* your p95. Now shown with the escalation-rate table and the consequence spelled out.
- **A gate that allowed decay.** Baseline-only regression passes twenty changes each losing 1.9 percent of recall. The gate now carries a floor set at go-live, and fails on precision and projected alert volume, not just recall.
- **An unsafe retirement proxy.** "No true positive in a year" cannot distinguish a rare attack, a deterred one, and a missed one. Retirement now requires evidence the harm is covered elsewhere.
- **A self-contradicting worked example.** ARCH-007 recorded a successful block then called it a coverage miss. Rewritten as a true positive plus a genuine red-team-found false negative.
- **Unsourced numbers** removed or labelled illustrative throughout, including retention periods, sampling rates, cost ratios and shadow durations.

## Verification

- `npm run build` green, `astro check` 0 errors, `vitest` 21/21
- Every declared anchor resolves; every internal link resolves
- No em dashes, no AI tells
- Architecture index renders five Control and three Evidence blueprints

## Pre-existing, not fixed here

The site footer links `/roadmap/` and `/code/` return 404 on every page, including the live site. Not introduced by this work.
