### PR TITLE
Link the blueprints back to the transformation playbook

### DIFF
--- a/src/content/architecture/005-ownership-and-decision-rights.mdx
+++ b/src/content/architecture/005-ownership-and-decision-rights.mdx
@@ -198,6 +198,8 @@ None of those artefacts contains a prompt or a response. The decision records ca
 
 ## Where this blueprint stops working
 
+**This assumes a governance function exists to assign the decisions to.** Where one does not, the blueprint describes a structure with nobody to put in it, and the prior work is establishing the mandate, the funding and the operating model that make these roles real. The [Enterprise AI Transformation playbook](https://sunilprakash.com/enterprise-ai/governance/architecture/) covers that layer, including the three-layer separation of policy, process and control this blueprint sits inside.
+
 **Small organisations do not have three lines.** In a company where the same person owns product and risk, the model collapses into a checklist rather than a structure. It still helps to keep the five decisions separate and to write down who made each one, because the value was never the org chart. It was the separation of the threshold decision from the model decision.
 
 **Ownership does not survive a reorg on its own.** A control-to-evidence table with a named role in it is stale the moment that role changes hands. The table needs an owner too, and the only durable answer is to attach the control to a role that appears in the system of record rather than to a person, then review the mapping on the same cadence as the controls.

--- a/src/content/architecture/006-the-guardrail-lifecycle.mdx
+++ b/src/content/architecture/006-the-guardrail-lifecycle.mdx
@@ -93,6 +93,8 @@ Tier on three properties, scored independently, then take the highest. **Authori
 
 Every number in that table is illustrative. Neither the NIST Generative AI Profile nor the OWASP list sets review frequencies or shadow durations; those are yours to choose, and no external source will settle them for you. What matters is that they exist before the first system needs them, because a tier model negotiated during a launch is a tier model that reflects the launch date.
 
+Tiering is also the point where this lifecycle meets an organisation's wider agent governance posture. The [Enterprise AI Transformation playbook](https://sunilprakash.com/enterprise-ai/governance/agent-governance/) sets out a maturity ladder for that posture, from ad hoc through to governance embedded in the development lifecycle, which is a useful way to work out which gates you can realistically enforce today rather than which ones you would like to.
+
 <Callout type="warn" label="Tier the system, not the model">
 Tiering by model capability produces nonsense: the same model is a Tier 3 drafting aid and a Tier 1 payment agent depending on what you connected it to. The tier belongs to the deployed system and its authority, which is why it can change without the model changing.
 </Callout>

--- a/src/pages/architecture/index.astro
+++ b/src/pages/architecture/index.astro
@@ -59,6 +59,11 @@ const byLayer = LAYERS.map((l) => ({
         <strong>how you know what it did</strong>. Blueprints are written to be read in
         order within a layer, and revised rather than republished.
       </p>
+      <p class="arch-thesis__aside">
+        These are engineering specifications. For the same territory at board and operating-model
+        altitude, funding, mandate, maturity and the org structure around all of this, see the
+        <a href="https://sunilprakash.com/enterprise-ai/">Enterprise AI Transformation playbook</a>.
+      </p>
     </section>
 
     {entries.length === 0 ? (
@@ -99,6 +104,24 @@ const byLayer = LAYERS.map((l) => ({
     margin: 0 0 var(--space-5);
     text-align: center;
   }
+
+  .arch-thesis__aside {
+    font-size: var(--body-2);
+    color: var(--fg-light);
+    border-top: 1px solid var(--fg-faint);
+    padding-top: var(--space-4);
+    margin-top: var(--space-4);
+  }
+
+  .arch-thesis__aside a {
+    color: var(--fg);
+    text-decoration: underline;
+    text-decoration-color: var(--brick);
+    text-decoration-thickness: 1.5px;
+    text-underline-offset: 3px;
+  }
+
+  .arch-thesis__aside a:hover { color: var(--brick); }
 
   .arch-thesis {
     max-width: var(--reader-max);


### PR DESCRIPTION
The return path for the cross-linking, kept deliberately thin.

The Enterprise AI Transformation playbook now points into the Architecture pillar in twelve places (separate repo, separate PR). This adds three links back:

- **/architecture/ index**: one aside under the thesis, saying these are engineering specifications and the playbook covers the same territory at board and operating-model altitude.
- **ARCH-005**: links to the playbook's three-layer governance architecture, placed at the honest limit, where the blueprint assumes a governance function already exists to assign the five decisions to.
- **ARCH-006**: links to the agent governance maturity ladder, at tiering, because maturity decides which gates a team can realistically enforce today rather than which ones it would like to.

Deliberately thin. The two properties have different audiences and different visual brands; the dominant direction should be playbook to blueprint, sending an executive reader to the spec.

Verification: build green, astro check 0 errors, vitest 21/21, all three outbound links return 200. The aside link carries the house brick underline (it was unstyled at first because .arch-thesis is not .prose).